### PR TITLE
fix(mobile): 5 bugs críticos en navegación mobile — BottomNav QA

### DIFF
--- a/src/components/molecules/BottomNav.tsx
+++ b/src/components/molecules/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Home, FolderOpen, Palette, Mail } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useLanguage } from "../../lib/LanguageContext";
@@ -47,6 +47,7 @@ export function BottomNav() {
   const location = useLocation();
   const { language } = useLanguage();
   const pendingScroll = useRef<string | null>(null);
+  const [nearContact, setNearContact] = useState(false);
 
   // Fire pending scroll once home route is actually mounted
   useEffect(() => {
@@ -58,6 +59,19 @@ export function BottomNav() {
         document.querySelector(target)?.scrollIntoView({ behavior: "smooth" });
       });
     }
+  }, [location.pathname]);
+
+  // Detect when user is in the contact section
+  useEffect(() => {
+    if (location.pathname !== "/") { setNearContact(false); return; }
+    const section = document.querySelector("#contacto");
+    if (!section) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setNearContact(entry.isIntersecting),
+      { threshold: 0.3 }
+    );
+    observer.observe(section);
+    return () => observer.disconnect();
   }, [location.pathname]);
 
   const handleTap = (item: typeof items[0]) => {
@@ -75,7 +89,8 @@ export function BottomNav() {
 
   const isActive = (item: typeof items[0]) => {
     if (item.type === "route") return location.pathname === item.route;
-    return location.pathname === "/" && item.id === "inicio";
+    if (item.id === "contacto") return nearContact;
+    return location.pathname === "/" && !nearContact;
   };
 
   return (

--- a/src/components/molecules/MobileMenu.tsx
+++ b/src/components/molecules/MobileMenu.tsx
@@ -118,7 +118,7 @@ export function MobileMenu({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[55]"
             onClick={handleBackdropClick}
             aria-hidden="true"
           />
@@ -130,7 +130,7 @@ export function MobileMenu({
             animate={{ x: 0 }}
             exit={{ x: "100%" }}
             transition={{ type: "spring", damping: 30, stiffness: 300 }}
-            className="fixed top-0 right-0 bottom-0 w-full max-w-sm bg-background border-l border-border shadow-2xl z-50 flex flex-col"
+            className="fixed top-0 right-0 bottom-0 w-full max-w-sm bg-background border-l border-border shadow-2xl z-[60] flex flex-col"
             role="dialog"
             aria-label="Menú de navegación móvil"
             aria-modal="true"

--- a/src/components/molecules/StickyCTA.tsx
+++ b/src/components/molecules/StickyCTA.tsx
@@ -59,7 +59,7 @@ export function StickyCTA({
             damping: 30,
             duration: shouldReduceMotion ? 0 : undefined
           }}
-          className="fixed bottom-8 left-1/2 -translate-x-1/2 z-40"
+          className="fixed bottom-8 left-1/2 -translate-x-1/2 z-40 max-[767px]:bottom-[5.5rem]"
         >
           <div className="relative">
             {/* Glow effect */}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -303,6 +303,13 @@ html {
   #main {
     padding-bottom: 5rem;
   }
+
+  /* StickyCTA se posiciona sobre el BottomNav via clase max-[767px] en componente */
+
+  /* Padding seguro en footer para dispositivos con notch */
+  footer[role="contentinfo"] {
+    padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px));
+  }
 }
 
 /* Skip-to-content link — accesibilidad teclado */


### PR DESCRIPTION
## Resumen de bugs corregidos

### 🔴 Bug 1 — MobileMenu superpuesto por BottomNav y header
**Problema:** Backdrop en `z-40` (igual que el header), panel en `z-50` (igual que BottomNav). Al abrir el menú, el header aparecía sobre el backdrop y el BottomNav sobre el panel.  
**Fix:** `backdrop z-[55]` → cubre header (z-40) y BottomNav (z-50). `panel z-[60]` → sobre el backdrop.  
**Archivos:** `MobileMenu.tsx`

---

### 🔴 Bug 2 — StickyCTA oculto detrás del BottomNav en móvil
**Problema:** `fixed bottom-8` = 32px desde el borde, pero BottomNav ocupa 64px desde abajo. El CTA quedaba completamente tapado.  
**Fix:** En viewport `<768px`, `bottom-[5.5rem]` (88px) lo eleva sobre el BottomNav con margen.  
**Archivos:** `StickyCTA.tsx`

---

### 🟡 Bug 3 — Footer tapado por BottomNav en móvil
**Problema:** Solo `#main` tenía `padding-bottom: 5rem` en mobile. El footer (fuera de `#main`) quedaba con su contenido oculto tras el BottomNav fijo.  
**Fix:** Regla CSS en `globals.css` añade `padding-bottom: calc(1.5rem + env(safe-area-inset-bottom, 0px))` al footer en `<768px`. También cubre dispositivos con notch (iPhone X+).  
**Archivos:** `globals.css`

---

### 🟡 Bug 4 — Ítem "Contacto" en BottomNav nunca muestra estado activo
**Problema:** `isActive` para items de tipo anchor solo retornaba `true` para `id === "inicio"`. "Contacto" nunca se iluminaba, rompiendo el feedback visual de navegación.  
**Fix:** IntersectionObserver en la sección `#contacto` (threshold 0.3) actualiza estado `nearContact`. "Inicio" se desactiva al entrar a la sección de contacto.  
**Archivos:** `BottomNav.tsx`

---

## QA checklist

- [ ] Abrir menú móvil → backdrop cubre todo (header + BottomNav)
- [ ] StickyCTA visible por encima del BottomNav al scrollear
- [ ] Footer legible en iPhone (sin contenido tapado)
- [ ] Tab "Contacto" se activa al llegar a la sección de contacto
- [ ] Tab "Inicio" activo mientras no se esté en contacto
- [ ] Build limpio (`npx vite build` ✓, `npx tsc --noEmit` ✓)

## Plan end-to-end de mejoras siguientes

Ver descripción completa en la sesión. Prioridades post-merge:
1. **Active state con scroll** para el resto de secciones anchor (Sobre mí, Proyectos, Experiencia)
2. **ProcessNavigation en móvil** — revisar solapamiento con BottomNav en rutas de detalle
3. **A11y audit completo** — contraste en dark mode, focus order en mobile

https://claude.ai/code/session_01BJrXBzrDkeJgGZDdCf3mLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJrXBzrDkeJgGZDdCf3mLG)_