### PR TITLE
feat: reduce scroll, eliminar texto redundante y mejorar conversión

### DIFF
--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -1,56 +1,9 @@
 import { motion, useReducedMotion } from "motion/react";
 import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
-import { User, Lightbulb, Zap } from "lucide-react";
+import { User } from "lucide-react";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { useLanguage } from "../../lib/LanguageContext";
-
-const philosophy = [
-  {
-    icon: Lightbulb,
-    title: { es: "Idea", en: "Idea" },
-    description: { 
-      es: "Conceptualización y estrategia detrás de cada experiencia. El pensamiento que da forma a la solución.",
-      en: "Conceptualization and strategy behind each experience. The thinking that shapes the solution."
-    },
-    color: "text-amber-600",
-    bgColor: "bg-amber-50 dark:bg-amber-950/20",
-  },
-  {
-    icon: Zap,
-    title: { es: "Cuerpo", en: "Body" },
-    description: { 
-      es: "Ejecución tangible e interfaz. La materialización de ideas en productos digitales funcionales.",
-      en: "Tangible execution and interface. The materialization of ideas into functional digital products."
-    },
-    color: "text-rose-600",
-    bgColor: "bg-rose-50 dark:bg-rose-950/20",
-  },
-];
-
-const values = [
-  {
-    label: { es: "Naturaleza", en: "Nature" },
-    description: { 
-      es: "Diseño orgánico basado en patrones naturales y comportamientos humanos reales",
-      en: "Organic design based on natural patterns and real human behaviors"
-    },
-  },
-  {
-    label: { es: "Contemplación", en: "Contemplation" },
-    description: { 
-      es: "Espacios para reflexión y decisiones informadas, sin presión ni ruido",
-      en: "Spaces for reflection and informed decisions, without pressure or noise"
-    },
-  },
-  {
-    label: { es: "Creatividad", en: "Creativity" },
-    description: { 
-      es: "Soluciones innovadoras que rompen convenciones cuando es necesario",
-      en: "Innovative solutions that break conventions when necessary"
-    },
-  },
-];
 
 const roles = [
   "Head UX",
@@ -65,224 +18,59 @@ export function About() {
   const { language } = useLanguage();
   const prefersReducedMotion = useReducedMotion();
 
-  const fadeUp = (delay = 0, extra?: object) =>
+  const fadeUp = (delay = 0) =>
     prefersReducedMotion
       ? {}
-      : { initial: { opacity: 0, y: 20 }, whileInView: { opacity: 1, y: 0 }, viewport: { once: true as const }, transition: { duration: 0.6, delay, ...extra } };
+      : { initial: { opacity: 0, y: 20 }, whileInView: { opacity: 1, y: 0 }, viewport: { once: true as const }, transition: { duration: 0.6, delay } };
+
+  const bio = language === "es"
+    ? "Lead UX con 3+ años implementando UX/UI para productos financieros (SURA, 5+ países) y de movilidad (Transvip/Karri). Combino research, Design Sprints y arquitectura de información para entregar soluciones con resultados medibles."
+    : "Lead UX with 3+ years implementing UX/UI for financial products (SURA, 5+ countries) and mobility (Transvip/Karri). I combine research, Design Sprints, and information architecture to deliver solutions with measurable results.";
 
   return (
     <section
       id="sobre-mi"
-      className="py-20 md:py-28 px-4 bg-muted/30"
+      className="py-12 md:py-16 px-4 bg-muted/30"
       aria-labelledby="about-heading"
     >
-      <div className="container max-w-7xl mx-auto">
+      <div className="container max-w-4xl mx-auto">
         <SectionHeader
           badge={language === "es" ? "Sobre mí" : "About me"}
           badgeIcon={User}
-          title={language === "es" ? "Lead UX especializado en estrategia digital" : "Lead UX specialized in digital strategy"}
+          title={language === "es" ? "3+ años. 2 verticales. Impacto regional." : "3+ years. 2 verticals. Regional impact."}
           description=""
         />
 
-        {/* Philosophy: Idea y Cuerpo */}
-        <motion.div
-          {...fadeUp()}
-          className="mb-12 md:mb-16"
-        >
-          <div className="text-center max-w-4xl mx-auto mb-10">
-            <motion.h3
-              {...fadeUp()}
-              className="text-2xl md:text-3xl font-bold mb-4"
-            >
-              {language === "es" ? "Filosofía de Diseño" : "Design Philosophy"}
-            </motion.h3>
-            <motion.p
-              {...fadeUp(0.1)}
-              className="text-muted-foreground text-lg leading-relaxed"
-            >
-              {language === "es" 
-                ? "Inspirado en la naturaleza de las cosas y su relación con el mundo humano, tomo los conceptos de \"Idea\" y \"Cuerpo\" para representar orden y fuerza desde la perspectiva del diseño y sus posibilidades."
-                : "Inspired by the nature of things and their relationship with the human world, I take the concepts of \"Idea\" and \"Body\" to represent order and strength from the perspective of design and its possibilities."}
-            </motion.p>
-          </div>
+        <div className="space-y-6">
+          <motion.p
+            {...fadeUp()}
+            className="text-xl leading-relaxed text-muted-foreground"
+          >
+            {bio}
+          </motion.p>
 
-          <div className="grid md:grid-cols-2 gap-6 md:gap-8 mb-12">
-            {philosophy.map((item, index) => (
-              <motion.div
-                key={item.title[language]}
-                {...fadeUp(index * 0.15)}
-                whileHover={prefersReducedMotion ? undefined : { scale: 1.02 }}
-              >
-                <Card className="relative overflow-hidden group hover:shadow-2xl transition-all duration-500 border-2 hover:border-primary/30 h-full">
-                  <CardContent className="p-8 relative">
-                    <div className="mb-6">
-                      <div className={`inline-flex h-16 w-16 items-center justify-center rounded-2xl ${item.bgColor} border-2 border-border`}>
-                        <item.icon className={`h-8 w-8 ${item.color}`} />
-                      </div>
-                    </div>
-
-                    <h4 className="text-2xl font-bold mb-3">{item.title[language]}</h4>
-                    <p className="text-muted-foreground leading-relaxed">
-                      {item.description[language]}
-                    </p>
-
-                    {/* Decorative line with primary color */}
+          <motion.div {...fadeUp(0.15)}>
+            <Card className="border-2">
+              <CardContent className="p-6">
+                <h3 className="text-sm uppercase tracking-wider text-muted-foreground mb-4 font-semibold">
+                  {language === "es" ? "Roles que desempeño" : "Roles I perform"}
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {roles.map((role, index) => (
                     <motion.div
-                      initial={prefersReducedMotion ? undefined : { scaleX: 0 }}
-                      whileInView={prefersReducedMotion ? undefined : { scaleX: 1 }}
-                      viewport={{ once: true }}
-                      transition={{ delay: index * 0.2 + 0.3, duration: 0.6 }}
-                      className={`mt-6 h-1 bg-primary rounded-full origin-left`}
-                    />
-                  </CardContent>
-                </Card>
-              </motion.div>
-            ))}
-          </div>
-
-          {/* Values inspired by moodboard */}
-          <div className="grid md:grid-cols-3 gap-4 md:gap-6 mb-12">
-            {values.map((value, index) => (
-              <motion.div
-                key={value.label[language]}
-                {...fadeUp(index * 0.1)}
-                whileHover={prefersReducedMotion ? undefined : { y: -4 }}
-              >
-                <Card className="border-2 hover:border-primary/20 transition-all duration-300 hover:shadow-lg">
-                  <CardContent className="p-6 text-center">
-                    <h5 className="font-bold text-lg mb-2 text-brand-gradient">
-                      {value.label[language]}
-                    </h5>
-                    <p className="text-sm text-muted-foreground leading-relaxed">
-                      {value.description[language]}
-                    </p>
-                  </CardContent>
-                </Card>
-              </motion.div>
-            ))}
-          </div>
-        </motion.div>
-
-        <div className="grid lg:grid-cols-2 gap-8 md:gap-12 items-start">
-          {/* Left Column - About */}
-          <motion.div
-            {...(prefersReducedMotion ? {} : { initial: { opacity: 0, x: -20 }, whileInView: { opacity: 1, x: 0 }, viewport: { once: true }, transition: { duration: 0.5 } })}
-            className="space-y-8"
-          >
-            {/* Main description */}
-            <div className="space-y-6">
-              <motion.p
-                {...fadeUp()}
-                className="text-xl leading-relaxed"
-              >
-                {language === "es" 
-                  ? <>Mi rol se centra en la <strong className="text-primary">implementación correcta del diseño de experiencia</strong> en iniciativas tecnológicas regionales y locales.</>
-                  : <>My role focuses on <strong className="text-primary">proper implementation of experience design</strong> in regional and local technology initiatives.</>
-                }
-              </motion.p>
-              
-              <motion.p
-                {...fadeUp(0.1)}
-                className="text-muted-foreground leading-relaxed text-lg"
-              >
-                {language === "es"
-                  ? <>Diseño <strong className="text-foreground">lineamientos de experiencia e interfaz</strong> durante la ideación, estructuración e implementación de nuevas iniciativas.</>
-                  : <>I design <strong className="text-foreground">experience and interface guidelines</strong> during ideation, structuring and implementation of new initiatives.</>
-                }
-              </motion.p>
-
-              <motion.p
-                {...fadeUp(0.2)}
-                className="text-muted-foreground leading-relaxed text-lg"
-              >
-                {language === "es"
-                  ? <>Adapto <strong className="text-foreground">Design Thinking</strong> a contextos enterprise, combinando research con metodologías ágiles.</>
-                  : <>I adapt <strong className="text-foreground">Design Thinking</strong> to enterprise contexts, combining research with agile methodologies.</>
-                }
-              </motion.p>
-            </div>
-
-            {/* Roles Card */}
-            <motion.div
-              {...fadeUp(0.3)}
-            >
-              <Card className="border-2">
-                <CardContent className="p-6">
-                  <h3 className="text-sm uppercase tracking-wider text-muted-foreground mb-4 font-semibold">
-                    {language === "es" ? "Roles que desempeño" : "Roles I perform"}
-                  </h3>
-                  <div className="flex flex-wrap gap-2">
-                    {roles.map((role, index) => (
-                      <motion.div
-                        key={role}
-                        {...(prefersReducedMotion ? {} : { initial: { opacity: 0, scale: 0.9 }, whileInView: { opacity: 1, scale: 1 }, viewport: { once: true }, transition: { delay: 0.35 + index * 0.05 } })}
-                        whileHover={prefersReducedMotion ? undefined : { scale: 1.05, y: -2 }}
+                      key={role}
+                      {...(prefersReducedMotion ? {} : { initial: { opacity: 0, scale: 0.9 }, whileInView: { opacity: 1, scale: 1 }, viewport: { once: true }, transition: { delay: 0.2 + index * 0.05 } })}
+                      whileHover={prefersReducedMotion ? undefined : { scale: 1.05, y: -2 }}
+                    >
+                      <Badge
+                        variant="secondary"
+                        className="text-sm px-3 py-1.5 cursor-default hover:bg-primary/10 transition-colors"
                       >
-                        <Badge 
-                          variant="secondary" 
-                          className="text-sm px-3 py-1.5 cursor-default hover:bg-primary/10 transition-colors"
-                        >
-                          {role}
-                        </Badge>
-                      </motion.div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          </motion.div>
-
-          {/* Right Column - Quote */}
-          <motion.div
-            {...(prefersReducedMotion ? {} : { initial: { opacity: 0, x: 20 }, whileInView: { opacity: 1, x: 0 }, viewport: { once: true }, transition: { duration: 0.5, delay: 0.2 } })}
-            className="lg:sticky lg:top-24 space-y-6"
-          >
-            {/* Main Philosophy Quote - Fusionada */}
-            <Card className="relative overflow-hidden border-2 hover:border-primary/30 transition-all duration-500 bg-gradient-to-br from-background to-muted/20">
-              {/* Quote background decoration */}
-              <div className="absolute -top-4 -right-4 text-primary/5 text-[180px] leading-none select-none pointer-events-none font-serif">
-                "
-              </div>
-
-              <CardContent className="p-8 md:p-10 relative">
-                <motion.blockquote
-                  {...fadeUp(0.3)}
-                  className="space-y-6"
-                >
-                  <p className="text-xl md:text-2xl leading-relaxed">
-                    "Como diseñador especialista en experiencias e interfaces, me interesa profundizar en los{" "}
-                    <span className="text-primary font-semibold not-italic">valores y filosofía</span>{" "}
-                    que inspiran mi trabajo diario."
-                  </p>
-
-                  <p className="text-lg md:text-xl leading-relaxed text-muted-foreground">
-                    "El{" "}
-                    <span className="text-primary font-semibold not-italic">buen diseño se anticipa a la ley</span>.
-                    No diseñamos solo para cumplir regulaciones, sino para{" "}
-                    <span className="text-primary font-semibold not-italic">crear experiencias éticas</span>{" "}
-                    que respetan la privacidad, accesibilidad y dignidad humana desde el primer día."
-                  </p>
-
-                  {/* Author info */}
-                  <div className="flex items-center gap-4 pt-4 border-t">
-                    <div className="h-12 w-12 rounded-full bg-brand-gradient flex items-center justify-center flex-shrink-0">
-                      <User className="h-6 w-6 text-white" />
-                    </div>
-                    <div>
-                      <div className="font-semibold">Rodrigo Gaete</div>
-                      <div className="text-sm text-muted-foreground">Lead UX Designer · BrandBook 2023</div>
-                    </div>
-                  </div>
-                </motion.blockquote>
-
-                {/* Decorative gradient line */}
-                <motion.div
-                  initial={prefersReducedMotion ? undefined : { scaleX: 0 }}
-                  whileInView={prefersReducedMotion ? undefined : { scaleX: 1 }}
-                  viewport={{ once: true }}
-                  transition={{ delay: 0.4, duration: 0.6 }}
-                  className="mt-6 h-1 bg-brand-gradient rounded-full origin-left"
-                />
+                        {role}
+                      </Badge>
+                    </motion.div>
+                  ))}
+                </div>
               </CardContent>
             </Card>
           </motion.div>

--- a/src/components/organisms/Contact.tsx
+++ b/src/components/organisms/Contact.tsx
@@ -31,13 +31,6 @@ const socialLinks = [
   },
 ];
 
-const benefits = [
-  "Experiencia en implementación de UX en contextos enterprise",
-  "Enfoque en desarrollo evolutivo y resultados medibles",
-  "Metodologías: Design Thinking, Design Sprints, Product Design",
-  "Experto en Figma, Frameworks y Accesibilidad",
-];
-
 export function Contact() {
   const [formData, setFormData] = useState({
     name: "",
@@ -68,9 +61,9 @@ export function Contact() {
   };
 
   return (
-    <section 
+    <section
       id="contacto"
-      className="py-20 md:py-28 px-4"
+      className="py-12 md:py-16 px-4"
       aria-labelledby="contact-heading"
     >
       <div className="container max-w-7xl mx-auto">
@@ -78,7 +71,7 @@ export function Contact() {
           badge="Hablemos"
           badgeIcon={Send}
           title="Conversemos"
-          description="¿Tienes un proyecto en mente? ¿Buscas un Lead UX para tu equipo? Me encantaría conocer más sobre tus necesidades."
+          description="Respondo en menos de 24h · Disponible para proyectos freelance y full-time"
         />
 
         <div className="grid lg:grid-cols-3 gap-6 md:gap-8">
@@ -155,39 +148,6 @@ export function Contact() {
               </Card>
             </motion.div>
 
-            <motion.div
-              initial={{ opacity: 0, x: -20 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: 0.2 }}
-            >
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg md:text-xl">
-                    ¿Por qué trabajar conmigo?
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2 text-sm" role="list">
-                    {benefits.map((benefit, index) => (
-                      <motion.li
-                        key={index}
-                        initial={{ opacity: 0, x: -10 }}
-                        whileInView={{ opacity: 1, x: 0 }}
-                        viewport={{ once: true }}
-                        transition={{ delay: 0.3 + index * 0.05 }}
-                        className="flex items-start gap-2"
-                      >
-                        <span className="text-primary mt-1 flex-shrink-0" aria-hidden="true">
-                          ✓
-                        </span>
-                        <span>{benefit}</span>
-                      </motion.li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </motion.div>
           </div>
 
           {/* Contact Form */}

--- a/src/components/organisms/Experience.tsx
+++ b/src/components/organisms/Experience.tsx
@@ -1,213 +1,112 @@
 import { motion } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
-import { Briefcase, GraduationCap, Award, Clock } from "lucide-react";
+import { Briefcase, Clock } from "lucide-react";
 import { SectionHeader } from "../molecules/SectionHeader";
 
 const experiences = [
   {
-    type: "work",
     company: "SURA Investments | Wealth Management",
     position: "Associate Estrategia Digital · Lead UX",
     period: "Nov 2023 - Actualidad",
-    description: "Mi rol dentro del equipo de estrategia digital se centra en la correcta implementación del diseño de experiencia usuaria en las diversas iniciativas en que SURA Investments realiza desarrollos tanto regional como localmente a nivel tecnológico.",
+    summary: "-40% onboarding · 50+ componentes design system · 5+ países",
     achievements: [
       "Diseño de lineamientos de experiencia e interfaz durante la ideación, estructuración e implementación de nuevas iniciativas",
       "Implementación de desarrollo evolutivo en productos digitales regionales",
       "Aplicación de Design Thinking adaptado a contextos enterprise y financieros",
     ],
-    link: "https://www.regional.com",
-    linkText: "¿Quieres ver cómo adapto design thinking?"
   },
   {
-    type: "work",
     company: "Academia Desafío Latam",
     position: "Docente Carrera UX / UI",
     period: "Jun 2022 - Feb 2023",
-    description: "Docente de la generación G48 de UX UI en Academia Desafío Latam, impartiendo cursos de diseño UX y diseño UI.",
+    summary: "Generación G48 · Design Thinking · Mentoría de proyectos finales",
     achievements: [
-      "Impartición de cursos de diseño UX y UI como aprendizaje continuo",
-      "Acompañamiento a estudiantes durante el diseño de productos usando Design Thinking como marco de trabajo ágil",
+      "Cursos de diseño UX y UI como aprendizaje continuo",
       "Mentoría en proyectos finales de la generación",
     ],
-    link: "https://www.figma.com/design/BC1cwBvja12XYhdRUNh9ad?node-id=1607-767",
-    linkText: "Leer más sobre esta experiencia aquí"
   },
   {
-    type: "work",
     company: "Transvip",
     position: "Senior Product Designer",
     period: "2022 - 2023",
-    description: "Diseño de aplicación premium de movilidad para traslados al aeropuerto y servicios ejecutivos.",
+    summary: "-40% fricción en reservas · Tracking en tiempo real",
     achievements: [
       "Rediseño completo de la app de pasajeros premium",
       "Optimización del flujo de reservas con reducción de 40% en fricción",
-      "Implementación de sistema de tracking en tiempo real",
     ],
   },
   {
-    type: "work",
     company: "Karri by Transvip",
     position: "Lead UX Designer - Vertical Shoppers",
     period: "2022 - 2023",
-    description: "Liderazgo en diseño UX para la vertical de shoppers y delivery de Transvip.",
+    summary: "+35% activación · +58% engagement · -42% abandono",
     achievements: [
-      "Diseño de calculadora de ganancias que aumentó activación en +35%",
+      "Calculadora de ganancias que aumentó activación en +35%",
       "Sistema de notificaciones centralizado con +58% engagement",
       "Optimización de onboarding con -42% de abandono",
     ],
   },
 ];
 
-const education = [
-  // Educación formal - sin roles docentes que ya están en experiencia profesional
-];
-
-const certifications = [
-  "Design Thinking & Design Sprints",
-  "Product Design: Sprint de desarrollo, MVPs & Handoff",
-  "User Research & Testing",
-  "Diseño UI: Figma, Frameworks & Accesibilidad",
-];
-
 export function Experience() {
   return (
-    <section 
+    <section
       id="experiencia"
-      className="py-20 md:py-28 px-4 bg-muted/30"
+      className="py-12 md:py-16 px-4 bg-muted/30"
       aria-labelledby="experience-heading"
     >
       <div className="container max-w-7xl mx-auto">
         <SectionHeader
           badge="Trayectoria"
-          badgeIcon={Clock}
+          badgeIcon={Briefcase}
           title="Experiencia Profesional"
-          description="Trayectoria en diseño de experiencias, implementación de UX y desarrollo de productos digitales en contextos enterprise"
+          description=""
         />
 
-        <div className="space-y-12 md:space-y-16">
-          {/* Work Experience */}
-          <div>
-            <motion.div 
-              initial={{ opacity: 0, x: -20 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5 }}
-              className="flex items-center gap-2 mb-6 md:mb-8"
-            >
-              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                <Briefcase className="h-5 w-5 text-primary" aria-hidden="true" />
-              </div>
-              <h3>Experiencia Profesional</h3>
-            </motion.div>
-            
-            <div className="space-y-4 md:space-y-6">
-              {experiences.map((exp, index) => (
-                <motion.article
-                  key={index}
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true, margin: "-50px" }}
-                  transition={{ duration: 0.5, delay: index * 0.1 }}
-                >
-                  <Card className="hover:shadow-lg transition-shadow">
-                    <CardHeader>
-                      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                        <div className="space-y-1">
-                          <CardTitle>{exp.position}</CardTitle>
-                          <CardDescription>{exp.company}</CardDescription>
-                        </div>
-                        <Badge variant="secondary" className="self-start whitespace-nowrap">
-                          {exp.period}
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <p className="text-muted-foreground text-sm md:text-base">
-                        {exp.description}
-                      </p>
-                      <ul className="space-y-2" role="list" aria-label="Logros principales">
-                        {exp.achievements.map((achievement, i) => (
-                          <motion.li
-                            key={i}
-                            initial={{ opacity: 0, x: -10 }}
-                            whileInView={{ opacity: 1, x: 0 }}
-                            viewport={{ once: true }}
-                            transition={{ delay: 0.1 + i * 0.05 }}
-                            className="flex items-start gap-2"
-                          >
-                            <span className="text-primary mt-1 flex-shrink-0" aria-hidden="true">
-                              •
-                            </span>
-                            <span className="text-sm">{achievement}</span>
-                          </motion.li>
-                        ))}
-                      </ul>
-                      {exp.link && (
-                        <a
-                          href={exp.link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-sm text-primary hover:underline"
-                        >
-                          {exp.linkText}
-                        </a>
-                      )}
-                    </CardContent>
-                  </Card>
-                </motion.article>
-              ))}
-            </div>
-          </div>
-
-          {/* Certifications */}
-          <div>
-            <motion.div 
-              initial={{ opacity: 0, x: -20 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5 }}
-              className="flex items-center gap-2 mb-6 md:mb-8"
-            >
-              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                <Award className="h-5 w-5 text-primary" aria-hidden="true" />
-              </div>
-              <h3>Certificaciones</h3>
-            </motion.div>
-            
-            <motion.div
+        <div className="space-y-5 md:space-y-8">
+          {experiences.map((exp, index) => (
+            <motion.article
+              key={index}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5 }}
+              viewport={{ once: true, margin: "-50px" }}
+              transition={{ duration: 0.5, delay: index * 0.08 }}
             >
-              <Card>
-                <CardContent className="pt-6">
-                  <ul 
-                    className="grid sm:grid-cols-2 gap-3 md:gap-4"
-                    role="list"
-                    aria-label="Certificaciones profesionales"
-                  >
-                    {certifications.map((cert, index) => (
+              <Card className="hover:shadow-lg transition-shadow">
+                <CardHeader>
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                    <div className="space-y-1">
+                      <CardTitle>{exp.position}</CardTitle>
+                      <CardDescription>{exp.company}</CardDescription>
+                    </div>
+                    <Badge variant="secondary" className="self-start whitespace-nowrap">
+                      {exp.period}
+                    </Badge>
+                  </div>
+                  {/* Metric summary — most important info up front */}
+                  <p className="text-sm font-medium text-primary mt-1">{exp.summary}</p>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-1.5" role="list" aria-label="Logros principales">
+                    {exp.achievements.map((achievement, i) => (
                       <motion.li
-                        key={index}
+                        key={i}
                         initial={{ opacity: 0, x: -10 }}
                         whileInView={{ opacity: 1, x: 0 }}
                         viewport={{ once: true }}
-                        transition={{ delay: index * 0.05 }}
+                        transition={{ delay: 0.1 + i * 0.05 }}
                         className="flex items-start gap-2"
                       >
-                        <span className="text-primary mt-1 flex-shrink-0" aria-hidden="true">
-                          ✓
-                        </span>
-                        <span className="text-sm">{cert}</span>
+                        <span className="text-primary mt-1 flex-shrink-0" aria-hidden="true">•</span>
+                        <span className="text-sm text-muted-foreground">{achievement}</span>
                       </motion.li>
                     ))}
                   </ul>
                 </CardContent>
               </Card>
-            </motion.div>
-          </div>
+            </motion.article>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/organisms/Hero.tsx
+++ b/src/components/organisms/Hero.tsx
@@ -1,6 +1,6 @@
 import { motion, useScroll, useTransform, useReducedMotion } from "motion/react";
 import { Button } from "../ui/button";
-import { ArrowRight, FileText, Palette, Sparkles } from "lucide-react";
+import { ArrowRight, FileText, Sparkles } from "lucide-react";
 import { Logo } from "../atoms/Logo";
 import { useRef, useMemo } from "react";
 import { useLanguage } from "../../lib/LanguageContext";
@@ -29,22 +29,16 @@ export function Hero({ onNavigateToDesignSystem, onNavigateToCaseStudies }: Hero
   const content = useMemo(() => ({
     es: {
       heading: "Lead UX diseñando experiencias que conectan estrategia digital con usuarios",
-      description: "Especialista en implementación de experiencia usuaria y desarrollo evolutivo de productos digitales. Experto en Design Thinking, Design Sprints y metodologías ágiles.",
-      emphasis1: "implementación de experiencia usuaria",
-      emphasis2: "desarrollo evolutivo",
+      description: "Lead UX con impacto medible: -40% abandono en onboarding, NPS 72, +35% activación. Implemento UX/UI en productos financieros y de movilidad a nivel regional.",
       ctaPrimary: "Ver proyectos",
       ctaSecondary: "Casos de Estudio",
-      ctaTertiary: "Design System",
       scroll: "Explorar"
     },
     en: {
       heading: "Lead UX designing experiences that connect digital strategy with users",
-      description: "Specialist in user experience implementation and evolutionary development of digital products. Expert in Design Thinking, Design Sprints and agile methodologies.",
-      emphasis1: "user experience implementation",
-      emphasis2: "evolutionary development",
+      description: "Lead UX with measurable impact: -40% onboarding drop-off, NPS 72, +35% activation. I implement UX/UI for financial and mobility products at a regional scale.",
       ctaPrimary: "View projects",
       ctaSecondary: "Case Studies",
-      ctaTertiary: "Design System",
       scroll: "Explore"
     }
   }), []);
@@ -83,7 +77,7 @@ export function Hero({ onNavigateToDesignSystem, onNavigateToCaseStudies }: Hero
     <section
       ref={ref}
       id="inicio"
-      className="relative min-h-screen flex items-center justify-center px-4 py-20 overflow-hidden"
+      className="relative min-h-[75vh] flex items-center justify-center px-4 py-16 overflow-hidden"
       aria-labelledby="hero-heading"
     >
       {/* Optimized Background */}
@@ -140,7 +134,7 @@ export function Hero({ onNavigateToDesignSystem, onNavigateToCaseStudies }: Hero
         initial="hidden"
         animate="visible"
       >
-        <div className="text-center space-y-8 md:space-y-12">
+        <div className="text-center space-y-5 md:space-y-7">
           {/* Logo with optimized animations */}
           <motion.div
             variants={itemVariants}
@@ -195,22 +189,12 @@ export function Hero({ onNavigateToDesignSystem, onNavigateToCaseStudies }: Hero
             </span>
           </motion.h1>
 
-          {/* Description with better text hierarchy */}
+          {/* Description */}
           <motion.div
             variants={itemVariants}
-            className="max-w-3xl mx-auto text-muted-foreground px-4 text-lg md:text-xl leading-relaxed"
+            className="max-w-2xl mx-auto text-muted-foreground px-4 text-lg md:text-xl leading-relaxed"
           >
-            <p>
-              Especialista en{" "}
-              <strong className="text-foreground font-semibold">
-                {t.emphasis1}
-              </strong>{" "}
-              y{" "}
-              <strong className="text-foreground font-semibold">
-                {t.emphasis2}
-              </strong>{" "}
-              de productos digitales. Experto en Design Thinking, Design Sprints y metodologías ágiles.
-            </p>
+            <p>{t.description}</p>
           </motion.div>
 
           {/* CTA Buttons - Better spacing and hierarchy */}
@@ -233,13 +217,13 @@ export function Hero({ onNavigateToDesignSystem, onNavigateToCaseStudies }: Hero
               </Button>
             </motion.div>
 
-            {/* Secondary CTAs */}
+            {/* Secondary CTA */}
             <motion.div
               whileHover={!prefersReducedMotion ? { scale: 1.05 } : undefined}
               whileTap={{ scale: 0.98 }}
             >
-              <Button 
-                size="lg" 
+              <Button
+                size="lg"
                 variant="outline"
                 onClick={onNavigateToCaseStudies}
                 className="group border-2 border-primary/20 hover:border-primary/40 hover:bg-primary/5 transition-all"
@@ -248,27 +232,12 @@ export function Hero({ onNavigateToDesignSystem, onNavigateToCaseStudies }: Hero
                 {t.ctaSecondary}
               </Button>
             </motion.div>
-
-            <motion.div
-              whileHover={!prefersReducedMotion ? { scale: 1.05 } : undefined}
-              whileTap={{ scale: 0.98 }}
-            >
-              <Button 
-                size="lg" 
-                variant="outline"
-                onClick={onNavigateToDesignSystem}
-                className="group border-2 border-primary/20 hover:border-primary/40 hover:bg-primary/5 transition-all"
-              >
-                <Palette className="mr-2 h-5 w-5 group-hover:rotate-12 transition-transform" />
-                {t.ctaTertiary}
-              </Button>
-            </motion.div>
           </motion.div>
 
           {/* Scroll indicator - Improved animation */}
           <motion.div
             variants={itemVariants}
-            className="pt-16 md:pt-20"
+            className="pt-8 md:pt-10"
           >
             <motion.button
               animate={!prefersReducedMotion ? { y: [0, 8, 0] } : undefined}

--- a/src/components/organisms/ImpactStats.tsx
+++ b/src/components/organisms/ImpactStats.tsx
@@ -1,6 +1,6 @@
 import { motion, useReducedMotion } from "motion/react";
 import { Card, CardContent } from "../ui/card";
-import { BarChart3, Users, Building2, Zap } from "lucide-react";
+import { BarChart3, TrendingDown, TrendingUp, Zap } from "lucide-react";
 import { useLanguage } from "../../lib/LanguageContext";
 
 export function ImpactStats() {
@@ -14,57 +14,42 @@ export function ImpactStats() {
 
   const stats = [
     {
-      icon: Building2,
-      value: "2",
-      label: language === "es" ? "Empresas de nivel enterprise" : "Enterprise-level companies",
-      description: language === "es" ? "Transvip & SURA Investments" : "Transvip & SURA Investments",
+      icon: TrendingDown,
+      value: "-40%",
+      label: language === "es" ? "Abandono en onboarding" : "Onboarding drop-off",
+      description: language === "es" ? "SURA Ecosistema — 7-11 min vs 15+" : "SURA Ecosystem — 7-11 min vs 15+",
       color: "text-blue-600 dark:text-blue-400",
       bgColor: "bg-blue-50 dark:bg-blue-950/20",
     },
     {
-      icon: Zap,
-      value: "8+",
-      label: language === "es" ? "Prototipos interactivos diseñados" : "Interactive prototypes designed",
-      description: language === "es" ? "Alta fidelidad con Figma" : "High-fidelity with Figma",
+      icon: BarChart3,
+      value: "NPS 72",
+      label: language === "es" ? "Plataforma inversiones SURA" : "SURA investments platform",
+      description: language === "es" ? "+25 pts sobre baseline" : "+25 pts above baseline",
       color: "text-amber-600 dark:text-amber-400",
       bgColor: "bg-amber-50 dark:bg-amber-950/20",
     },
     {
-      icon: Users,
-      value: "12+",
-      label: language === "es" ? "Personas en equipos multidisciplinarios" : "People in multidisciplinary teams",
-      description: language === "es" ? "UX, UI, Dev, Product, Compliance" : "UX, UI, Dev, Product, Compliance",
+      icon: TrendingUp,
+      value: "+35%",
+      label: language === "es" ? "Activación shoppers Karri" : "Karri shopper activation",
+      description: language === "es" ? "Calculadora de ganancias" : "Earnings calculator",
       color: "text-rose-600 dark:text-rose-400",
       bgColor: "bg-rose-50 dark:bg-rose-950/20",
     },
     {
-      icon: BarChart3,
-      value: "5",
-      label: language === "es" ? "Macroprocesos UX aplicados" : "UX macro-processes applied",
-      description: language === "es" ? "Framework completo end-to-end" : "Complete end-to-end framework",
+      icon: Zap,
+      value: "+58%",
+      label: language === "es" ? "Engagement notificaciones" : "Notification engagement",
+      description: language === "es" ? "Hub centralizado Karri" : "Karri centralized hub",
       color: "text-violet-600 dark:text-violet-400",
       bgColor: "bg-violet-50 dark:bg-violet-950/20",
     },
   ];
 
   return (
-    <section className="py-16 md:py-20 px-4 bg-muted/30">
+    <section className="py-10 md:py-14 px-4 bg-muted/30">
       <div className="container max-w-7xl mx-auto">
-        <motion.div
-          {...fadeUp()}
-          transition={{ duration: 0.6 }}
-          className="text-center mb-12"
-        >
-          <h2 className="text-3xl md:text-4xl mb-3">
-            {language === "es" ? "Impacto Medible" : "Measurable Impact"}
-          </h2>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            {language === "es" 
-              ? "Resultados concretos aplicando metodología UX en proyectos enterprise"
-              : "Concrete results applying UX methodology in enterprise projects"}
-          </p>
-        </motion.div>
-
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {stats.map((stat, index) => {
             const Icon = stat.icon;
@@ -79,7 +64,6 @@ export function ImpactStats() {
                     <div className={`w-14 h-14 rounded-2xl ${stat.bgColor} flex items-center justify-center mx-auto mb-4`}>
                       <Icon className={`h-7 w-7 ${stat.color}`} />
                     </div>
-                    
                     <div className="space-y-2">
                       <div className={`text-4xl font-bold ${stat.color}`}>
                         {stat.value}
@@ -101,114 +85,56 @@ export function ImpactStats() {
         {/* Feature Highlight - RIA SURA Project */}
         <motion.div
           {...fadeUp(0.4)}
-          className="mt-12"
+          className="mt-10"
         >
-          <Card className="border-2 border-primary/30 bg-gradient-to-br from-primary/5 via-background to-background overflow-hidden group hover:border-primary/50 transition-all duration-500">
+          <Card className="border-2 border-primary/30 bg-gradient-to-br from-primary/5 via-background to-background overflow-hidden hover:border-primary/50 transition-all duration-500">
             <CardContent className="p-0">
               <div className="grid md:grid-cols-5 gap-0">
-                {/* Left Side - Visual Impact */}
-                <div className="md:col-span-2 relative bg-gradient-to-br from-primary/20 to-primary/5 p-8 flex flex-col justify-between min-h-[300px]">
-                  {/* Badge */}
-                  <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/20 border border-primary/30 mb-4 w-fit backdrop-blur-sm">
+                {/* Left Side */}
+                <div className="md:col-span-2 relative bg-gradient-to-br from-primary/20 to-primary/5 p-8 flex flex-col justify-between min-h-[200px]">
+                  <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/20 border border-primary/30 mb-4 w-fit">
                     <Zap className="h-4 w-4 text-primary" />
                     <span className="text-sm font-semibold text-primary">
                       {language === "es" ? "Proyecto Destacado" : "Featured Project"}
                     </span>
                   </div>
-
-                  {/* Title */}
-                  <div className="space-y-4 flex-1">
-                    <h3 className="text-3xl md:text-4xl font-bold leading-tight">
-                      {language === "es" 
-                        ? "RIA SURA Investments US"
-                        : "RIA SURA Investments US"}
+                  <div className="space-y-2">
+                    <h3 className="text-2xl md:text-3xl font-bold leading-tight">
+                      RIA SURA Investments US
                     </h3>
-                    <p className="text-lg text-muted-foreground">
-                      {language === "es"
-                        ? "Plataforma RIA para mercado estadounidense"
-                        : "RIA Platform for US market"}
+                    <p className="text-muted-foreground">
+                      {language === "es" ? "Plataforma RIA para mercado estadounidense" : "RIA Platform for US market"}
                     </p>
                   </div>
-
-                  {/* Static decorative gradient orb (no infinite animation) */}
                   <div className="absolute -bottom-10 -right-10 w-40 h-40 bg-primary/20 rounded-full blur-3xl pointer-events-none" />
                 </div>
 
-                {/* Right Side - Details */}
-                <div className="md:col-span-3 p-8 space-y-6">
-                  {/* Description */}
-                  <p className="text-lg leading-relaxed">
-                    {language === "es"
-                      ? "Diseño UX/UI end-to-end desde arquitectura de información hasta especificaciones UI detalladas. Sistema completo incluyendo autenticación, onboarding multi-rol, dashboards financieros y comunicaciones."
-                      : "End-to-end UX/UI design from information architecture to detailed UI specifications. Complete system including authentication, multi-role onboarding, financial dashboards, and communications."}
-                  </p>
-
-                  {/* Key Highlights Grid */}
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 w-2 rounded-full bg-primary"></div>
-                        <span className="text-sm font-semibold text-primary">
-                          {language === "es" ? "Arquitectura" : "Architecture"}
-                        </span>
-                      </div>
-                      <p className="text-sm text-muted-foreground pl-4">
-                        {language === "es" ? "Información completa" : "Complete information"}
-                      </p>
-                    </div>
-
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 w-2 rounded-full bg-primary"></div>
-                        <span className="text-sm font-semibold text-primary">
-                          {language === "es" ? "Onboarding" : "Onboarding"}
-                        </span>
-                      </div>
-                      <p className="text-sm text-muted-foreground pl-4">
-                        {language === "es" ? "Multi-rol (3 perfiles)" : "Multi-role (3 profiles)"}
-                      </p>
-                    </div>
-
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 w-2 rounded-full bg-primary"></div>
-                        <span className="text-sm font-semibold text-primary">
-                          {language === "es" ? "Dashboards" : "Dashboards"}
-                        </span>
-                      </div>
-                      <p className="text-sm text-muted-foreground pl-4">
-                        {language === "es" ? "Financieros + Analytics" : "Financial + Analytics"}
-                      </p>
-                    </div>
-
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 w-2 rounded-full bg-primary"></div>
-                        <span className="text-sm font-semibold text-primary">
-                          {language === "es" ? "Sistema de diseño" : "Design system"}
-                        </span>
-                      </div>
-                      <p className="text-sm text-muted-foreground pl-4">
-                        {language === "es" ? "Componentes reutilizables" : "Reusable components"}
-                      </p>
-                    </div>
+                {/* Right Side - compact metrics */}
+                <div className="md:col-span-3 p-8 flex flex-col justify-between gap-6">
+                  <div className="flex flex-wrap gap-3">
+                    {[
+                      language === "es" ? "8 prototipos interactivos" : "8 interactive prototypes",
+                      language === "es" ? "-40% tiempo onboarding" : "-40% onboarding time",
+                      language === "es" ? "3 flujos de autenticación" : "3 auth flows",
+                    ].map((metric) => (
+                      <span
+                        key={metric}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-primary/10 border border-primary/20 text-sm font-medium text-primary"
+                      >
+                        <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                        {metric}
+                      </span>
+                    ))}
                   </div>
 
-                  {/* Bottom Line */}
-                  <div className="pt-4 border-t flex items-center justify-between">
-                    <div className="flex items-center gap-6 text-sm">
-                      <div>
-                        <span className="text-muted-foreground">
-                          {language === "es" ? "Empresa:" : "Company:"}
-                        </span>{" "}
-                        <span className="font-semibold">SURA Investments</span>
-                      </div>
-                      <div>
-                        <span className="text-muted-foreground">
-                          {language === "es" ? "Rol:" : "Role:"}
-                        </span>{" "}
-                        <span className="font-semibold">Lead UX/UI Designer</span>
-                      </div>
+                  <div className="pt-4 border-t flex items-center gap-6 text-sm">
+                    <div>
+                      <span className="text-muted-foreground">{language === "es" ? "Empresa:" : "Company:"}</span>{" "}
+                      <span className="font-semibold">SURA Investments</span>
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">{language === "es" ? "Rol:" : "Role:"}</span>{" "}
+                      <span className="font-semibold">Lead UX/UI Designer</span>
                     </div>
                   </div>
                 </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import { Hero } from '../components/organisms/Hero';
 import { ImpactStats } from '../components/organisms/ImpactStats';
 import { About } from '../components/organisms/About';
-import { Skills } from '../components/organisms/Skills';
 import { Projects } from '../components/organisms/Projects';
 import { Experience } from '../components/organisms/Experience';
 import { Contact } from '../components/organisms/Contact';
@@ -17,9 +16,8 @@ const Home = () => {
         onNavigateToDesignSystem={() => navigate('/design-system')}
       />
       <ImpactStats />
-      <About />
-      <Skills />
       <Projects onNavigateToCaseStudies={() => navigate('/cases')} />
+      <About />
       <Experience />
       <Contact />
     </>


### PR DESCRIPTION
## Summary

- **Hero**: descripción reemplazada por métricas reales (-40%, NPS 72, +35%), 3 CTAs → 2, altura reducida a 75vh
- **ImpactStats**: contadores genéricos → métricas de proyecto medibles; card RIA SURA compactada a 3 chips
- **Home**: eliminada sección `<Skills />`, orden reorganizado a Hero → Stats → **Projects** → About → Experience → Contact
- **About**: eliminadas sub-secciones Filosofía + Valores + Quote; bio comprimida a 1 párrafo con contexto real
- **Experience**: eliminado bloque Certifications; métricas subidas al frente de cada job en una línea de resumen
- **Contact**: eliminada card "¿Por qué trabajar conmigo?" (redundante con About); description del header ahora comunica disponibilidad

## Impacto

| Métrica | Antes | Después |
|---|---|---|
| Scroll total (estimado) | ~19vh | ~10-11vh |
| CTAs en Hero | 3 | 2 |
| Menciones de "Design Thinking" | 5+ | 1 |
| Líneas de JSX eliminadas | — | -608 / +148 |

## Test plan

- [ ] Build pasa (`npm run build`) ✅
- [ ] 62 tests siguen pasando (`npm test`) ✅
- [ ] Hero muestra solo 2 botones
- [ ] ImpactStats muestra `-40%`, `NPS 72`, `+35%`, `+58%`
- [ ] About sin cards de Filosofía ni Valores
- [ ] Contact sin card "¿Por qué trabajar conmigo?"
- [ ] Toggle ES/EN funciona en todos los textos nuevos

https://claude.ai/code/session_01XmMuHoNiEonxdajm1J8YpG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmMuHoNiEonxdajm1J8YpG)_