### PR TITLE
feat: /auditoria completo — PDF print WCAG, nav link, SEOHead

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ function RouterNavigation() {
     <Navigation
       onNavigateToDesignSystem={() => navigate('/design-system')}
       onNavigateToCaseStudies={() => navigate('/cases')}
+      onNavigateToAuditoria={() => navigate('/auditoria')}
     />
   );
 }

--- a/src/components/molecules/MobileMenu.tsx
+++ b/src/components/molecules/MobileMenu.tsx
@@ -16,6 +16,7 @@ interface MobileMenuProps {
   navItems: NavItem[];
   onNavigateToDesignSystem?: () => void;
   onNavigateToCaseStudies?: () => void;
+  onNavigateToAuditoria?: () => void;
 }
 
 export function MobileMenu({ 
@@ -23,7 +24,8 @@ export function MobileMenu({
   onClose, 
   navItems, 
   onNavigateToDesignSystem,
-  onNavigateToCaseStudies 
+  onNavigateToCaseStudies,
+  onNavigateToAuditoria
 }: MobileMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const firstFocusableRef = useRef<HTMLButtonElement>(null);
@@ -82,6 +84,8 @@ export function MobileMenu({
         setTimeout(() => onNavigateToDesignSystem?.(), 300);
       } else if (item.href === "case-studies") {
         setTimeout(() => onNavigateToCaseStudies?.(), 300);
+      } else if (item.href === "auditoria") {
+        setTimeout(() => onNavigateToAuditoria?.(), 300);
       }
       return;
     }

--- a/src/components/organisms/Navigation.tsx
+++ b/src/components/organisms/Navigation.tsx
@@ -12,11 +12,13 @@ import { useTranslation } from "../../lib/i18n";
 interface NavigationProps {
   onNavigateToDesignSystem?: () => void;
   onNavigateToCaseStudies?: () => void;
+  onNavigateToAuditoria?: () => void;
 }
 
 export function Navigation({ 
   onNavigateToDesignSystem,
-  onNavigateToCaseStudies 
+  onNavigateToCaseStudies,
+  onNavigateToAuditoria
 }: NavigationProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isHidden, setIsHidden] = useState(false);
@@ -31,6 +33,7 @@ export function Navigation({
     { href: "design-system", label: language === "es" ? "Design System" : "Design System", type: "route" as const },
     { href: "#experiencia", label: t.nav.experience, type: "anchor" as const },
     { href: "#contacto", label: t.nav.contact, type: "anchor" as const },
+    { href: "auditoria", label: language === "es" ? "Auditoría ✦" : "Audit ✦", type: "route" as const },
   ];
 
   // Close mobile menu when clicking outside or on escape
@@ -144,8 +147,10 @@ export function Navigation({
                       variant="ghost"
                       className="hover:text-primary hover:bg-primary/10 transition-all"
                       onClick={
-                        item.href === "design-system" 
-                          ? onNavigateToDesignSystem 
+                        item.href === "design-system"
+                          ? onNavigateToDesignSystem
+                          : item.href === "auditoria"
+                          ? onNavigateToAuditoria
                           : onNavigateToCaseStudies
                       }
                     >
@@ -212,6 +217,7 @@ export function Navigation({
         navItems={navItems}
         onNavigateToDesignSystem={onNavigateToDesignSystem}
         onNavigateToCaseStudies={onNavigateToCaseStudies}
+        onNavigateToAuditoria={onNavigateToAuditoria}
       />
     </>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -5031,3 +5031,70 @@ html {
         transform: translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0) scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1)) rotate(var(--tw-exit-rotate, 0));
     }
 }
+
+/* ────────────────────────── Print / PDF Export ──────────────────────── */
+@media print {
+    html, body {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+        background: #ffffff !important;
+        color: #111111 !important;
+    }
+    /* Ocultar navegación, footer, iframes y elementos marcados */
+    nav, footer, iframe, .no-print {
+        display: none !important;
+    }
+    /* Revelar contenido solo visible en impresión */
+    .print-only {
+        display: block !important;
+    }
+    /* Texto con gradiente → color sólido primario */
+    .text-brand-gradient {
+        background: none !important;
+        -webkit-background-clip: unset !important;
+        background-clip: unset !important;
+        -webkit-text-fill-color: #ff1d25 !important;
+        color: #ff1d25 !important;
+    }
+    /* Fondos con gradiente → color sólido */
+    .bg-brand-gradient {
+        background: #ff1d25 !important;
+    }
+    /* Línea decorativa → sólida */
+    .gradient-line {
+        background: #ff1d25 !important;
+    }
+    /* Badge numérico → sólido */
+    .number-badge {
+        background: #ff1d25 !important;
+        color: #ffffff !important;
+    }
+    /* Texto secundario → mayor contraste WCAG AA */
+    .text-muted-foreground {
+        color: #444444 !important;
+    }
+    /* Tarjetas → fondo blanco sin sombras */
+    .bg-card {
+        background: #ffffff !important;
+    }
+    /* Colores semánticos en impresión */
+    .text-destructive {
+        color: #c4002a !important;
+    }
+    /* Sin saltos de página dentro de secciones */
+    section, article, .rounded-xl, .rounded-lg {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+    /* Ancho completo en impresión */
+    .max-w-7xl {
+        max-width: 100% !important;
+        padding-left: 2rem !important;
+        padding-right: 2rem !important;
+    }
+    /* Eliminar decoraciones hover */
+    * {
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+}

--- a/src/pages/AuditoriaPortfolio.tsx
+++ b/src/pages/AuditoriaPortfolio.tsx
@@ -96,7 +96,7 @@ export default function AuditoriaPortfolio() {
             </div>
 
             {/* Right - Image */}
-            <div className="relative lg:block hidden">
+            <div className="relative lg:block hidden no-print">
               <div className="absolute inset-0 bg-brand-gradient opacity-10"></div>
               <img
                 src="https://images.unsplash.com/photo-1621111848501-8d3634f82336?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080"
@@ -195,7 +195,7 @@ export default function AuditoriaPortfolio() {
                 {section.observations.slice(0, 2).map((obs, idx) => (
                   <div
                     key={idx}
-                    className={`absolute ${
+                    className={`no-print absolute ${
                       colIdx === 0
                         ? idx === 0 ? '-top-3 -left-3 -rotate-2' : '-bottom-3 -right-3 rotate-1'
                         : colIdx === 1
@@ -331,7 +331,7 @@ export default function AuditoriaPortfolio() {
             <div className="gradient-line"></div>
             <p className="text-muted-foreground mt-4">Análisis completo interactivo</p>
           </div>
-          <div className="bg-card border border-border rounded-xl overflow-hidden shadow-xl">
+          <div className="bg-card border border-border rounded-xl overflow-hidden shadow-xl no-print">
             <iframe
               style={{ border: '1px solid rgba(0, 0, 0, 0.1)' }}
               width="100%"
@@ -351,6 +351,10 @@ export default function AuditoriaPortfolio() {
             >
               Abrir FigJam en nueva pestaña →
             </a>
+          </p>
+          {/* URL visible solo en PDF */}
+          <p className="print-only hidden text-sm border border-border rounded-lg p-4 mt-4">
+            <strong>FigJam Board:</strong> figma.com/board/lEGDG3EDlNI3OOUCucTyyx/PORTAFOLIO?node-id=2-41
           </p>
         </section>
 
@@ -426,7 +430,7 @@ export default function AuditoriaPortfolio() {
               <p className="text-muted-foreground mt-4">Trackea tu progreso</p>
             </div>
 
-            <div className="mb-8 p-6 bg-card border border-border rounded-xl shadow-lg">
+            <div className="no-print mb-8 p-6 bg-card border border-border rounded-xl shadow-lg">
               <div className="flex items-center justify-between mb-2">
                 <p className="text-sm font-medium">Progreso general</p>
                 <p className="text-sm text-brand-gradient font-medium">{completedCount}/{checklistItems.length} completadas</p>
@@ -477,7 +481,7 @@ export default function AuditoriaPortfolio() {
               ))}
             </div>
 
-            <p className="text-sm text-muted-foreground mt-8 text-center">
+            <p className="no-print text-sm text-muted-foreground mt-8 text-center">
               Haz clic para cambiar estado: Pendiente → En Progreso → Completado
             </p>
           </div>

--- a/src/pages/AuditoriaPortfolio.tsx
+++ b/src/pages/AuditoriaPortfolio.tsx
@@ -1,6 +1,7 @@
 import { Calendar, User, Sparkles, Download, CheckCircle2, Circle, Clock } from 'lucide-react';
 import { auditData } from '../data/audit-data';
 import { useState } from 'react';
+import { SEOHead } from '../components/atoms/SEOHead';
 
 export default function AuditoriaPortfolio() {
   const [checklistItems, setChecklistItems] = useState([
@@ -37,6 +38,12 @@ export default function AuditoriaPortfolio() {
 
   return (
     <div className="min-h-screen bg-background">
+      <SEOHead
+        title="Auditoría Portfolio UX/UI"
+        description="Análisis estratégico del portfolio UX/UI de Laura: 5 riesgos críticos, 6 quick wins SEO, plan de mentoría en 3 sesiones. Por Rodrigo Gaete, Lead UX Designer."
+        url="https://vientonorte.github.io/mi-portafolio/auditoria"
+        type="article"
+      />
       {/* Hero */}
       <header className="relative overflow-hidden bg-gradient-to-br from-primary/5 via-background to-orange-500/5">
         <div className="absolute inset-0 bg-brand-gradient opacity-5"></div>


### PR DESCRIPTION
Consolida todos los cambios de la ruta /auditoria:

## Cambios
- `@media print` en index.css: contraste WCAG AA, gradientes sólidos, ocultar iframe/post-its/progress-bar
- Nav desktop + mobile: link "Auditoría ✦" → /auditoria
- SEOHead con title/description/OG/canonical para /auditoria
- `react-helmet-async` instalado (dep. faltante)
- Fix backtick sintaxis en post-its