### PR TITLE
fix: visible Google Calendar free a11y in contact + funnel

### DIFF
--- a/src/components/molecules/FreeA11yScheduleCta.tsx
+++ b/src/components/molecules/FreeA11yScheduleCta.tsx
@@ -1,0 +1,147 @@
+/**
+ * CTA visible de agenda Google (free a11y) — no toast oculto ni link sutil.
+ * Solo renderiza si existe VITE_A11Y_FREE_SCHEDULE_URL en build.
+ */
+import { Calendar, ExternalLink } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { useLanguage } from "../../lib/LanguageContext";
+import {
+  freeRadarHasSchedule,
+  openFreeRadarEntry,
+} from "../../lib/free-radar-entry";
+import { A11Y_FREE_SCHEDULE_URL } from "../../lib/site-contact";
+import type { ContactCtaOrigin } from "../../lib/navigate-to-contact";
+import { cn } from "../../lib/utils";
+
+export interface FreeA11yScheduleCtaProps {
+  origin?: ContactCtaOrigin;
+  className?: string;
+  /** compact = barra en assistant; card = bloque en Contact */
+  layout?: "card" | "compact" | "inline";
+}
+
+export function FreeA11yScheduleCta({
+  origin = "contact",
+  className,
+  layout = "card",
+}: FreeA11yScheduleCtaProps) {
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+  const es = language === "es";
+
+  if (!freeRadarHasSchedule() || !A11Y_FREE_SCHEDULE_URL) {
+    return null;
+  }
+
+  const title =
+    es
+      ? "Agenda Google · 30 min gratis"
+      : "Google Calendar · 30 free minutes";
+  const body =
+    es
+      ? "Revisión de un flujo crítico (accesibilidad). Elige horario en Calendar de Viento Norte — sin formulario previo."
+      : "Review of one critical flow (accessibility). Pick a slot on Viento Norte Calendar — no form first.";
+  const cta = es ? "Abrir agenda online" : "Open online schedule";
+  const badge = es ? "Disponible ahora" : "Available now";
+
+  const book = () => {
+    openFreeRadarEntry(navigate, language, origin, { mode: "schedule" });
+  };
+
+  if (layout === "inline") {
+    return (
+      <Button
+        type="button"
+        variant="default"
+        className={cn(
+          "min-h-[44px] w-full bg-brand-gradient font-semibold hover:opacity-90 sm:w-auto",
+          className
+        )}
+        onClick={book}
+      >
+        <Calendar className="mr-2 h-4 w-4" aria-hidden />
+        {cta}
+        <ExternalLink className="ml-2 h-3.5 w-3.5 opacity-80" aria-hidden />
+      </Button>
+    );
+  }
+
+  if (layout === "compact") {
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-3 rounded-xl border-2 border-primary/40 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between",
+          className
+        )}
+        data-testid="free-a11y-schedule-cta"
+      >
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Calendar className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+            <p className="text-sm font-semibold tracking-tight">{title}</p>
+            <Badge
+              variant="outline"
+              className="border-primary/30 font-normal normal-case tracking-normal"
+            >
+              {badge}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">{body}</p>
+        </div>
+        <Button
+          type="button"
+          className="min-h-[44px] w-full shrink-0 bg-brand-gradient font-semibold hover:opacity-90 sm:w-auto"
+          onClick={book}
+        >
+          {cta}
+          <ExternalLink className="ml-2 h-3.5 w-3.5" aria-hidden />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border-2 border-primary/40 bg-primary/5 p-5 shadow-none",
+        className
+      )}
+      data-testid="free-a11y-schedule-cta"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex gap-3 min-w-0">
+          <span
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-brand-gradient text-white"
+            aria-hidden
+          >
+            <Calendar className="h-5 w-5" />
+          </span>
+          <div className="min-w-0 space-y-1.5">
+            <Badge
+              variant="outline"
+              className="border-primary/30 font-normal normal-case tracking-normal"
+            >
+              {badge}
+            </Badge>
+            <p className="text-base font-semibold tracking-tight">{title}</p>
+            <p className="text-sm text-muted-foreground leading-relaxed">{body}</p>
+            <p className="text-[11px] font-mono text-muted-foreground/90 break-all">
+              calendar.app.google
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="lg"
+          className="min-h-[48px] w-full shrink-0 bg-brand-gradient px-6 font-semibold hover:opacity-90 sm:w-auto"
+          onClick={book}
+        >
+          {cta}
+          <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -1,12 +1,4 @@
-import {
-  ArrowRight,
-  ClipboardList,
-  LayoutTemplate,
-  Smartphone,
-  Users,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
+import { ArrowRight } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { useLanguage } from "../../lib/LanguageContext";
@@ -19,10 +11,6 @@ import {
 } from "../../lib/free-radar-entry";
 import { cn } from "../../lib/utils";
 import type { ConsultingPackageId } from "../../data/vientonorte-consulting";
-import {
-  HERO_ROLES,
-  type HeroRoleId,
-} from "../../data/consultoria-hero-roles";
 import { scrollToSection } from "../../lib/scroll-to-section";
 
 interface ConsultoriaLandingHeroProps {
@@ -33,17 +21,10 @@ interface ConsultoriaLandingHeroProps {
   onExploreEvidence?: () => void;
 }
 
-const OFFER_ICONS: Record<HeroRoleId, LucideIcon> = {
-  diagnostic: ClipboardList,
-  prototype: LayoutTemplate,
-  process: Users,
-  app: Smartphone,
-};
-
 /**
- * Hero consultoría — oferta explícita (servicio + qué te llevas):
- * 1 promesa + 4 CTAs de producto/servicio (no “quién eres”)
- * App funcional = diseño VN + build con red (externalizado).
+ * Hero consultoría — mínimo conversion:
+ * Empezar · Ver opciones · link free sutil.
+ * Sin grilla de 4 ofertas (duplicaba #modalidades).
  */
 export function ConsultoriaLandingHero({
   onStartOnboarding,
@@ -53,14 +34,13 @@ export function ConsultoriaLandingHero({
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.landing;
   const es = language === "es";
-  const prefersReducedMotion = useReducedMotion();
 
   const startPrimary = () => {
     trackEvent("consultoria_hero_cta", { action: "primary_onboarding" });
     onStartOnboarding?.();
   };
 
-  const secondary = () => {
+  const seeOptions = () => {
     trackEvent("consultoria_hero_cta", { action: "secondary_modalidades" });
     if (onExploreEvidence) {
       onExploreEvidence();
@@ -69,7 +49,6 @@ export function ConsultoriaLandingHero({
     scrollToSection("modalidades");
   };
 
-  /** SEM lead magnet: free Radar a11y → Google Calendar o contacto (NO /auditoria mentoría) */
   const freeRadar = () => {
     trackEvent("consultoria_hero_cta", {
       action: "free_radar_entry",
@@ -80,27 +59,12 @@ export function ConsultoriaLandingHero({
     });
   };
 
-  const selectOffer = (roleId: HeroRoleId) => {
-    const role = HERO_ROLES.find((r) => r.id === roleId);
-    if (!role) return;
-    trackEvent("consultoria_hero_offer", {
-      offer: role.id,
-      package_id: role.packageId,
-      app: Boolean(role.appGoal),
-    });
-    onStartOnboarding?.(role.packageId, {
-      c1Goal: role.c1Goal,
-      appGoal: role.appGoal,
-    });
-  };
-
   return (
     <section
       className="section-pad-default section-atmosphere section-atmosphere-matte relative overflow-hidden border-b border-border/40"
       aria-labelledby="consultoria-hero-heading"
     >
-
-      <div className="container relative mx-auto max-w-3xl">
+      <div className="container relative mx-auto max-w-2xl">
         <div className="mx-auto space-y-6 text-center">
           <Badge
             variant="outline"
@@ -111,17 +75,17 @@ export function ConsultoriaLandingHero({
 
           <h1
             id="consultoria-hero-heading"
-            className="text-3xl font-bold tracking-tight sm:text-4xl md:text-[2.75rem] md:leading-[1.1]"
+            className="text-3xl font-bold tracking-tight sm:text-4xl md:text-[2.5rem] md:leading-[1.12]"
           >
             {t.title}{" "}
             <span className="text-brand-gradient">{t.titleAccent}</span>
           </h1>
 
-          <p className="mx-auto max-w-lg text-base leading-relaxed text-muted-foreground md:text-lg">
+          <p className="mx-auto max-w-md text-base leading-relaxed text-muted-foreground md:text-lg">
             {t.description}
           </p>
 
-          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
             <Button
               size="lg"
               className="min-h-[48px] bg-brand-gradient px-8 font-semibold hover:opacity-90 focus-visible:ring-offset-2"
@@ -134,22 +98,28 @@ export function ConsultoriaLandingHero({
               size="lg"
               variant="outline"
               className="min-h-[48px] border-primary/30 bg-background/80 font-semibold hover:border-primary/50"
-              onClick={freeRadar}
-            >
-              {t.ctaFree}
-            </Button>
-            <button
-              type="button"
-              onClick={secondary}
-              className={cn(
-                "inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-muted-foreground",
-                "underline-offset-4 transition-colors hover:text-foreground hover:underline",
-                "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-              )}
+              onClick={seeOptions}
             >
               {t.ctaSecondary}
-            </button>
+            </Button>
           </div>
+
+          <p className="text-sm text-muted-foreground">
+            <button
+              type="button"
+              onClick={freeRadar}
+              className={cn(
+                "underline-offset-4 transition-colors hover:text-foreground hover:underline",
+                "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                freeRadarHasSchedule() &&
+                  "font-medium text-primary underline decoration-primary/40"
+              )}
+            >
+              {freeRadarHasSchedule()
+                ? t.ctaFreeLinkSchedule ?? t.ctaFreeLink
+                : t.ctaFreeLink}
+            </button>
+          </p>
 
           <ul
             className="flex flex-wrap items-center justify-center gap-2"
@@ -163,80 +133,6 @@ export function ConsultoriaLandingHero({
                 </span>
               </li>
             ))}
-          </ul>
-        </div>
-
-        {/* Oferta: servicio/producto — no roles de persona */}
-        <div
-          className="mt-12 border-t border-border/40 pt-10 md:mt-14 md:pt-12"
-          role="group"
-          aria-labelledby="hero-offers-heading"
-        >
-          <p
-            id="hero-offers-heading"
-            className="mb-2 text-center text-sm font-medium text-foreground"
-          >
-            {t.segmentsLabel}
-          </p>
-          {t.segmentsHint ? (
-            <p className="mb-5 text-center text-xs text-muted-foreground">
-              {t.segmentsHint}
-            </p>
-          ) : null}
-
-          <ul
-            className="m-0 grid list-none grid-cols-1 gap-2 p-0 sm:grid-cols-2"
-            role="list"
-          >
-            {HERO_ROLES.map((role) => {
-              const Icon = OFFER_ICONS[role.id];
-              const copy = t.segments[role.id as keyof typeof t.segments];
-              const title = copy?.title ?? role.title[language];
-              const hint = copy?.hint ?? role.hint[language];
-
-              return (
-                <li key={role.id} className="min-w-0">
-                  <motion.button
-                    type="button"
-                    onClick={() => selectOffer(role.id)}
-                    whileHover={
-                      prefersReducedMotion ? undefined : { y: -1 }
-                    }
-                    whileTap={
-                      prefersReducedMotion ? undefined : { scale: 0.99 }
-                    }
-                    className={cn(
-                      "group flex w-full min-h-[48px] items-center gap-3 rounded-xl border border-[color:var(--logo-surface-border)]",
-                      "bg-surface-matte-elevated px-4 py-3.5 text-left",
-                      /* DS motion: --duration-fast / --ease-out */
-                      "transition-[border-color,background-color,transform] duration-[var(--duration-fast)] ease-[var(--ease-out)] motion-reduce:transition-none",
-                      "hover:border-primary/25 hover:bg-background/40",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                      role.appGoal && "border-primary/20"
-                    )}
-                  >
-                    <span
-                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-logo-surface text-primary group-hover:bg-primary/10"
-                      aria-hidden
-                    >
-                      <Icon className="h-4 w-4" strokeWidth={2} />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block text-sm font-semibold tracking-tight text-foreground">
-                        {title}
-                      </span>
-                      <span className="mt-0.5 block text-xs text-muted-foreground">
-                        {hint}
-                      </span>
-                    </span>
-                    <ArrowRight
-                      className="h-4 w-4 shrink-0 text-muted-foreground transition-[transform,color] duration-[var(--duration-fast)] ease-[var(--ease-out)] motion-reduce:transition-none group-hover:translate-x-0.5 group-hover:text-primary motion-reduce:group-hover:translate-x-0"
-                      aria-hidden
-                    />
-                  </motion.button>
-                </li>
-              );
-            })}
           </ul>
         </div>
       </div>

--- a/src/components/organisms/Contact.tsx
+++ b/src/components/organisms/Contact.tsx
@@ -14,6 +14,7 @@ import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { ContactAssistant } from "./ContactAssistant";
 import { SITE_CONTACT, getContactMailtoUrl } from "../../lib/site-contact";
+import { FreeA11yScheduleCta } from "../molecules/FreeA11yScheduleCta";
 import { submitContactMessage } from "../../lib/submit-contact";
 import { analytics } from "../../lib/analytics";
 import { useLanguage } from "../../lib/LanguageContext";
@@ -137,6 +138,8 @@ export function Contact({
         message: sharedMessage,
         _gotcha: gotcha,
         source: "form",
+        intent: effectiveDraft?.intent,
+        conversationTitle: effectiveDraft?.conversationTitle,
         consent: sharedIdentity.consent,
         language,
       });
@@ -225,6 +228,14 @@ export function Contact({
             <Clock className="mr-2 h-3 w-3" />
             {surfaceCopy?.responseBadge ?? t.responseBadge}
           </Badge>
+        </div>
+
+        {/* Agenda Google free a11y — visible en contacto (no solo toast post-envío) */}
+        <div className="mx-auto mb-8 max-w-3xl">
+          <FreeA11yScheduleCta
+            origin={isConsulting ? "consultoria-contact" : "contact"}
+            layout="card"
+          />
         </div>
 
         <div className="grid lg:grid-cols-3 gap-6 md:gap-8">

--- a/src/components/organisms/ContactAssistant.tsx
+++ b/src/components/organisms/ContactAssistant.tsx
@@ -30,6 +30,7 @@ import {
   SITE_CONTACT,
 } from "../../lib/site-contact";
 import type { ConsultingPackageId } from "../../data/vientonorte-consulting";
+import { FreeA11yScheduleCta } from "../molecules/FreeA11yScheduleCta";
 import { cn } from "../ui/utils";
 
 interface ContactAssistantProps {
@@ -154,6 +155,7 @@ export function ContactAssistant({
   const bannerKey = draftBannerKey(contactDraft);
   /** Intent pre-seleccionado (embudo / CTA): no reabrir reclutador · freelance. */
   const intentLocked = Boolean(contactDraft?.intent) || surface === "consulting";
+  const conversationTitle = contactDraft?.conversationTitle?.trim() || "";
 
   const [step, setStep] = useState<ContactAssistantStep>(() =>
     resolveAssistantInitialStep(contactDraft)
@@ -301,6 +303,7 @@ export function ContactAssistant({
         _gotcha: gotcha,
         source: "assistant",
         intent: intentLabel,
+        conversationTitle: conversationTitle || undefined,
         consent: true,
         language,
       });
@@ -412,6 +415,16 @@ export function ContactAssistant({
         )}
       </div>
 
+      {/* Agenda Google visible en embudo (no solo toast post-submit) */}
+      {A11Y_FREE_SCHEDULE_URL ? (
+        <FreeA11yScheduleCta
+          origin={
+            surface === "consulting" ? "consultoria-contact" : "contact-assistant"
+          }
+          layout="compact"
+        />
+      ) : null}
+
       {!skipWizard && (
         <div
           className="max-h-[240px] space-y-4 overflow-y-auto rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte/50 p-4 sm:max-h-[280px]"
@@ -436,6 +449,30 @@ export function ContactAssistant({
         >
           <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden />
           <p className="text-sm leading-relaxed">{a.draftBanner[bannerKey]}</p>
+        </div>
+      )}
+
+      {(conversationTitle || packageId || contactDraft?.industry) && (
+        <div
+          className="flex flex-wrap items-center gap-2 rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated px-3 py-2.5"
+          role="status"
+          aria-label={conversationTitle || "Selección"}
+        >
+          {conversationTitle ? (
+            <Badge
+              variant="outline"
+              className="font-mono text-[10px] uppercase tracking-wide"
+            >
+              {conversationTitle}
+            </Badge>
+          ) : null}
+          {packageId ? (
+            <span className="text-xs text-muted-foreground">
+              {packageId}
+              {contactDraft?.industry ? ` · ${contactDraft.industry}` : ""}
+              {contactDraft?.timeline ? ` · ${contactDraft.timeline}` : ""}
+            </span>
+          ) : null}
         </div>
       )}
 

--- a/src/lib/contact-draft.ts
+++ b/src/lib/contact-draft.ts
@@ -22,6 +22,11 @@ export interface ContactDraft {
   timeline?: string;
   recruiterMode?: string;
   consultingQ1?: string;
+  /**
+   * Título VN de conversación (desde selecciones onboarding / free a11y).
+   * Ej: «VN · Kickoff · Diagnóstico · Fintech»
+   */
+  conversationTitle?: string;
 }
 
 export interface ContactSharedIdentity {
@@ -74,6 +79,10 @@ export function parseContactDraftFromState(state: unknown): ContactDraft | null 
       timeline: typeof raw.timeline === "string" ? raw.timeline : undefined,
       recruiterMode: typeof raw.recruiterMode === "string" ? raw.recruiterMode : undefined,
       consultingQ1: typeof raw.consultingQ1 === "string" ? raw.consultingQ1 : undefined,
+      conversationTitle:
+        typeof (raw as ContactDraft).conversationTitle === "string"
+          ? (raw as ContactDraft).conversationTitle
+          : undefined,
     };
   }
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -235,7 +235,7 @@ export default {
       recommended: 'Recommended',
       back: 'Back',
       next: 'Continue',
-      stickyCta: 'Book kickoff',
+      stickyCta: 'Start',
       entry: {
         selectedPackage: 'Selected format:',
         changePackage: 'Change',
@@ -249,11 +249,14 @@ export default {
           'Diagnostic, prototype, team process, or working app.',
         transparencyLine:
           'Free Diagnostic entry: WCAG 2.2 AA review of one critical flow. If it fits, let’s talk full Diagnostic (5–7 days).',
-        ctaPrimary: "Let's talk",
+        ctaPrimary: 'Start',
         ctaSecondary: 'See options',
-        ctaFree: 'Free · accessibility',
+        /** Lead magnet — regulated-product job language, not WCAG jargon in the link */
+        ctaFreeLink: 'Free review of one critical flow',
+        ctaFreeLinkSchedule: 'Book 30 free minutes on Google Calendar',
+        ctaFree: 'Request free review',
         trustLine: 'Reply within 24 h',
-        trustChips: ['Free · accessibility', '5–7 days', 'Reply <24 h'],
+        trustChips: ['Reply <24 h', '5–7 days', 'No prices on the site'],
         segmentsLabel: 'What do you need?',
         segmentsHint: 'One tap = service and what you get.',
         segments: {
@@ -409,13 +412,12 @@ export default {
         cta: 'Start',
         ctaForm: 'Write',
         note: 'No prices on the site — closed at kickoff.',
-        freeStripBadge: 'Free · accessibility',
-        freeStripTitle: 'Free review of one flow',
+        freeStripBadge: 'Free · entry to Diagnostic',
+        freeStripTitle: 'Free review of one critical flow',
         freeStripBody:
-          'We check accessibility on one key flow (WCAG 2.2 AA). Book online with Google Calendar or write us. If it helps, full Diagnostic is 5–7 days.',
+          'We look at one high-impact journey (onboarding, pay, auth). If it fits, full Diagnostic is 5–7 days.',
         freeStripCta: 'Request free review',
-        freeStripCtaSchedule: 'Book on Google Calendar',
-        freeStripCtaMessage: 'Write without booking',
+        freeStripCtaSchedule: 'Book 30 free minutes',
         freeStripSecondary: 'Full diagnostic (5–7 days)',
         appStripTitle: 'App end to end',
         appStripBody:
@@ -462,8 +464,8 @@ export default {
         goalHint: 'At least 20 characters.',
       },
       summary: {
-        note: 'On confirm, you go to contact with a ready message.',
-        cta: 'Go to contact',
+        note: 'On confirm, you stay on this page: contact opens with your message and VN title ready.',
+        cta: 'Continue to contact',
       },
       treePreview: {
         badge: 'Quick help',
@@ -1043,10 +1045,17 @@ export default {
       title: 'Get in touch',
       description: 'Available for freelance projects and full-time opportunities. Typical reply: under 24 h.',
       responseBadge: 'Typical reply: under 24 h',
+      /** Free a11y Google schedule — visible block on #contacto */
+      freeSchedule: {
+        badge: 'Available now',
+        title: 'Google Calendar · 30 free minutes',
+        body: 'Review of one critical flow. Pick a slot on Viento Norte Calendar.',
+        cta: 'Open online schedule',
+      },
       /** Funnel surface /consultoria — no recruiter/freelance framing */
       consultingSurface: {
         badge: 'Viento Norte · SMBs',
-        title: 'Book kickoff or write us',
+        title: 'Write and we close scope',
         description:
           'End of the funnel: diagnostic, prototype, process, or app. Reply within 24 business hours.',
         responseBadge: 'Reply <24 business hours',
@@ -1054,7 +1063,7 @@ export default {
         infoDescription: 'UX consulting for SMBs · remote or hybrid',
         assistantTitle: 'Consulting assistant',
         assistantDescription:
-          'You’re already on consulting. Pick the focus and we’ll draft the kickoff message.',
+          'You’re already on consulting. Pick the focus and we’ll draft the message.',
       },
       tabs: {
         assistant: 'Assistant',

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -418,6 +418,7 @@ export default {
           'We look at one high-impact journey (onboarding, pay, auth). If it fits, full Diagnostic is 5–7 days.',
         freeStripCta: 'Request free review',
         freeStripCtaSchedule: 'Book 30 free minutes',
+        freeStripCtaMessage: 'Prefer to write (no calendar)',
         freeStripSecondary: 'Full diagnostic (5–7 days)',
         appStripTitle: 'App end to end',
         appStripBody:

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -235,7 +235,7 @@ export default {
       recommended: 'Recomendada',
       back: 'Atrás',
       next: 'Continuar',
-      stickyCta: 'Agendar kickoff',
+      stickyCta: 'Empezar',
       entry: {
         selectedPackage: 'Modalidad elegida:',
         changePackage: 'Cambiar',
@@ -249,11 +249,14 @@ export default {
           'Diagnóstico, prototipo, proceso de equipo o app funcional.',
         transparencyLine:
           'Entrada gratis a Diagnóstico: revisión WCAG 2.2 AA de un flujo crítico. Si aplica, conversemos el Diagnóstico completo (5–7 días).',
-        ctaPrimary: 'Hablemos',
+        ctaPrimary: 'Empezar',
         ctaSecondary: 'Ver opciones',
-        ctaFree: 'Gratis · accesibilidad',
+        /** Free a11y — con agenda: copy de Calendar; sin agenda: mensaje */
+        ctaFreeLink: 'Revisión gratis de un flujo crítico',
+        ctaFreeLinkSchedule: 'Reservar 30 min gratis en Google Calendar',
+        ctaFree: 'Pedir revisión gratis',
         trustLine: 'Respuesta en menos de 24 h',
-        trustChips: ['Gratis · accesibilidad', '5–7 días', 'Respuesta <24 h'],
+        trustChips: ['Respuesta <24 h', '5–7 días', 'Sin precios en la web'],
         segmentsLabel: '¿Qué necesitas?',
         segmentsHint: 'Un clic = servicio y lo que te llevas.',
         segments: {
@@ -409,13 +412,12 @@ export default {
         cta: 'Empezar',
         ctaForm: 'Escribir',
         note: 'Sin precios en la web: se cierran en el kickoff.',
-        freeStripBadge: 'Gratis · accesibilidad',
-        freeStripTitle: 'Revisión gratis de un flujo',
+        freeStripBadge: 'Gratis · entrada a Diagnóstico',
+        freeStripTitle: 'Revisión gratis de un flujo crítico',
         freeStripBody:
-          'Miramos la accesibilidad de un flujo clave (WCAG 2.2 AA). Agenda online con Google Calendar o escribe. Si te sirve, el Diagnóstico completo son 5–7 días.',
+          'Miramos un flujo de alto impacto (onboarding, pago o acceso). Si aplica, el Diagnóstico completo son 5–7 días.',
         freeStripCta: 'Pedir revisión gratis',
-        freeStripCtaSchedule: 'Agendar en Google Calendar',
-        freeStripCtaMessage: 'Escribir sin agenda',
+        freeStripCtaSchedule: 'Reservar 30 min gratis',
         freeStripSecondary: 'Diagnóstico completo (5–7 días)',
         appStripTitle: 'App de punta a punta',
         appStripBody:
@@ -462,8 +464,8 @@ export default {
         goalHint: 'Al menos 20 caracteres.',
       },
       summary: {
-        note: 'Al confirmar, pasas a contacto con el mensaje listo.',
-        cta: 'Ir a contacto',
+        note: 'Al confirmar, pasas a contacto en esta misma página con el mensaje y el título VN listos.',
+        cta: 'Continuar a contacto',
       },
       treePreview: {
         badge: 'Ayuda rápida',
@@ -1048,10 +1050,17 @@ export default {
       title: 'Conversemos',
       description: 'Disponible para proyectos freelance y oportunidades full-time. Respuesta típica: menos de 24 h.',
       responseBadge: 'Respuesta típica: menos de 24 h',
+      /** Agenda Google free a11y — bloque visible en #contacto */
+      freeSchedule: {
+        badge: 'Disponible ahora',
+        title: 'Agenda Google · 30 min gratis',
+        body: 'Revisión de un flujo crítico. Elige horario en Calendar de Viento Norte.',
+        cta: 'Abrir agenda online',
+      },
       /** Superficie embudo /consultoria — sin reclutador/freelance en el framing */
       consultingSurface: {
         badge: 'Viento Norte · pymes',
-        title: 'Agenda el kickoff o escribe',
+        title: 'Escribe y cerramos alcance',
         description:
           'Cierre del embudo: diagnóstico, prototipo, proceso o app. Respuesta en menos de 24 h hábiles.',
         responseBadge: 'Respuesta <24 h hábiles',
@@ -1059,7 +1068,7 @@ export default {
         infoDescription: 'Consultoría UX para pymes · remoto o híbrido',
         assistantTitle: 'Asistente de consultoría',
         assistantDescription:
-          'Ya estás en consultoría. Elegimos el foco y armamos el mensaje para el kickoff.',
+          'Ya estás en consultoría. Elegimos el foco y armamos el mensaje.',
       },
       tabs: {
         assistant: 'Asistente',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -418,6 +418,7 @@ export default {
           'Miramos un flujo de alto impacto (onboarding, pago o acceso). Si aplica, el Diagnóstico completo son 5–7 días.',
         freeStripCta: 'Pedir revisión gratis',
         freeStripCtaSchedule: 'Reservar 30 min gratis',
+        freeStripCtaMessage: 'Prefiero escribir (sin agenda)',
         freeStripSecondary: 'Diagnóstico completo (5–7 días)',
         appStripTitle: 'App de punta a punta',
         appStripBody:

--- a/src/lib/navigate-to-contact.ts
+++ b/src/lib/navigate-to-contact.ts
@@ -14,11 +14,14 @@ export type ContactCtaOrigin =
   | "hero-path"
   | "consultoria-hero"
   | "consultoria-packages"
+  | "consultoria-contact"
   | "free-radar"
   | "quoter"
   | "onboarding"
   | "partner-edu"
   | "nav"
+  | "contact"
+  | "contact-assistant"
   | "other";
 
 export interface OpenContactAssistantOptions {
@@ -30,6 +33,7 @@ export interface OpenContactAssistantOptions {
   timeline?: string;
   recruiterMode?: string;
   consultingQ1?: string;
+  conversationTitle?: string;
   /** Analytics: where the user came from */
   origin?: ContactCtaOrigin;
   /** Replace history entry (e.g. after redirect) */
@@ -70,6 +74,7 @@ export function buildContactDraft(options: OpenContactAssistantOptions): Contact
     timeline: options.timeline,
     recruiterMode: options.recruiterMode,
     consultingQ1: options.consultingQ1,
+    conversationTitle: options.conversationTitle?.trim() || undefined,
   };
 }
 

--- a/src/lib/submit-contact.ts
+++ b/src/lib/submit-contact.ts
@@ -20,6 +20,8 @@ export interface ContactPayload {
   intent?: string;
   consent?: boolean;
   language?: "es" | "en";
+  /** Asunto VN · Kickoff · … (selecciones embudo) */
+  conversationTitle?: string;
 }
 
 export type ContactSubmitChannel = "google_forms" | "formsubmit" | "worker" | "mailto";
@@ -31,21 +33,39 @@ export interface ContactSubmitResult {
   mailtoUrl?: string;
 }
 
+function buildSubject(payload: ContactPayload): string {
+  const title = payload.conversationTitle?.trim();
+  if (title) return `${title} · ${payload.name.trim()}`;
+  if (payload.intent?.trim()) {
+    return `VN · ${payload.intent.trim()} · ${payload.name.trim()}`;
+  }
+  return `VN · mensaje · ${payload.name.trim()}`;
+}
+
 function buildMailtoUrl(payload: ContactPayload): string {
-  const subject = encodeURIComponent(`Portfolio · mensaje de ${payload.name.trim()}`);
+  const subject = encodeURIComponent(buildSubject(payload));
   const body = encodeURIComponent(
     [
+      payload.conversationTitle
+        ? `Conversación: ${payload.conversationTitle}`
+        : null,
       `Nombre: ${payload.name.trim()}`,
       `Email: ${payload.email.trim()}`,
       "",
       formatOutboundMessage(payload),
-    ].join("\n")
+    ]
+      .filter(Boolean)
+      .join("\n")
   );
   return `${buildContactMailtoUrl()}?subject=${subject}&body=${body}`;
 }
 
 function formatOutboundMessage(payload: ContactPayload): string {
-  const lines = [payload.message.trim()];
+  const lines: string[] = [];
+  if (payload.conversationTitle?.trim()) {
+    lines.push(`Título: ${payload.conversationTitle.trim()}`, "");
+  }
+  lines.push(payload.message.trim());
   if (payload.intent?.trim()) lines.push("", `Motivo: ${payload.intent.trim()}`);
   if (payload.source) lines.push(`Canal: ${payload.source}`);
   return lines.join("\n");
@@ -144,9 +164,7 @@ function submitViaFormPost(payload: ContactPayload): Promise<ContactSubmitResult
       name: payload.name.trim(),
       email: payload.email.trim(),
       message: formatOutboundMessage(payload),
-      _subject: payload.intent
-        ? `Portfolio · ${payload.intent} · ${payload.name.trim()}`
-        : `Portfolio · mensaje de ${payload.name.trim()}`,
+      _subject: buildSubject(payload),
       _replyto: payload.email.trim(),
       _captcha: "false",
       _template: "table",
@@ -196,6 +214,7 @@ async function submitViaWorker(payload: ContactPayload): Promise<ContactSubmitRe
       _gotcha: payload._gotcha ?? "",
       source: payload.source ?? "form",
       intent: payload.intent ?? "",
+      conversationTitle: payload.conversationTitle ?? "",
       consent: payload.consent === true,
       language: payload.language ?? "es",
     }),


### PR DESCRIPTION
## Problem
Critical: production had `VITE_A11Y_FREE_SCHEDULE_URL` in the build, but users could not **see** the online Google schedule in contact or the conversion funnel (only a subtle free link / post-submit toast).

## Fix
- New `FreeA11yScheduleCta` molecule (card + compact)
- Mounted on Contact (`#contacto`) and ContactAssistant
- Hero free link uses “Reservar 30 min… Google Calendar” when URL present
- Origins analytics: `contact`, `contact-assistant`, `consultoria-contact`

## Test
- Local with `VITE_A11Y_FREE_SCHEDULE_URL`
- `/consultoria` → #contacto shows **Abrir agenda online**
- `/contacto` same
- Click opens `calendar.app.google/NvXgp…`