### PR TITLE
chore(deps): @vientonorte core pins + cli@0.1.1

### DIFF
--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,4 +1,3 @@
-# Copy to ~/.npmrc or export NODE_AUTH_TOKEN
 legacy-peer-deps=true
 @vientonorte:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/docs/VN-PACKAGES.md
+++ b/docs/VN-PACKAGES.md
@@ -1,35 +1,52 @@
-# @vientonorte packages en mi-portafolio
+# @vientonorte/* · core GitHub Packages
 
-Dependencias (GitHub Packages):
+**Registry canónico:** https://github.com/vientonorte?tab=packages  
+**Monorepo (publica):** https://github.com/vientonorte/vientonorte-core  
+**Doc org:** https://github.com/vientonorte/vientonorte-core/blob/main/docs/PACKAGES-CORE.md  
+**DS visual:** https://dot-wool-76997229.figma.site  
+
+Este portafolio **consume** el design system / core compartido (no duplica tokens UI).
+
+## Dependencias (pinned)
 
 ```json
 "@vientonorte/a11y": "0.1.1",
+"@vientonorte/cli": "0.1.1",
 "@vientonorte/security": "0.1.1",
 "@vientonorte/tokens": "0.2.0",
 "@vientonorte/ui": "0.3.2"
 ```
 
+```bash
+npx vientonorte --help
+# vientonorte init <nombre> --template=react-ts [--with-auth] [--with-analytics]
+```
+
 ## Local
 
 ```bash
-export NODE_AUTH_TOKEN=ghp_xxx   # PAT con read:packages
-# o token en ~/.npmrc
-npm install
+export NODE_AUTH_TOKEN=ghp_xxx   # PAT read:packages
+# o token en ~/.npmrc para //npm.pkg.github.com/
+npm ci
 ```
 
-`.npmrc` del repo (gitignored) usa `${NODE_AUTH_TOKEN}`. Ver `.npmrc.example`.
+Ver `.npmrc.example`. El `.npmrc` local (gitignored) usa `${NODE_AUTH_TOKEN}`.
 
 ## CI
 
-- Secret `VN_PACKAGES_TOKEN` en el repo
+- Secret `VN_PACKAGES_TOKEN`
 - `permissions.packages: read`
-- `setup-node` con `registry-url` + `scope: @vientonorte`
+- `setup-node` → `registry-url` + `scope: @vientonorte`
 - `npm ci` con `NODE_AUTH_TOKEN`
 
-## DS visual
+## Bump de core
 
-https://dot-wool-76997229.figma.site
+1. Cambiar / versionar en `vientonorte-core`
+2. Actions → **Publish (GitHub Packages)**
+3. PR aquí con pins nuevos
+4. CI verde → merge → Pages deploy
 
-## Publish monorepo
+## Política multi-repo
 
-https://github.com/vientonorte/vientonorte-core/blob/main/docs/publish-packages.md
+Misma regla en table-ro, uxtools, aruma, dashfin: secret + `.npmrc` apuntando a Packages.  
+No usar `file:../vientonorte-core` en prod ni `*` en versiones.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-tooltip": "^1.2.11",
         "@tailwindcss/vite": "*",
         "@vientonorte/a11y": "0.1.1",
+        "@vientonorte/cli": "0.1.1",
         "@vientonorte/security": "0.1.1",
         "@vientonorte/tokens": "0.2.0",
         "@vientonorte/ui": "0.3.2",
@@ -4019,6 +4020,15 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/@vientonorte/cli": {
+      "version": "0.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@vientonorte/cli/0.1.1/2412c32670b6b61ebd14a0f9ade7b8d60dd0a7de",
+      "integrity": "sha512-Np4MVmdM6tk0NMOWAlzuUAdLPXCdL6OOdCo+RFRt8PDrf+wudQ+F65KuvwMeaHxGoXAfmUZ9zeRWPoIfCpfn4Q==",
+      "license": "MIT",
+      "bin": {
+        "vientonorte": "dist/index.js"
       }
     },
     "node_modules/@vientonorte/security": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-tooltip": "^1.2.11",
     "@tailwindcss/vite": "*",
     "@vientonorte/a11y": "0.1.1",
+    "@vientonorte/cli": "0.1.1",
     "@vientonorte/security": "0.1.1",
     "@vientonorte/tokens": "0.2.0",
     "@vientonorte/ui": "0.3.2",


### PR DESCRIPTION
## Summary
- Pins exactos del **core Packages** (https://github.com/vientonorte?tab=packages):
  - `@vientonorte/a11y@0.1.1`
  - `@vientonorte/cli@0.1.1`
  - `@vientonorte/security@0.1.1`
  - `@vientonorte/tokens@0.2.0`
  - `@vientonorte/ui@0.3.2`
- Docs `docs/VN-PACKAGES.md` + `.npmrc.example` (política multi-repo)

## Test plan
- [ ] CI npm ci + Build/TS/a11y
- [ ] `npx vientonorte --help` en checkout con NODE_AUTH_TOKEN