### PR TITLE
fix(design-system): replace hardcoded brand colors with CSS tokens

### DIFF
--- a/src/components/Buscador.tsx
+++ b/src/components/Buscador.tsx
@@ -36,7 +36,7 @@ const Buscador = () => {
   }, [query]);
 
   return (
-    <section aria-labelledby="buscador-title" style={{ maxWidth: 480, margin: '0 auto', padding: 24 }}>
+    <section aria-labelledby="buscador-title" className="max-w-lg mx-auto p-6">
       <h2 id="buscador-title">Buscador de casos</h2>
       <label htmlFor="buscador-input" className="sr-only">Buscar caso</label>
       <input
@@ -46,21 +46,21 @@ const Buscador = () => {
         onChange={e => setQuery(e.target.value)}
         placeholder="Busca por palabra clave, actor o campo"
         aria-describedby="buscador-help"
-        style={{ width: '100%', padding: 12, fontSize: 16, borderRadius: 4, border: '1px solid #ccc', marginBottom: 8 }}
+        className="w-full p-3 text-base rounded border border-border mb-2 bg-background text-foreground"
       />
-      <div id="buscador-help" style={{ fontSize: 14, color: '#4B5563', marginBottom: 16 }}>
+      <div id="buscador-help" className="text-sm text-muted-foreground mb-4">
         Escribe para filtrar casos institucionales. Prueba: "SURA", "Mapuche", "Lobby".
       </div>
       <ExportarCSV data={resultados} />
       {loading && <div role="status" aria-live="polite">Cargando…</div>}
-      {error && <div role="alert" style={{ color: 'red' }}>{error}</div>}
+      {error && <div role="alert" className="text-destructive">{error}</div>}
       {!loading && !error && (
         <ul aria-live="polite" aria-label="Resultados de búsqueda">
           {resultados.length === 0 ? (
             <li>No se encontraron resultados.</li>
           ) : (
             resultados.map(caso => (
-              <li key={caso.id} style={{ marginBottom: 12, background: '#F9FAFB', padding: 12, borderRadius: 4 }}>
+              <li key={caso.id} className="mb-3 bg-muted p-3 rounded">
                 <strong>{caso.nombre}</strong><br />
                 <span>{caso.descripcion}</span>
               </li>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 const Footer = () => (
-  <footer role="contentinfo" style={{ marginTop: '48px', padding: '24px 0', background: 'var(--color-pizarra)', color: 'var(--color-marfil)', textAlign: 'center' }}>
+  <footer role="contentinfo" className="mt-12 py-6 bg-[--color-pizarra] text-[--color-marfil] text-center">
     <div>
-      <a href="mailto:rodrigo.gaete@gmail.com" style={{ color: 'var(--color-marfil)' }}>Contacto</a> | <a href="/privacy" style={{ color: 'var(--color-marfil)' }}>Privacidad</a>
+      <a href="mailto:rodrigo.gaete@gmail.com" className="text-[--color-marfil]">Contacto</a> | <a href="/privacy" className="text-[--color-marfil]">Privacidad</a>
     </div>
-    <div style={{ fontSize: '0.9em', marginTop: '8px' }}>
+    <div className="text-sm mt-2">
       © {new Date().getFullYear()} Rodrigo Gaete Gaona
     </div>
   </footer>

--- a/src/components/atoms/ScrollProgress.tsx
+++ b/src/components/atoms/ScrollProgress.tsx
@@ -20,9 +20,9 @@ export function ScrollProgress() {
       {/* Main progress bar with gradient */}
       <motion.div
         className="fixed top-0 left-0 right-0 h-1 origin-left z-50"
-        style={{ 
+        style={{
           scaleX,
-          background: "linear-gradient(90deg, #FF1D25 0%, #FF931E 100%)",
+          background: "linear-gradient(90deg, var(--brand-red) 0%, var(--brand-orange) 100%)",
         }}
         role="progressbar"
         aria-label="Progreso de lectura de la página"
@@ -33,9 +33,9 @@ export function ScrollProgress() {
       {/* Glow effect */}
       <motion.div
         className="fixed top-0 left-0 right-0 h-1 origin-left z-40 blur-sm"
-        style={{ 
+        style={{
           scaleX,
-          background: "linear-gradient(90deg, #FF1D25 0%, #FF931E 100%)",
+          background: "linear-gradient(90deg, var(--brand-red) 0%, var(--brand-orange) 100%)",
           opacity: 0.6,
         }}
       />

--- a/src/components/molecules/KPICard.tsx
+++ b/src/components/molecules/KPICard.tsx
@@ -63,7 +63,7 @@ export function KPICard({ label, value, description, icon: Icon, index }: KPICar
                 transition={{ duration: 0.8, delay: index * 0.1 + 0.4 }}
               />
               
-              <span className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-[#FF1D25] to-[#FF931E] bg-clip-text text-transparent leading-none">
+              <span className="text-5xl md:text-6xl font-bold text-brand-gradient leading-none">
                 {value}
               </span>
             </div>

--- a/src/components/molecules/StatCard.tsx
+++ b/src/components/molecules/StatCard.tsx
@@ -67,13 +67,7 @@ export function StatCard({ value, label, index = 0 }: StatCardProps) {
             }}
           >
             <motion.span
-              className="text-4xl md:text-5xl font-bold text-foreground inline-block"
-              style={{
-                background: "linear-gradient(135deg, #FF1D25 0%, #FF931E 100%)",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-              }}
+              className="text-4xl md:text-5xl font-bold inline-block text-brand-gradient"
               whileHover={{ scale: 1.1 }}
               transition={{ type: "spring", stiffness: 400, damping: 10 }}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -5548,17 +5548,17 @@
   }
 
   .bg-brand-gradient {
-    background: linear-gradient(135deg, #ff1d25 0%, #ff931e 100%);
+    background: var(--brand-gradient);
   }
 
   .text-brand-gradient {
-    background: linear-gradient(135deg, #ff1d25 0%, #ff931e 100%);
+    background: var(--brand-gradient);
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
 
   .border-brand-gradient {
-    border-image: linear-gradient(135deg, #ff1d25 0%, #ff931e 100%) 1;
+    border-image: var(--brand-gradient) 1;
   }
 }
 


### PR DESCRIPTION
## Summary

- **index.css** — point `.bg-brand-gradient`, `.text-brand-gradient`, and `.border-brand-gradient` utilities at `var(--brand-gradient)` instead of duplicating the raw hex values `#FF1D25 / #FF931E`
- **StatCard.tsx** — remove inline `background`/`WebkitBackgroundClip`/`WebkitTextFillColor` gradient style; use existing `text-brand-gradient` utility class instead
- **KPICard.tsx** — replace arbitrary Tailwind classes `from-[#FF1D25] to-[#FF931E] bg-clip-text text-transparent` with `text-brand-gradient`
- **ScrollProgress.tsx** — replace hardcoded hex strings in inline `background` styles with `var(--brand-red)` / `var(--brand-orange)` (the `useTransform` color-stop array keeps literals — Framer Motion needs concrete values to interpolate)
- **Footer.tsx** — convert all inline styles to Tailwind (`mt-12 py-6 text-center text-sm mt-2`) referencing existing `--color-pizarra` / `--color-marfil` tokens via `bg-[--color-pizarra]` / `text-[--color-marfil]`
- **Buscador.tsx** — fully reconnect to the token system; replace every hardcoded `#ccc`, `#4B5563`, `#F9FAFB` and numeric `padding`/`fontSize`/`borderRadius` with semantic Tailwind utilities (`border-border`, `bg-background`, `text-foreground`, `text-muted-foreground`, `text-destructive`, `bg-muted`)

## Why

A design system audit (`/design:design-system qa`) identified these as the main sources of token drift — the same brand colors were duplicated in 5+ components as raw hex strings, bypassing the CSS variable system already defined in `:root`. One source of truth means a single edit to `--brand-red` / `--brand-orange` now propagates everywhere.

## Test plan

- [ ] Build passes (`npm run build` — ✅ verified locally, 0 errors)
- [ ] Scroll progress bar still renders brand gradient on the live site
- [ ] Stat/KPI card values still display with brand gradient text
- [ ] Footer renders with correct dark background and light text
- [ ] Buscador search renders correctly (border, background, muted text, error state)
- [ ] Dark mode: verify Buscador and Footer still look correct (semantic tokens handle this automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)