### PR TITLE
feat(consultoria): add GEES Figma Sites proposal demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-07-21] — Demo GEES en consultoría
+
+### Added
+- **GEES · Propuesta** en Figma Sites (`https://duct-juice-51509104.figma.site`): segunda demo en `#consultoria-demo`, card en Arsenal de valor y sugerencia del buscador hero (ES/EN).
+- `CONSULTORIA_DEMOS` multi-demo en `consultoria-demos.ts` (X | CMS + GEES).
+
+### Changed
+- **ConsultoriaDemoShowcase** soporta varias demos publicadas; CTA Figma Make solo si hay `figmaMakeUrl`.
+- QA `qa-prototypes.mjs` valida todos los `figmaSitesUrl` de consultoría.
+
+---
+
 ## [2026-07-08] — QA rutas, hero mobile, assets consultoría
 
 ### Added

--- a/scripts/qa-prototypes.mjs
+++ b/scripts/qa-prototypes.mjs
@@ -55,10 +55,11 @@ function parseValueProofExternalUrls(arsenalTs, demosTs) {
   const body = block[1];
 
   const entryRe =
-    /"([^"]+)":\s*(?:"([^"]+)"|(CONSULTORIA_DEMO_X_CMS\.figmaSitesUrl)|([A-Z][A-Z0-9_]+))/g;
+    /"([^"]+)":\s*(?:"([^"]+)"|(CONSULTORIA_DEMO_(?:X_CMS|GEES)\.figmaSitesUrl)|([A-Z][A-Z0-9_]+))/g;
   for (const match of body.matchAll(entryRe)) {
     const [, id, quoted, consultoriaRef, constRef] = match;
     if (quoted) urls[id] = quoted;
+    else if (consultoriaRef?.includes('GEES')) urls[id] = consultoria.figmaSitesUrls?.find((u) => u.includes('duct-juice')) || consultoria.figmaSitesUrls?.[1];
     else if (consultoriaRef) urls[id] = consultoria.figmaSitesUrl;
     else if (constRef && constUrls[constRef]) urls[id] = constUrls[constRef];
   }
@@ -80,9 +81,13 @@ function parseArsenalTitlesEs(ts) {
 }
 
 function parseConsultoriaDemos(ts) {
-  const sites = ts.match(/figmaSitesUrl:\s*"([^"]+)"/)?.[1];
+  const sites = [...ts.matchAll(/figmaSitesUrl:\s*"([^"]+)"/g)].map((m) => m[1]);
   const make = ts.match(/figmaMakeUrl:\s*\n?\s*"([^"]+)"/)?.[1];
-  return { figmaSitesUrl: sites, figmaMakeUrl: make };
+  return {
+    figmaSitesUrl: sites[0],
+    figmaSitesUrls: sites,
+    figmaMakeUrl: make,
+  };
 }
 
 function parseProjectExternalLinks(ts, constUrls) {
@@ -172,12 +177,20 @@ async function checkConsultoriaDemo(page, consultoria) {
 
   const errors = [];
   const haystack = (await collectHrefAndIframeSrc(page)).join('\n');
-  if (!haystack.includes(urlNeedle(consultoria.figmaSitesUrl))) {
-    errors.push('iframe/link Figma Sites ausente');
+  const siteUrls = consultoria.figmaSitesUrls?.length
+    ? consultoria.figmaSitesUrls
+    : [consultoria.figmaSitesUrl].filter(Boolean);
+
+  for (const siteUrl of siteUrls) {
+    if (!haystack.includes(urlNeedle(siteUrl))) {
+      errors.push(`iframe/link Figma Sites ausente: ${urlNeedle(siteUrl)}`);
+    }
   }
 
   const primary = page.getByRole('button', { name: /demo publicada|published demo|abrir demo|open demo/i });
-  if ((await primary.count()) === 0) errors.push('CTA principal demo no encontrado');
+  if ((await primary.count()) < siteUrls.length) {
+    errors.push(`CTA principal demo: esperados ≥${siteUrls.length}, hay ${await primary.count()}`);
+  }
 
   const secondary = page.getByRole('button', { name: /figma make/i });
   if ((await secondary.count()) === 0) errors.push('CTA secundario Figma Make no encontrado');
@@ -198,7 +211,7 @@ async function checkConsultoriaDemo(page, consultoria) {
     }
   }
 
-  return { label: 'Consultoría X | CMS demo', ok: errors.length === 0, errors };
+  return { label: 'Consultoría demos Figma Sites', ok: errors.length === 0, errors };
 }
 
 async function expandArsenal(page) {
@@ -317,7 +330,7 @@ async function main() {
   const results = [];
 
   const siteUrls = [
-    consultoria.figmaSitesUrl,
+    ...(consultoria.figmaSitesUrls || [consultoria.figmaSitesUrl]),
     ...Object.values(arsenalExternal),
     ...projects.map((p) => p.url),
   ].filter(Boolean);

--- a/src/__tests__/data/value-content-arsenal.test.ts
+++ b/src/__tests__/data/value-content-arsenal.test.ts
@@ -9,6 +9,7 @@ import { getPortfolioImages } from "@/lib/image-overrides";
 /** Claves de portfolioImages esperadas por card — imagen alineada a contenido y evidencia. */
 const EXPECTED_IMAGE_KEYS: Record<string, string> = {
   "x-cms-demo": "consultoria.xCmsDashboard",
+  "gees-propuesta": "consultoria.xCmsDashboard",
   "ria-us": "sura.riaOnboarding",
   "ria-celula-evolutiva": "sura.celulaEvolutivaFlow",
   "poc-ia-dei": "sura.iaAutomationDashboard",

--- a/src/__tests__/lib/i18n.test.ts
+++ b/src/__tests__/lib/i18n.test.ts
@@ -38,7 +38,11 @@ describe('translations', () => {
         expect(hero.unifiedBanner).toHaveProperty('searchPlaceholder');
         expect(hero.unifiedBanner).toHaveProperty('liveSuggestionsCount');
         expect(hero.unifiedBanner).toHaveProperty('liveSuggestionsActive');
-        expect(hero.unifiedBanner.suggestions).toHaveLength(3);
+        // X | CMS + GEES + contacto + auditoría (mín. 3; crece con demos)
+        expect(hero.unifiedBanner.suggestions.length).toBeGreaterThanOrEqual(3);
+        expect(hero.unifiedBanner.suggestions.map((s) => s.id)).toEqual(
+          expect.arrayContaining(['negocios-demo', 'negocios-gees', 'contacto-perfil', 'auditoria-freemium'])
+        );
         expect(hero.unifiedBanner.panels.negocios).toHaveProperty('composerHint');
         expect(hero.unifiedBanner.panels.negocios).toHaveProperty('ctaPrimary');
         expect(hero.unifiedBanner.panels.contacto).toHaveProperty('ctaPrimary');

--- a/src/components/organisms/ConsultoriaDemoShowcase.tsx
+++ b/src/components/organisms/ConsultoriaDemoShowcase.tsx
@@ -2,7 +2,11 @@ import { ExternalLink, Layers, Sparkles } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
-import { CONSULTORIA_DEMO_X_CMS } from "../../data/consultoria-demos";
+import {
+  CONSULTORIA_DEMOS,
+  type ConsultoriaDemoConfig,
+  type ConsultoriaDemoId,
+} from "../../data/consultoria-demos";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { trackEvent } from "../../lib/analytics";
@@ -10,22 +14,24 @@ import { trackEvent } from "../../lib/analytics";
 export function ConsultoriaDemoShowcase() {
   const { language } = useLanguage();
   const demo = useTranslation(language).consultoria.demo;
-  const opensNewTab = language === "es" ? "se abre en una pestaña nueva" : "opens in a new tab";
+  const opensNewTab =
+    language === "es" ? "se abre en una pestaña nueva" : "opens in a new tab";
 
-  const openPublishedSite = () => {
+  const openPublishedSite = (config: ConsultoriaDemoConfig) => {
     trackEvent("consultoria_demo_open", {
-      demo_id: CONSULTORIA_DEMO_X_CMS.id,
+      demo_id: config.id,
       target: "figma_sites",
     });
-    window.open(CONSULTORIA_DEMO_X_CMS.figmaSitesUrl, "_blank", "noopener,noreferrer");
+    window.open(config.figmaSitesUrl, "_blank", "noopener,noreferrer");
   };
 
-  const openMakeFile = () => {
+  const openMakeFile = (config: ConsultoriaDemoConfig) => {
+    if (!config.figmaMakeUrl) return;
     trackEvent("consultoria_demo_open", {
-      demo_id: CONSULTORIA_DEMO_X_CMS.id,
+      demo_id: config.id,
       target: "figma_make",
     });
-    window.open(CONSULTORIA_DEMO_X_CMS.figmaMakeUrl, "_blank", "noopener,noreferrer");
+    window.open(config.figmaMakeUrl, "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -40,83 +46,104 @@ export function ConsultoriaDemoShowcase() {
             <Sparkles className="mr-1.5 h-3.5 w-3.5 text-primary" aria-hidden />
             {demo.badge}
           </Badge>
-          <h2 id="consultoria-demo-heading" className="text-2xl md:text-3xl font-semibold tracking-tight">
+          <h2
+            id="consultoria-demo-heading"
+            className="text-2xl md:text-3xl font-semibold tracking-tight"
+          >
             {demo.title}
           </h2>
           <p className="max-w-3xl text-muted-foreground">{demo.description}</p>
         </div>
 
-        <Card className="overflow-hidden border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-md">
-          <CardContent className="p-0">
-            <div className="grid gap-0 lg:grid-cols-5">
-              <div className="lg:col-span-2 flex flex-col justify-between gap-6 p-6 md:p-8 border-b lg:border-b-0 lg:border-r border-[color:var(--logo-surface-border)]">
-                <div className="space-y-4">
-                  <div className="inline-flex items-center gap-2 rounded-full bg-[var(--featured-matte-accent)] border border-[color:var(--logo-surface-border)] px-3 py-1.5">
-                    <Layers className="h-4 w-4 text-primary" aria-hidden />
-                    <span className="text-sm font-semibold text-primary">{demo.projectName}</span>
-                  </div>
-                  <p className="text-sm leading-relaxed text-foreground/90">{demo.approach}</p>
-                  <ul className="flex flex-wrap gap-2" role="list">
-                    {demo.highlights.map((item) => (
-                      <li key={item}>
-                        <span className="inline-flex rounded-full border border-border/80 bg-muted/40 px-2.5 py-1 text-xs font-medium text-foreground">
-                          {item}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap">
-                  <Button
-                    type="button"
-                    size="lg"
-                    className="w-full bg-brand-gradient font-semibold hover:opacity-90 sm:w-auto"
-                    onClick={openPublishedSite}
-                  >
-                    {demo.cta}
-                    <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
-                  </Button>
-                  <Button
-                    type="button"
-                    size="lg"
-                    variant="outline"
-                    className="w-full sm:w-auto"
-                    onClick={openMakeFile}
-                  >
-                    {demo.ctaSecondary}
-                    <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
-                  </Button>
-                </div>
-              </div>
+        <div className="space-y-6">
+          {CONSULTORIA_DEMOS.map((config) => {
+            const item = demo.items[config.id as ConsultoriaDemoId];
+            if (!item) return null;
 
-              <div className="lg:col-span-3 relative min-h-[280px] md:min-h-[360px] bg-muted/20">
-                <button
-                  type="button"
-                  onClick={openPublishedSite}
-                  className="group absolute inset-0 h-full w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
-                  aria-label={`${demo.cta} (${opensNewTab})`}
-                >
-                  <iframe
-                    title={demo.embedTitle}
-                    src={CONSULTORIA_DEMO_X_CMS.figmaSitesUrl}
-                    className="pointer-events-none absolute inset-0 h-full w-full border-0"
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/70 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-                  <span className="pointer-events-none absolute bottom-4 right-4 rounded-full border border-border/80 bg-background/90 px-3 py-1.5 text-xs font-medium text-foreground opacity-0 shadow-sm transition-opacity duration-300 group-hover:opacity-100">
-                    {demo.previewCta}
-                  </span>
-                </button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+            return (
+              <Card
+                key={config.id}
+                className="overflow-hidden border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-md"
+              >
+                <CardContent className="p-0">
+                  <div className="grid gap-0 lg:grid-cols-5">
+                    <div className="lg:col-span-2 flex flex-col justify-between gap-6 p-6 md:p-8 border-b lg:border-b-0 lg:border-r border-[color:var(--logo-surface-border)]">
+                      <div className="space-y-4">
+                        <div className="inline-flex items-center gap-2 rounded-full bg-[var(--featured-matte-accent)] border border-[color:var(--logo-surface-border)] px-3 py-1.5">
+                          <Layers className="h-4 w-4 text-primary" aria-hidden />
+                          <span className="text-sm font-semibold text-primary">
+                            {item.projectName}
+                          </span>
+                        </div>
+                        <p className="text-sm leading-relaxed text-foreground/90">
+                          {item.approach}
+                        </p>
+                        <ul className="flex flex-wrap gap-2" role="list">
+                          {item.highlights.map((tag) => (
+                            <li key={tag}>
+                              <span className="inline-flex rounded-full border border-border/80 bg-muted/40 px-2.5 py-1 text-xs font-medium text-foreground">
+                                {tag}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap">
+                        <Button
+                          type="button"
+                          size="lg"
+                          className="w-full bg-brand-gradient font-semibold hover:opacity-90 sm:w-auto"
+                          onClick={() => openPublishedSite(config)}
+                        >
+                          {demo.cta}
+                          <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+                        </Button>
+                        {config.figmaMakeUrl ? (
+                          <Button
+                            type="button"
+                            size="lg"
+                            variant="outline"
+                            className="w-full sm:w-auto"
+                            onClick={() => openMakeFile(config)}
+                          >
+                            {demo.ctaSecondary}
+                            <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className="lg:col-span-3 relative min-h-[280px] md:min-h-[360px] bg-muted/20">
+                      <button
+                        type="button"
+                        onClick={() => openPublishedSite(config)}
+                        className="group absolute inset-0 h-full w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+                        aria-label={`${demo.cta}: ${item.projectName} (${opensNewTab})`}
+                      >
+                        <iframe
+                          title={item.embedTitle}
+                          src={config.figmaSitesUrl}
+                          className="pointer-events-none absolute inset-0 h-full w-full border-0"
+                          loading="lazy"
+                          allowFullScreen
+                        />
+                        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/70 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                        <span className="pointer-events-none absolute bottom-4 right-4 rounded-full border border-border/80 bg-background/90 px-3 py-1.5 text-xs font-medium text-foreground opacity-0 shadow-sm transition-opacity duration-300 group-hover:opacity-100">
+                          {demo.previewCta}
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
 
         <p className="mt-3 text-center text-xs text-muted-foreground">
           <button
             type="button"
-            onClick={openMakeFile}
+            onClick={() => openMakeFile(CONSULTORIA_DEMOS[0])}
             className="text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
             aria-label={`${demo.ctaMakeLink} (${opensNewTab})`}
           >

--- a/src/components/organisms/ConsultoriaDemoShowcase.tsx
+++ b/src/components/organisms/ConsultoriaDemoShowcase.tsx
@@ -98,7 +98,7 @@ export function ConsultoriaDemoShowcase() {
                           {demo.cta}
                           <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
                         </Button>
-                        {config.figmaMakeUrl ? (
+                        {config.figmaMakeUrl != null && config.figmaMakeUrl !== "" ? (
                           <Button
                             type="button"
                             size="lg"

--- a/src/data/consultoria-demos.ts
+++ b/src/data/consultoria-demos.ts
@@ -30,9 +30,9 @@ export const CONSULTORIA_DEMO_GEES = {
 } as const satisfies ConsultoriaDemoConfig;
 
 /** Orden de aparición en #consultoria-demo */
-export const CONSULTORIA_DEMOS = [
+export const CONSULTORIA_DEMOS: readonly ConsultoriaDemoConfig[] = [
   CONSULTORIA_DEMO_X_CMS,
   CONSULTORIA_DEMO_GEES,
-] as const;
+];
 
 export type ConsultoriaDemoId = (typeof CONSULTORIA_DEMOS)[number]["id"];

--- a/src/data/consultoria-demos.ts
+++ b/src/data/consultoria-demos.ts
@@ -1,12 +1,38 @@
-/** Demos públicas de consultoría Viento Norte (Figma Make, etc.) */
+/** Demos públicas de consultoría Viento Norte (Figma Sites / Make). */
 
+export type ConsultoriaDemoConfig = {
+  id: string;
+  /** Sitio publicado navegable (CTA principal + preview iframe) */
+  figmaSitesUrl: string;
+  /** Archivo editable en Figma Make (CTA secundario, opcional) */
+  figmaMakeUrl?: string;
+  /** Embed Make (legado; el preview usa figmaSitesUrl) */
+  embedUrl?: string;
+};
+
+/** X | CMS · N2N Design Thinking + Design Sprint */
 export const CONSULTORIA_DEMO_X_CMS = {
   id: "x-cms-n2n",
-  /** Sitio publicado navegable (CTA principal) */
   figmaSitesUrl: "https://pouch-growl-74881457.figma.site",
-  /** Archivo editable en Figma Make (CTA secundario) */
   figmaMakeUrl:
     "https://www.figma.com/make/nHrKYiEtbE0gYnTFB4Ast6/X-%7C-CMS",
   embedUrl:
     "https://www.figma.com/embed?embed_host=mi-portafolio&url=https%3A%2F%2Fwww.figma.com%2Fmake%2FnHrKYiEtbE0gYnTFB4Ast6%2FX-%257C-CMS",
-} as const;
+} as const satisfies ConsultoriaDemoConfig;
+
+/**
+ * GEES · Propuesta ejecutiva (dashboard de cotización y KPIs).
+ * Publicado: https://duct-juice-51509104.figma.site
+ */
+export const CONSULTORIA_DEMO_GEES = {
+  id: "gees-propuesta",
+  figmaSitesUrl: "https://duct-juice-51509104.figma.site",
+} as const satisfies ConsultoriaDemoConfig;
+
+/** Orden de aparición en #consultoria-demo */
+export const CONSULTORIA_DEMOS = [
+  CONSULTORIA_DEMO_X_CMS,
+  CONSULTORIA_DEMO_GEES,
+] as const;
+
+export type ConsultoriaDemoId = (typeof CONSULTORIA_DEMOS)[number]["id"];

--- a/src/data/value-content-arsenal.ts
+++ b/src/data/value-content-arsenal.ts
@@ -1,7 +1,10 @@
 import type { Language } from "../lib/i18n";
 import { getPortfolioImages } from "../lib/image-overrides";
 import { ROUTES } from "../lib/routes";
-import { CONSULTORIA_DEMO_X_CMS } from "./consultoria-demos";
+import {
+  CONSULTORIA_DEMO_GEES,
+  CONSULTORIA_DEMO_X_CMS,
+} from "./consultoria-demos";
 import type { ConsultingPackageId } from "./vientonorte-consulting";
 
 /** Figma · System Design App Cliente Transvip (handoff navegable). */
@@ -66,6 +69,30 @@ export const VALUE_PROOF_ITEMS: ValueProofItem[] = [
         title: "X | CMS · Design Thinking + Sprint",
         outcome: "N2N case on Figma Sites — from brief to prototype for SEM/SEO campaigns.",
         metric: "N2N",
+      },
+    },
+  },
+  {
+    id: "gees-propuesta",
+    kind: "prototype",
+    imagePath: img((i) => i.consultoria.xCmsDashboard),
+    href: CONSULTORIA_DEMO_GEES.figmaSitesUrl,
+    external: true,
+    bundleId: "marco",
+    copy: {
+      es: {
+        kindLabel: "Propuesta publicada",
+        title: "GEES · Dashboard de cotización",
+        outcome:
+          "Propuesta ejecutiva en Figma Sites — cotización digital, KPIs en tiempo real y decisión estratégica.",
+        metric: "Figma Sites",
+      },
+      en: {
+        kindLabel: "Published proposal",
+        title: "GEES · Quoting dashboard",
+        outcome:
+          "Executive proposal on Figma Sites — digital quoting, real-time KPIs, and strategic decisions.",
+        metric: "Figma Sites",
       },
     },
   },
@@ -586,6 +613,7 @@ export const VALUE_PROOF_ITEMS: ValueProofItem[] = [
 
 export const VALUE_PROOF_EXTERNAL_URLS: Record<string, string> = {
   "x-cms-demo": CONSULTORIA_DEMO_X_CMS.figmaSitesUrl,
+  "gees-propuesta": CONSULTORIA_DEMO_GEES.figmaSitesUrl,
   "ria-us": RIA_US_PROTO_URL,
   "poc-ia-dei": "https://badge-sweet-21070688.figma.site",
   "transvip-mobile": TRANSVIP_APP_PROTO_URL,

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -450,19 +450,30 @@ export default {
         cta: 'Continue with this format',
       },
       demo: {
-        badge: 'Method demo',
-        title: 'N2N design · Design Thinking + Sprint',
+        badge: 'Method demos',
+        title: 'Published prototypes · Figma Sites',
         description:
-          'Published demo case: from brief to prototype on Figma Sites. Shows how we apply discovery, sprint, and handoff — the same standard as the landing playbook.',
-        projectName: 'X | CMS',
-        approach:
-          'Needle-to-needle: Design Thinking ideation, Design Sprint validation, and navigable prototype for implementation handoff.',
-        highlights: ['Design Thinking', 'Design Sprint', 'CMS', 'N2N', 'Figma Sites'],
+          'Open demo cases: from brief to navigable prototype. They show discovery, sprint, handoff, and proposal deliverables — the same standard as the landing playbook.',
         cta: 'Open published demo',
         ctaSecondary: 'Open in Figma Make',
-        ctaMakeLink: 'View editable file in Figma Make',
+        ctaMakeLink: 'View editable X | CMS file in Figma Make',
         previewCta: 'Open full site',
-        embedTitle: 'X | CMS demo — Figma Sites',
+        items: {
+          'x-cms-n2n': {
+            projectName: 'X | CMS',
+            approach:
+              'Needle-to-needle: Design Thinking ideation, Design Sprint validation, and navigable prototype for implementation handoff.',
+            highlights: ['Design Thinking', 'Design Sprint', 'CMS', 'N2N', 'Figma Sites'],
+            embedTitle: 'X | CMS demo — Figma Sites',
+          },
+          'gees-propuesta': {
+            projectName: 'GEES · Proposal',
+            approach:
+              'Executive dashboard for digital quoting and management: real-time KPIs and strategic decision support — UX proposal ready for stakeholders.',
+            highlights: ['Dashboard', 'Quoting', 'KPIs', 'Proposal', 'Figma Sites'],
+            embedTitle: 'GEES · Proposal — Figma Sites',
+          },
+        },
       },
       appQuoter: {
         badge: 'App & web quoter',
@@ -664,6 +675,25 @@ export default {
             hint: 'From brief to published prototype — Design Thinking and Sprint for campaigns.',
             badge: 'Demo',
             keywords: ['demo', 'business', 'cms', 'sem', 'seo', 'case', 'x cms', 'consulting', 'leads'],
+            href: 'section/consultoria/consultoria-demo',
+          },
+          {
+            id: 'negocios-gees',
+            category: 'negocios',
+            title: 'GEES · Proposal',
+            hint: 'Executive quoting dashboard and KPIs — Figma Sites prototype for stakeholders.',
+            badge: 'Demo',
+            keywords: [
+              'gees',
+              'proposal',
+              'dashboard',
+              'quoting',
+              'kpis',
+              'demo',
+              'business',
+              'consulting',
+              'figma',
+            ],
             href: 'section/consultoria/consultoria-demo',
           },
           {

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -450,19 +450,30 @@ export default {
         cta: 'Continuar con esta modalidad',
       },
       demo: {
-        badge: 'Demo de método',
-        title: 'Diseño N2N · Design Thinking + Sprint',
+        badge: 'Demos de método',
+        title: 'Prototipos publicados · Figma Sites',
         description:
-          'Caso demo publicado: del brief al prototipo en Figma Sites. Muestra cómo aplicamos discovery, sprint y handoff — el mismo estándar del playbook de la landing.',
-        projectName: 'X | CMS',
-        approach:
-          'Needle-to-needle: ideación con Design Thinking, validación en Design Sprint y prototipo navegable para handoff a implementación.',
-        highlights: ['Design Thinking', 'Design Sprint', 'CMS', 'N2N', 'Figma Sites'],
+          'Casos demo abiertos: del brief al prototipo navegable. Muestran discovery, sprint, handoff y entregables de propuesta — el mismo estándar del playbook de la landing.',
         cta: 'Abrir demo publicada',
         ctaSecondary: 'Abrir en Figma Make',
-        ctaMakeLink: 'Ver archivo editable en Figma Make',
+        ctaMakeLink: 'Ver archivo editable X | CMS en Figma Make',
         previewCta: 'Abrir sitio completo',
-        embedTitle: 'Demo X | CMS — Figma Sites',
+        items: {
+          'x-cms-n2n': {
+            projectName: 'X | CMS',
+            approach:
+              'Needle-to-needle: ideación con Design Thinking, validación en Design Sprint y prototipo navegable para handoff a implementación.',
+            highlights: ['Design Thinking', 'Design Sprint', 'CMS', 'N2N', 'Figma Sites'],
+            embedTitle: 'Demo X | CMS — Figma Sites',
+          },
+          'gees-propuesta': {
+            projectName: 'GEES · Propuesta',
+            approach:
+              'Dashboard ejecutivo de cotización y gestión digital: KPIs en tiempo real y apoyo a la decisión estratégica — propuesta UX lista para stakeholders.',
+            highlights: ['Dashboard', 'Cotización', 'KPIs', 'Propuesta', 'Figma Sites'],
+            embedTitle: 'GEES · Propuesta — Figma Sites',
+          },
+        },
       },
       appQuoter: {
         badge: 'Cotizador app & web',
@@ -664,6 +675,25 @@ export default {
             hint: 'Del brief al prototipo publicado — Design Thinking y Sprint para campañas.',
             badge: 'Demo',
             keywords: ['demo', 'negocios', 'cms', 'sem', 'seo', 'caso', 'x cms', 'consultoría', 'leads'],
+            href: 'section/consultoria/consultoria-demo',
+          },
+          {
+            id: 'negocios-gees',
+            category: 'negocios',
+            title: 'GEES · Propuesta',
+            hint: 'Dashboard ejecutivo de cotización y KPIs — prototipo Figma Sites para stakeholders.',
+            badge: 'Demo',
+            keywords: [
+              'gees',
+              'propuesta',
+              'dashboard',
+              'cotización',
+              'kpis',
+              'demo',
+              'negocios',
+              'consultoría',
+              'figma',
+            ],
             href: 'section/consultoria/consultoria-demo',
           },
           {


### PR DESCRIPTION
## Summary
Adds **GEES · Propuesta** (https://duct-juice-51509104.figma.site) to the portfolio as a published Figma Sites demo.

- Second card in `/#/consultoria` → `#consultoria-demo` (next to X | CMS)
- Arsenal de valor card with external link
- Hero search suggestion (ES/EN)
- Multi-demo registry (`CONSULTORIA_DEMOS`)
- QA prototypes updated for multiple Figma Sites URLs

## Where to verify
| Surface | URL |
|---------|-----|
| Demo section | `/#/consultoria` → `#consultoria-demo` (after merge/deploy) |
| Live prototype | https://duct-juice-51509104.figma.site |

## Test plan
- [ ] CI green on this PR
- [ ] `/#/consultoria#consultoria-demo` shows X | CMS **and** GEES cards
- [ ] GEES primary CTA opens `duct-juice-51509104.figma.site`
- [ ] GEES has no Figma Make secondary CTA (only Sites)
- [ ] Arsenal card “GEES · Dashboard de cotización” opens the same URL
- [ ] Hero search “GEES” / “propuesta” → consultoria demo section
- [ ] EN labels for GEES look correct

## Note
GEES arsenal thumbnail reuses `consultoria.xCmsDashboard` until a dedicated screenshot is captured.