### PR TITLE
fix: SPA routing GitHub Pages (404.html)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
 
       - run: npx vite build
 
+      - name: SPA fallback for GitHub Pages
+        run: cp dist/index.html dist/404.html
+
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
GitHub Pages devuelve 404 para rutas SPA como `/auditoria` porque no existe ese archivo físico.

Fix estándar: copiar `dist/index.html` → `dist/404.html` en el workflow de deploy. Cuando GitHub Pages no encuentra la ruta, sirve `404.html` (que es el bundle de React), y React Router resuelve la ruta client-side.