### PR TITLE
feat(contra-archivo): mover CitasAttac de /investigacion a /contra-archivo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const DesignSystem = lazy(() => import('./pages/DesignSystem'));
 const CaseStudies = lazy(() => import('./pages/CaseStudies'));
 const AuditoriaPortfolio = lazy(() => import('./pages/AuditoriaPortfolio'));
 const ProcessDetail = lazy(() => import('./pages/ProcessDetail'));
-const CitasAttac = lazy(() => import('./pages/CitasAttac'));
+const CitasAttac = lazy(() => import('./pages/contra-archivo/CitasAttac'));
 
 function RouterNavigation() {
   const navigate = useNavigate();
@@ -29,7 +29,7 @@ function RouterNavigation() {
       onNavigateToDesignSystem={() => navigate('/design-system')}
       onNavigateToCaseStudies={() => navigate('/cases')}
       onNavigateToAuditoria={() => navigate('/auditoria')}
-      onNavigateToCitasAttac={() => navigate('/investigacion/citas-attac')}
+      onNavigateToCitasAttac={() => navigate('/contra-archivo/citas-attac')}
     />
   );
 }
@@ -73,7 +73,7 @@ const App = () => (
             <Route path="/cases" element={<CaseStudiesPage />} />
             <Route path="/cases/process/:processId" element={<ProcessDetailPage />} />
             <Route path="/auditoria" element={<AuditoriaPortfolio />} />
-            <Route path="/investigacion/citas-attac" element={<CitasAttac />} />
+            <Route path="/contra-archivo/citas-attac" element={<CitasAttac />} />
           </Routes>
         </Suspense>
       </main>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 const Footer = () => (
   <footer role="contentinfo" className="mt-12 py-6 bg-[--color-pizarra] text-white text-center">
     <div>
-      <a href="mailto:gaete.gaona@gmail.com" className="text-white underline underline-offset-2">Contacto</a> | <Link to="/privacy" className="text-white underline underline-offset-2">Privacidad</Link> | <Link to="/investigacion/citas-attac" className="text-white underline underline-offset-2">Investigación</Link>
+      <a href="mailto:gaete.gaona@gmail.com" className="text-white underline underline-offset-2">Contacto</a> | <Link to="/privacy" className="text-white underline underline-offset-2">Privacidad</Link> | <Link to="/contra-archivo/citas-attac" className="text-white underline underline-offset-2">Investigación</Link>
     </div>
     <div className="text-sm mt-2">
       © {new Date().getFullYear()} Rodrigo Gaete Gaona

--- a/src/components/molecules/MobileMenu.tsx
+++ b/src/components/molecules/MobileMenu.tsx
@@ -148,7 +148,7 @@ export function MobileMenu({
         onNavigateToCaseStudies?.();
       } else if (item.href === "auditoria") {
         onNavigateToAuditoria?.();
-      } else if (item.href === "investigacion/citas-attac") {
+      } else if (item.href === "contra-archivo/citas-attac") {
         onNavigateToCitasAttac?.();
       }
       return;

--- a/src/components/organisms/Navigation.tsx
+++ b/src/components/organisms/Navigation.tsx
@@ -37,7 +37,7 @@ export function Navigation({
     { href: "#experiencia", label: t.nav.experience, type: "anchor" as const },
     { href: "#contacto", label: t.nav.contact, type: "anchor" as const },
     { href: "auditoria", label: language === "es" ? "Auditoría ✦" : "Audit ✦", type: "route" as const },
-    { href: "investigacion/citas-attac", label: language === "es" ? "Investigación" : "Research", type: "route" as const },
+    { href: "contra-archivo/citas-attac", label: language === "es" ? "Investigación" : "Research", type: "route" as const },
   ];
 
   // Close mobile menu when clicking outside or on escape
@@ -85,7 +85,7 @@ export function Navigation({
         onNavigateToCaseStudies?.();
       } else if (item.href === "auditoria") {
         onNavigateToAuditoria?.();
-      } else if (item.href === "investigacion/citas-attac") {
+      } else if (item.href === "contra-archivo/citas-attac") {
         onNavigateToCitasAttac?.();
       }
       return;
@@ -161,7 +161,7 @@ export function Navigation({
                           ? onNavigateToAuditoria
                           : item.href === "cases"
                           ? onNavigateToCaseStudies
-                          : item.href === "investigacion/citas-attac"
+                          : item.href === "contra-archivo/citas-attac"
                           ? onNavigateToCitasAttac
                           : undefined
                       }

--- a/src/pages/contra-archivo/CitasAttac.tsx
+++ b/src/pages/contra-archivo/CitasAttac.tsx
@@ -65,7 +65,7 @@ export default function CitasAttac() {
       <SEOHead
         title="Citas ATTAC — Etnografía Digital SURA Investments"
         description="Fichas de citas y capturas de ATTAC usadas como evidencia en la tesis doctoral Contra-Archivo: Antropología y Corrupción. Análisis de circuitos financieros transnacionales, mistranslation institucional y marcadores de fricción semántica."
-        url="https://vientonorte.github.io/mi-portafolio/#/investigacion/citas-attac"
+        url="https://vientonorte.github.io/mi-portafolio/#/contra-archivo/citas-attac"
         type="article"
         noIndex={false}
       />

--- a/src/pages/contra-archivo/CitasAttac.tsx
+++ b/src/pages/contra-archivo/CitasAttac.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BookOpen, ExternalLink, FileText, Hash, Shield } from 'lucide-react';
-import { SEOHead } from '../components/atoms/SEOHead';
+import { SEOHead } from '../../components/atoms/SEOHead';
 
 // ─── Datos ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Mueve `src/pages/CitasAttac.tsx` → `src/pages/contra-archivo/CitasAttac.tsx`
- Cambia la ruta de `#/investigacion/citas-attac` a `#/contra-archivo/citas-attac`
- Actualiza todos los references: `App.tsx`, `Footer.tsx`, `Navigation.tsx`, `MobileMenu.tsx`
- Actualiza la URL canónica en el `SEOHead` de la página

## Test plan

- [ ] Visitar `#/contra-archivo/citas-attac` → página carga correctamente
- [ ] Link "Investigación" en Footer navega a la nueva ruta
- [ ] Link "Investigación" en Navigation (desktop y mobile) navega a la nueva ruta
- [ ] La ruta antigua `#/investigacion/citas-attac` ya no existe

https://claude.ai/code/session_0152TN4J9PXi7T5MCUoQdPPm

---
_Generated by [Claude Code](https://claude.ai/code/session_0152TN4J9PXi7T5MCUoQdPPm)_