### PR TITLE
chore(ci): Dependabot policy + branch cleanup (PDF automaciones P0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,18 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     groups:
       radix-ui:
         patterns:
           - "@radix-ui/*"
       dev-deps:
         dependency-type: development
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,46 @@
+name: Branch cleanup
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  delete-merged-branch:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            if (branch === 'main' || branch.startsWith('dependabot/')) {
+              console.log('skip', branch);
+              return;
+            }
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              console.log('deleted', branch);
+            } catch (e) {
+              console.log('skip delete', branch, e.message);
+            }
+
+  audit-stale:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: List remote branches except main
+        run: |
+          git fetch --prune origin
+          echo "Remote branches:"
+          git branch -r | grep -v 'HEAD' | sed 's|origin/||'

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "ci": "npm run lint && npm run type-check && npm run test && npm run build",
     "clean": "rm -rf dist coverage",
     "reset": "npm run clean && npm install",
-    "prepare": "husky"
+    "prepare": "husky",
+    "smoke:cierre": "bash ~/.grok/skills/seo-vn/scripts/cierre-smoke.sh http://127.0.0.1:5173/mi-portafolio"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "^1.1.4"


### PR DESCRIPTION
## Summary
Applies PDF *Automaciones M5/Google* P0 items that cannot land via direct push (main requires status checks):

- Dependabot: limit 3, groups (radix/dev/prod minor-patch), ignore majors
- Workflow `branch-cleanup` on merge + manual audit
- `npm run smoke:cierre` → local SEO+Ads matrix (M5 gate)

## Test plan
- [ ] CI green on this PR
- [ ] Dependabot config validates in GitHub UI
- [ ] Optional: `npm run smoke:cierre` with dev server