### PR TITLE
ci: add Lighthouse CI with accessibility enforcement

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,29 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli serve
+          serve -s dist -p 3000 &
+          sleep 3
+          lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,20 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:3000"],
+      "numberOfRuns": 2
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.85 }],
+        "categories:seo": ["warn", { "minScore": 0.85 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Qué cambia

- `.github/workflows/lighthouse.yml` — build Vite + audita localhost en cada PR contra `main`
- `.lighthouserc.json` — umbrales de calidad configurados

## Comportamiento

| Métrica | Umbral | Acción |
|---|---|---|
| Accesibilidad | ≥ 0.90 | **Bloquea el PR** (error) |
| Performance | ≥ 0.80 | Aviso |
| Best Practices | ≥ 0.85 | Aviso |
| SEO | ≥ 0.85 | Aviso |

El umbral de accesibilidad es más exigente (0.9) porque es un portafolio de UX Lead — la accesibilidad es parte del producto. Resultados se publican en Lighthouse public storage (enlace en el resumen del check).

## Para el reviewer

- El token `LHCI_GITHUB_APP_TOKEN` es opcional; sin él el workflow corre igual pero no deja comentarios inline en el PR.
- Los umbrales se pueden ajustar en `.lighthouserc.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)