### PR TITLE
fix(ci): Tests + qa-routes al embudo consultoria actual

### DIFF
--- a/scripts/qa-routes.mjs
+++ b/scripts/qa-routes.mjs
@@ -44,17 +44,17 @@ const PROJECT_IDS = [
   'framework',
 ];
 
+// Anclas que existen en el embudo actual (ConsultoriaVientoNorte).
+// Secciones legacy (offline-private, practicas, cotizador, arbol, #valor en consultoría)
+// ya no se montan en la página — no deben fallar CI.
 const SECTION_CHECKS = [
   { path: '/', sectionId: 'valor', label: 'Home #valor', lazy: true },
-  { path: '/consultoria', sectionId: 'metodo-n2n', label: 'Consultoría #metodo-n2n' },
-  { path: '/consultoria', sectionId: 'offline-private', label: 'Consultoría #offline-private' },
-  { path: '/consultoria', sectionId: 'practicas', label: 'Consultoría #practicas' },
-  { path: '/consultoria', sectionId: 'partner-educacion', label: 'Consultoría #partner-educacion' },
-  { path: '/consultoria', sectionId: 'valor', label: 'Consultoría #valor' },
-  { path: '/consultoria', sectionId: 'consultoria-demo', label: 'Consultoría #consultoria-demo' },
-  { path: '/consultoria', sectionId: 'cotizador', label: 'Consultoría #cotizador' },
-  { path: '/consultoria', sectionId: 'arbol', label: 'Consultoría #arbol' },
+  { path: '/consultoria', sectionId: 'modalidades', label: 'Consultoría #modalidades' },
   { path: '/consultoria', sectionId: 'consultoria-onboarding', label: 'Consultoría #onboarding' },
+  { path: '/consultoria', sectionId: 'metodo-n2n', label: 'Consultoría #metodo-n2n' },
+  { path: '/consultoria', sectionId: 'partner-educacion', label: 'Consultoría #partner-educacion' },
+  { path: '/consultoria', sectionId: 'consultoria-demo', label: 'Consultoría #consultoria-demo' },
+  { path: '/consultoria', sectionId: 'contacto', label: 'Consultoría #contacto' },
   { path: '/design-system', sectionId: 'figma-export', label: 'Design System #figma-export' },
 ];
 

--- a/src/__tests__/components/HeroIntelligentSearch.a11y.test.tsx
+++ b/src/__tests__/components/HeroIntelligentSearch.a11y.test.tsx
@@ -7,6 +7,7 @@ import {
   heroSuggestionOptionId,
 } from "@/components/molecules/HeroIntelligentSearch";
 import type { HeroSearchSuggestion } from "@/lib/hero-search";
+import { LanguageProvider } from "@/lib/LanguageContext";
 
 const suggestions: HeroSearchSuggestion[] = [
   {
@@ -71,24 +72,26 @@ const panels = {
 function renderSearch() {
   return render(
     <MemoryRouter>
-      <HeroIntelligentSearch
-        groupLabel="¿Qué buscas?"
-        searchPlaceholder="Buscar"
-        searchAriaLabel="Buscador inteligente del portafolio"
-        suggestionsLabel="Sugerencias"
-        noResults="Sin coincidencias"
-        liveSuggestionsCount="{{count}} sugerencias disponibles"
-        liveSuggestionsActive="{{count}} sugerencias. {{title}}, {{hint}}"
-        tabs={{
-          negocios: "Empresas",
-          contacto: "Reclutadores",
-          auditorias: "Auditoría",
-        }}
-        panels={panels}
-        suggestions={suggestions}
-        onPrimaryAction={() => undefined}
-        onSecondaryAction={() => undefined}
-      />
+      <LanguageProvider>
+        <HeroIntelligentSearch
+          groupLabel="¿Qué buscas?"
+          searchPlaceholder="Buscar"
+          searchAriaLabel="Buscador inteligente del portafolio"
+          suggestionsLabel="Sugerencias"
+          noResults="Sin coincidencias"
+          liveSuggestionsCount="{{count}} sugerencias disponibles"
+          liveSuggestionsActive="{{count}} sugerencias. {{title}}, {{hint}}"
+          tabs={{
+            negocios: "Empresas",
+            contacto: "Reclutadores",
+            auditorias: "Auditoría",
+          }}
+          panels={panels}
+          suggestions={suggestions}
+          onPrimaryAction={() => undefined}
+          onSecondaryAction={() => undefined}
+        />
+      </LanguageProvider>
     </MemoryRouter>
   );
 }

--- a/src/__tests__/data/n2n-method.test.ts
+++ b/src/__tests__/data/n2n-method.test.ts
@@ -18,11 +18,10 @@ describe("n2n-method", () => {
     }
   });
 
-  it("C1 goal template mentions offline, GitHub, WCAG and 21.719", () => {
-    expect(C1_ONBOARDING_GOAL.es).toMatch(/offline/i);
-    expect(C1_ONBOARDING_GOAL.es).toMatch(/GitHub/i);
-    expect(C1_ONBOARDING_GOAL.es).toMatch(/21\.719|WCAG/i);
-    expect(C1_ONBOARDING_GOAL.en).toMatch(/offline/i);
+  it("C1 goal template covers private data / no public tools", () => {
+    expect(C1_ONBOARDING_GOAL.es).toMatch(/privado|datos sensibles|herramientas públicas/i);
+    expect(C1_ONBOARDING_GOAL.es).toMatch(/Radar|Marco|diagnóstico|prototipo/i);
+    expect(C1_ONBOARDING_GOAL.en).toMatch(/private|sensitive|public tools/i);
     expect(C1_ONBOARDING_GOAL.en.length).toBeGreaterThan(40);
   });
 });

--- a/src/__tests__/lib/session-qa-landing.test.ts
+++ b/src/__tests__/lib/session-qa-landing.test.ts
@@ -140,18 +140,19 @@ describe("session QA · consultoria landing content", () => {
     }
   });
 
-  it("SEO mentions Figma tokens and playbook", () => {
+  it("SEO mentions Figma tokens and free a11y diagnóstico", () => {
     expect(es.seo.pages.designSystem.description.toLowerCase()).toMatch(
       /figma|tokens/
     );
     expect(en.seo.pages.designSystem.description.toLowerCase()).toMatch(
       /figma|tokens/
     );
+    // Copy comercial actual (free a11y / diagnóstico / pymes) — no playbook legacy
     expect(es.seo.pages.consultoria.description.toLowerCase()).toMatch(
-      /prácticas|playbook|modalidades/
+      /accesibilidad|wcag|diagnóstico|gratis|pyme/
     );
     expect(en.seo.pages.consultoria.description.toLowerCase()).toMatch(
-      /practice|playbook|format/
+      /accessib|wcag|diagnos|free|sme|pyme/
     );
   });
 });


### PR DESCRIPTION
## B — Tests / Playwright
- **197/197** vitest PASS local
- `qa-routes`: anclas del embudo real (`modalidades`, onboarding, metodo, partner, demo, contacto) — quita legacy offline/practicas/cotizador/arbol/#valor en consultoría
- Hero search a11y: `LanguageProvider`
- SEO + C1 goal: copy comercial actual

## C — Dependabot #122 / #123
- Fallaban con `403 read_package` en CI (Dependabot **no** ve Actions secrets)
- Set `VN_PACKAGES_TOKEN` como **Dependabot secret**
- Re-run CI en #122/#123 tras merge de este fix

## Test plan
- [ ] CI Tests green
- [ ] CI QA rutas green (or near)
- [ ] Build/TS/a11y still green