### PR TITLE
feat(consultoria): agendar a11y gratis con Google Calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,11 @@ VITE_GTM_ID=
 
 # Relay backup Cloudflare Worker (opcional)
 # VITE_CONTACT_API_URL=https://mi-portafolio-contact.vientonorte.workers.dev/api/contact
+
+# Agenda Google Calendar (Appointment Schedule)
+# Crear: https://calendar.google.com/calendar/u/0/r/appointment
+# Título sugerido: «VN · revisión a11y gratis (30 min)» · timezone America/Santiago
+# Pegar el link público (calendar.app.google/… o appointments/schedules/…)
+# VITE_A11Y_FREE_SCHEDULE_URL=https://calendar.app.google/XXXXXXXX
+# Opcional: misma u otra agenda para partner educación
+# VITE_VIDEO_CALL_URL=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,8 @@ jobs:
           VITE_GOOGLE_FORM_ENTRY_INTENT: ${{ secrets.VITE_GOOGLE_FORM_ENTRY_INTENT }}
           VITE_GOOGLE_FORM_ENTRY_SOURCE: ${{ secrets.VITE_GOOGLE_FORM_ENTRY_SOURCE }}
           VITE_GOOGLE_FORM_ENTRY_LANGUAGE: ${{ secrets.VITE_GOOGLE_FORM_ENTRY_LANGUAGE }}
+          VITE_A11Y_FREE_SCHEDULE_URL: ${{ secrets.VITE_A11Y_FREE_SCHEDULE_URL }}
+          VITE_VIDEO_CALL_URL: ${{ secrets.VITE_VIDEO_CALL_URL }}
 
       - name: SPA fallback for GitHub Pages
         run: cp dist/index.html dist/404.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-07-27] — Agendar a11y gratis con Google Calendar
+
+- **Free Radar / a11y:** CTAs abren Google Calendar Appointment Schedule si hay `VITE_A11Y_FREE_SCHEDULE_URL` (fallback: form prearmado).
+- Evento analytics **`generate_lead`** (`lead_type=free_a11y`, channel calendar|form).
+- Strip modalidades: dual CTA «Agendar en Google Calendar» + «Escribir sin agenda».
+- Banner `/auditoria` freemium → free radar (no mentoría).
+- Deploy Pages bakea secrets `VITE_A11Y_FREE_SCHEDULE_URL` y `VITE_VIDEO_CALL_URL`.
+- Docs: `docs/CONTACT_AND_PRIVACY.md` (crear appointment schedule + `gh secret set`).
+
 ## [2026-07-26] — Consultoría embudo, free a11y, DS, hygiene
 
 ### Added

--- a/docs/CONTACT_AND_PRIVACY.md
+++ b/docs/CONTACT_AND_PRIVACY.md
@@ -13,8 +13,27 @@ Runbook operativo del formulario de contacto, asistente guiado y cumplimiento Le
 |---------------------|-------------------|
 | `contacto@vientonorte.cl` (mailto, footer, contacto) | Alias de marca; no expone Gmail |
 | Formulario o asistente con checkbox de consentimiento | POST HTTPS → Google Forms → copia al remitente + notificación al inbox |
+| **Gratis · accesibilidad** (Radar freemium) | Si hay `VITE_A11Y_FREE_SCHEDULE_URL` → Google Calendar Appointment Schedule; si no → form prearmado |
 | Enlace a `/privacy` | Política bilingüe ES/EN |
 | Si todo falla | Toast con fallback `mailto:` |
+
+### Agenda Google · auditoría a11y gratis
+
+1. En [Google Calendar](https://calendar.google.com/calendar/u/0/r/appointment) → **Create** → **Appointment schedule**.
+2. Título: `VN · revisión a11y gratis (30 min)` · timezone `America/Santiago` · duración 30 min.
+3. Descripción: «Revisión WCAG 2.2 AA de un flujo. Trae URL o captura del flujo.»
+4. Copia el **link de reserva** (`calendar.app.google/…`).
+5. Secrets de deploy (GitHub → mi-portafolio → Settings → Secrets):
+
+```bash
+gh secret set VITE_A11Y_FREE_SCHEDULE_URL -R vientonorte/mi-portafolio -b 'https://calendar.app.google/XXXX'
+# opcional partner edu:
+# gh secret set VITE_VIDEO_CALL_URL -R vientonorte/mi-portafolio -b 'https://calendar.app.google/YYYY'
+```
+
+6. Push a `main` o `workflow_dispatch` del Deploy Pages para bakear la URL en el build.
+
+CTAs cableados: hero consultoría, strip modalidades, path `route/radar-gratis`, banner free en home/auditoría, analytics `generate_lead` + `free_radar_entry_open`.
 
 ---
 

--- a/src/__tests__/lib/free-radar-entry.test.ts
+++ b/src/__tests__/lib/free-radar-entry.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NavigateFunction } from "react-router-dom";
+
+const openSpy = vi.fn();
+const navigateSpy = vi.fn();
+
+vi.mock("../../lib/analytics", () => ({
+  trackEvent: vi.fn(),
+  analytics: { clickHeroFreeAudit: vi.fn() },
+}));
+
+vi.mock("../../lib/navigate-to-contact", () => ({
+  navigateToContactAssistant: (...args: unknown[]) => navigateSpy(...args),
+}));
+
+describe("openFreeRadarEntry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    openSpy.mockReset();
+    navigateSpy.mockReset();
+    vi.stubGlobal("open", openSpy);
+  });
+
+  it("opens Google Calendar when schedule URL is configured (mode schedule)", async () => {
+    vi.doMock("../../lib/site-contact", () => ({
+      A11Y_FREE_SCHEDULE_URL: "https://calendar.app.google/vn-a11y-test",
+      openA11yFreeScheduleOrFallback: (fallback: () => void) => {
+        window.open("https://calendar.app.google/vn-a11y-test", "_blank", "noopener,noreferrer");
+        return true;
+      },
+    }));
+
+    const { openFreeRadarEntry } = await import("../../lib/free-radar-entry");
+    const channel = openFreeRadarEntry(
+      navigateSpy as unknown as NavigateFunction,
+      "es",
+      "consultoria-hero",
+      { mode: "schedule" }
+    );
+
+    expect(channel).toBe("google_calendar");
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://calendar.app.google/vn-a11y-test",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to contact form when no schedule URL", async () => {
+    vi.doMock("../../lib/site-contact", () => ({
+      A11Y_FREE_SCHEDULE_URL: null,
+      openA11yFreeScheduleOrFallback: (fallback: () => void) => {
+        fallback();
+        return false;
+      },
+    }));
+
+    const { openFreeRadarEntry } = await import("../../lib/free-radar-entry");
+    const channel = openFreeRadarEntry(
+      navigateSpy as unknown as NavigateFunction,
+      "es",
+      "free-radar",
+      { mode: "auto" }
+    );
+
+    expect(channel).toBe("contact_form");
+    expect(navigateSpy).toHaveBeenCalled();
+    const opts = navigateSpy.mock.calls[0][1];
+    expect(opts.packageId).toBe("radar");
+    expect(opts.consultingQ1).toBe("radar-free");
+    expect(opts.intent).toBe("consulting");
+    expect(String(opts.message)).toMatch(/revisión gratis de accesibilidad/i);
+  });
+
+  it("mode message always opens contact form even if schedule exists", async () => {
+    vi.doMock("../../lib/site-contact", () => ({
+      A11Y_FREE_SCHEDULE_URL: "https://calendar.app.google/vn-a11y-test",
+      openA11yFreeScheduleOrFallback: vi.fn(),
+    }));
+
+    const { openFreeRadarEntry } = await import("../../lib/free-radar-entry");
+    const channel = openFreeRadarEntry(
+      navigateSpy as unknown as NavigateFunction,
+      "en",
+      "consultoria-packages",
+      { mode: "message" }
+    );
+
+    expect(channel).toBe("contact_form");
+    expect(navigateSpy).toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -13,7 +13,10 @@ import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { useNavigate } from "react-router-dom";
 import { trackEvent } from "../../lib/analytics";
-import { openFreeRadarEntry } from "../../lib/free-radar-entry";
+import {
+  freeRadarHasSchedule,
+  openFreeRadarEntry,
+} from "../../lib/free-radar-entry";
 import { cn } from "../../lib/utils";
 import type { ConsultingPackageId } from "../../data/vientonorte-consulting";
 import {
@@ -66,10 +69,15 @@ export function ConsultoriaLandingHero({
     scrollToSection("modalidades");
   };
 
-  /** SEM lead magnet: free Radar a11y entry → contacto (NO /auditoria mentoría) */
+  /** SEM lead magnet: free Radar a11y → Google Calendar o contacto (NO /auditoria mentoría) */
   const freeRadar = () => {
-    trackEvent("consultoria_hero_cta", { action: "free_radar_entry" });
-    openFreeRadarEntry(navigate, language, "consultoria-hero");
+    trackEvent("consultoria_hero_cta", {
+      action: "free_radar_entry",
+      has_schedule: freeRadarHasSchedule(),
+    });
+    openFreeRadarEntry(navigate, language, "consultoria-hero", {
+      mode: freeRadarHasSchedule() ? "schedule" : "auto",
+    });
   };
 
   const selectOffer = (roleId: HeroRoleId) => {

--- a/src/components/organisms/ConsultoriaPackages.tsx
+++ b/src/components/organisms/ConsultoriaPackages.tsx
@@ -12,7 +12,10 @@ import {
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { trackEvent } from "../../lib/analytics";
-import { openFreeRadarEntry } from "../../lib/free-radar-entry";
+import {
+  freeRadarHasSchedule,
+  openFreeRadarEntry,
+} from "../../lib/free-radar-entry";
 import { cn } from "../../lib/utils";
 
 export type PackageSelectOptions = { appGoal?: boolean };
@@ -38,10 +41,16 @@ export function ConsultoriaPackages({ onSelectPackage }: ConsultoriaPackagesProp
     onSelectPackage?.(id, options);
   };
 
-  const freeRadar = () => {
-    trackEvent("consultoria_free_radar", { source: "packages_strip" });
-    openFreeRadarEntry(navigate, language, "consultoria-packages");
+  const freeRadar = (mode: "auto" | "schedule" | "message" = "auto") => {
+    trackEvent("consultoria_free_radar", {
+      source: "packages_strip",
+      mode,
+      has_schedule: freeRadarHasSchedule(),
+    });
+    openFreeRadarEntry(navigate, language, "consultoria-packages", { mode });
   };
+
+  const scheduleReady = freeRadarHasSchedule();
 
   return (
     <PageSection
@@ -160,11 +169,20 @@ export function ConsultoriaPackages({ onSelectPackage }: ConsultoriaPackagesProp
           <div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto">
             <Button
               className="w-full min-h-[44px] bg-brand-gradient font-semibold hover:opacity-90"
-              onClick={freeRadar}
+              onClick={() => freeRadar(scheduleReady ? "schedule" : "auto")}
             >
-              {t.freeStripCta}
+              {scheduleReady ? t.freeStripCtaSchedule : t.freeStripCta}
               <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
             </Button>
+            {scheduleReady ? (
+              <Button
+                variant="outline"
+                className="w-full min-h-[40px]"
+                onClick={() => freeRadar("message")}
+              >
+                {t.freeStripCtaMessage}
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               className="w-full min-h-[40px] text-muted-foreground"

--- a/src/components/organisms/ContactAssistant.tsx
+++ b/src/components/organisms/ContactAssistant.tsx
@@ -25,7 +25,10 @@ import {
 } from "../../lib/contact-draft";
 import { submitContactMessage } from "../../lib/submit-contact";
 import { analytics } from "../../lib/analytics";
-import { SITE_CONTACT } from "../../lib/site-contact";
+import {
+  A11Y_FREE_SCHEDULE_URL,
+  SITE_CONTACT,
+} from "../../lib/site-contact";
 import type { ConsultingPackageId } from "../../data/vientonorte-consulting";
 import { cn } from "../ui/utils";
 
@@ -304,7 +307,40 @@ export function ContactAssistant({
 
       if (result.ok) {
         analytics.submitContactForm(true, result.channel);
-        toast.success(a.success);
+        const isFreeA11y =
+          packageId === "radar" ||
+          consultingQ1 === "radar-free" ||
+          /accesibilidad|accessibility|radar-free|revisión gratis|free accessibility/i.test(
+            sharedMessage
+          );
+        if (isFreeA11y) {
+          analytics.generateLead({
+            lead_type: "free_a11y",
+            channel: result.channel ?? "contact_form",
+            origin: "contact_assistant",
+            package_id: "radar",
+          });
+        }
+        if (isFreeA11y && A11Y_FREE_SCHEDULE_URL) {
+          toast.success(a.success, {
+            description:
+              language === "es"
+                ? "¿Prefieres un slot ahora? Agenda 30 min en Google Calendar."
+                : "Prefer a slot now? Book 30 min on Google Calendar.",
+            action: {
+              label: language === "es" ? "Agendar" : "Book",
+              onClick: () => {
+                window.open(
+                  A11Y_FREE_SCHEDULE_URL,
+                  "_blank",
+                  "noopener,noreferrer"
+                );
+              },
+            },
+          });
+        } else {
+          toast.success(a.success);
+        }
         onSuccess?.();
         return;
       }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -58,6 +58,20 @@ export const analytics = {
     category: "conversion",
     label: "Hero CTA — Free B2B audit",
   }),
+
+  /** Lead freemium a11y (Calendar booking o form prearmado). */
+  generateLead: (params: {
+    lead_type?: string;
+    channel?: string;
+    origin?: string;
+    package_id?: string;
+  }) =>
+    trackEvent("generate_lead", {
+      category: "conversion",
+      lead_type: params.lead_type ?? "free_a11y",
+      freemium: true,
+      ...params,
+    }),
   
   clickDesignSystem: () => trackEvent("click_design_system", {
     category: "engagement",

--- a/src/lib/free-radar-entry.ts
+++ b/src/lib/free-radar-entry.ts
@@ -1,7 +1,11 @@
 /**
- * Lead magnet · Probar gratis (Diagnóstico de un flujo).
+ * Lead magnet · Probar gratis (Diagnóstico de un flujo / a11y WCAG 2.2 AA).
  * 1 flujo accesible → conversación por Diagnóstico completo 5–7 días.
  * NO redirige a /auditoria (mentoría portfolio).
+ *
+ * Prioridad de canal:
+ * 1. Google Calendar Appointment Schedule (agendar online)
+ * 2. Formulario de contacto con mensaje prearmado (fallback)
  */
 
 import type { NavigateFunction } from "react-router-dom";
@@ -11,12 +15,17 @@ import {
   navigateToContactAssistant,
   type ContactCtaOrigin,
 } from "./navigate-to-contact";
+import {
+  A11Y_FREE_SCHEDULE_URL,
+  openA11yFreeScheduleOrFallback,
+} from "./site-contact";
 
 export const FREE_RADAR_ENTRY_MESSAGE: Record<Language, string> = {
   es: `Hola Viento Norte — quiero la revisión gratis de accesibilidad de un flujo.
 
 Qué revisar: [link o describe el flujo]
 Empresa o producto: [breve]
+Horario preferido (si no agendaste en Calendar): [día / franja CLT]
 
 Si sirve, hablamos del Diagnóstico completo (5–7 días).
 
@@ -25,30 +34,88 @@ Gracias.`,
 
 What to review: [link or describe the flow]
 Company or product: [brief]
+Preferred time (if you did not book on Calendar): [day / slot, America/Santiago]
 
 If it helps, we can talk about the full Diagnostic (5–7 days).
 
 Thanks.`,
 };
 
-export function openFreeRadarEntry(
-  navigate: NavigateFunction,
-  language: Language,
-  origin: ContactCtaOrigin = "free-radar"
+export type FreeRadarEntryMode = "auto" | "schedule" | "message";
+
+export interface OpenFreeRadarEntryOptions {
+  /** auto = Calendar si hay URL, si no formulario. schedule = fuerza Calendar o form. message = solo form. */
+  mode?: FreeRadarEntryMode;
+}
+
+function trackGenerateLead(
+  origin: ContactCtaOrigin,
+  channel: "google_calendar" | "contact_form"
 ): void {
+  trackEvent("generate_lead", {
+    category: "conversion",
+    lead_type: "free_a11y",
+    package_id: "radar",
+    freemium: true,
+    channel,
+    origin,
+  });
   trackEvent("free_radar_entry_open", {
     origin,
     package_id: "radar",
     freemium: true,
+    channel,
   });
   analytics.clickHeroFreeAudit();
+}
 
-  navigateToContactAssistant(navigate, {
-    origin,
-    source: "cta",
-    intent: "consulting",
-    packageId: "radar",
-    message: FREE_RADAR_ENTRY_MESSAGE[language],
-    consultingQ1: "radar-free",
-  });
+/**
+ * Entrada freemium a11y.
+ * @returns canal usado
+ */
+export function openFreeRadarEntry(
+  navigate: NavigateFunction,
+  language: Language,
+  origin: ContactCtaOrigin = "free-radar",
+  options: OpenFreeRadarEntryOptions = {}
+): "google_calendar" | "contact_form" {
+  const mode = options.mode ?? "auto";
+
+  const openMessage = () => {
+    trackGenerateLead(origin, "contact_form");
+    navigateToContactAssistant(navigate, {
+      origin,
+      source: "cta",
+      intent: "consulting",
+      packageId: "radar",
+      message: FREE_RADAR_ENTRY_MESSAGE[language],
+      consultingQ1: "radar-free",
+    });
+  };
+
+  if (mode === "message") {
+    openMessage();
+    return "contact_form";
+  }
+
+  if (mode === "schedule" || mode === "auto") {
+    if (A11Y_FREE_SCHEDULE_URL) {
+      trackGenerateLead(origin, "google_calendar");
+      openA11yFreeScheduleOrFallback(openMessage);
+      return "google_calendar";
+    }
+    if (mode === "schedule") {
+      // Sin URL de agenda: degradar a formulario (mismo mensaje freemium)
+      openMessage();
+      return "contact_form";
+    }
+  }
+
+  openMessage();
+  return "contact_form";
+}
+
+/** True si el build tiene agenda Google de a11y gratis (para CTAs duales). */
+export function freeRadarHasSchedule(): boolean {
+  return Boolean(A11Y_FREE_SCHEDULE_URL);
 }

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -412,8 +412,10 @@ export default {
         freeStripBadge: 'Free · accessibility',
         freeStripTitle: 'Free review of one flow',
         freeStripBody:
-          'We check accessibility on one key flow (WCAG 2.2 AA). If it helps, full Diagnostic is 5–7 days.',
+          'We check accessibility on one key flow (WCAG 2.2 AA). Book online with Google Calendar or write us. If it helps, full Diagnostic is 5–7 days.',
         freeStripCta: 'Request free review',
+        freeStripCtaSchedule: 'Book on Google Calendar',
+        freeStripCtaMessage: 'Write without booking',
         freeStripSecondary: 'Full diagnostic (5–7 days)',
         appStripTitle: 'App end to end',
         appStripBody:

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -412,8 +412,10 @@ export default {
         freeStripBadge: 'Gratis · accesibilidad',
         freeStripTitle: 'Revisión gratis de un flujo',
         freeStripBody:
-          'Miramos la accesibilidad de un flujo clave (WCAG 2.2 AA). Si te sirve, el Diagnóstico completo son 5–7 días.',
+          'Miramos la accesibilidad de un flujo clave (WCAG 2.2 AA). Agenda online con Google Calendar o escribe. Si te sirve, el Diagnóstico completo son 5–7 días.',
         freeStripCta: 'Pedir revisión gratis',
+        freeStripCtaSchedule: 'Agendar en Google Calendar',
+        freeStripCtaMessage: 'Escribir sin agenda',
         freeStripSecondary: 'Diagnóstico completo (5–7 días)',
         appStripTitle: 'App de punta a punta',
         appStripBody:

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -17,12 +17,27 @@ export const SITE_CONTACT = {
 } as const;
 
 /**
- * URL de agenda de videollamada (Calendly, Google Calendar, etc.).
+ * URL de agenda de videollamada (partner edu, etc.).
  * Override: VITE_VIDEO_CALL_URL
  * Si no está definida, el CTA de partner / educación abre contacto con mensaje prearmado.
  */
 export const VIDEO_CALL_URL =
   (import.meta.env.VITE_VIDEO_CALL_URL as string | undefined)?.trim() || null;
+
+/**
+ * Google Calendar Appointment Schedule — auditoría a11y gratis (Radar freemium).
+ * Override: VITE_A11Y_FREE_SCHEDULE_URL
+ * Preferido: booking page de Calendar (calendar.app.google/… o appointments/schedules/…).
+ * Fallback: VITE_VIDEO_CALL_URL si se reutiliza la misma agenda.
+ */
+export const A11Y_FREE_SCHEDULE_URL =
+  (import.meta.env.VITE_A11Y_FREE_SCHEDULE_URL as string | undefined)?.trim() ||
+  VIDEO_CALL_URL ||
+  null;
+
+export function hasA11yFreeSchedule(): boolean {
+  return Boolean(A11Y_FREE_SCHEDULE_URL);
+}
 
 export function openVideoCallOrFallback(fallback: () => void): void {
   if (VIDEO_CALL_URL) {
@@ -30,6 +45,16 @@ export function openVideoCallOrFallback(fallback: () => void): void {
     return;
   }
   fallback();
+}
+
+/** Abre la agenda Google de a11y gratis; si no hay URL, ejecuta fallback (formulario). */
+export function openA11yFreeScheduleOrFallback(fallback: () => void): boolean {
+  if (A11Y_FREE_SCHEDULE_URL) {
+    window.open(A11Y_FREE_SCHEDULE_URL, '_blank', 'noopener,noreferrer');
+    return true;
+  }
+  fallback();
+  return false;
 }
 
 /** Relay Cloudflare Worker — POST formulario de contacto */

--- a/src/pages/AuditoriaPortfolio.tsx
+++ b/src/pages/AuditoriaPortfolio.tsx
@@ -16,6 +16,7 @@ import { Badge } from "../components/ui/badge";
 import { getConsultingPackage } from "../data/vientonorte-consulting";
 import { scrollToSection } from "../lib/scroll-to-section";
 import { navigateToContactAssistant } from "../lib/navigate-to-contact";
+import { openFreeRadarEntry } from "../lib/free-radar-entry";
 
 type ChecklistStatus = "pending" | "in_progress" | "completed";
 
@@ -135,7 +136,13 @@ export default function AuditoriaPortfolio() {
 
   const recommendedPackage = getConsultingPackage("marco");
 
+  /** Banner freemium: agendar a11y gratis (Calendar) o form — no mentoría. */
   const handleStartConsulting = () => {
+    openFreeRadarEntry(navigate, language, "audit-page", { mode: "auto" });
+  };
+
+  /** CTA de muestra de auditoría (diagnóstico con evidencia). */
+  const handlePaidDiagnostic = () => {
     const message =
       language === "es"
         ? "Solicito una auditoría / diagnóstico UX con evidencia (WCAG, heurísticas y plan P0–P2). Vi la muestra en /auditoria."
@@ -470,7 +477,7 @@ export default function AuditoriaPortfolio() {
                 <Button
                   size="lg"
                   className="mt-8 w-full bg-brand-gradient font-semibold hover:opacity-90 sm:w-auto"
-                  onClick={handleStartConsulting}
+                  onClick={handlePaidDiagnostic}
                 >
                   {copy.sections.consultingCtaPrimary}
                   <ArrowRight className="ml-2 h-4 w-4" aria-hidden />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,6 +12,10 @@ interface ImportMetaEnv {
   readonly VITE_GOOGLE_FORM_ENTRY_INTENT?: string;
   readonly VITE_GOOGLE_FORM_ENTRY_SOURCE?: string;
   readonly VITE_GOOGLE_FORM_ENTRY_LANGUAGE?: string;
+  /** Google Calendar Appointment Schedule — a11y gratis / Radar freemium */
+  readonly VITE_A11Y_FREE_SCHEDULE_URL?: string;
+  /** Agenda genérica (partner edu); fallback de a11y si no hay schedule dedicado */
+  readonly VITE_VIDEO_CALL_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Free Radar / a11y CTAs open **Google Calendar Appointment Schedule** when `VITE_A11Y_FREE_SCHEDULE_URL` is set; otherwise contact form with prefilled free-a11y message.
- Analytics: **`generate_lead`** (`lead_type=free_a11y`, channel calendar|form).
- Modalidades strip dual CTA: «Agendar en Google Calendar» + «Escribir sin agenda».
- `/auditoria` freemium banner → free radar (not mentoría path).
- Deploy Pages bakes `VITE_A11Y_FREE_SCHEDULE_URL` + `VITE_VIDEO_CALL_URL`.
- Docs in `CONTACT_AND_PRIVACY.md` for creating the appointment schedule.

## After merge
1. Create schedule: https://calendar.google.com/calendar/u/0/r/appointment  
2. `gh secret set VITE_A11Y_FREE_SCHEDULE_URL -R vientonorte/mi-portafolio -b 'https://calendar.app.google/…'`  
3. Redeploy Pages (push or workflow_dispatch) so the URL is in the build.

## Test plan
- [x] `vitest` free-radar-entry (3 tests)
- [x] `tsc --noEmit`
- [ ] With secret set: CTA «Gratis · accesibilidad» opens Calendar booking
- [ ] Without secret: CTA opens contact compose with free a11y draft
- [ ] Form submit free a11y → toast + optional Agendar if URL present