### PR TITLE
chore: switch production URLs and contact to vientonorte.io

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ const DesignSystem = lazyWithRetry(() => import('./pages/DesignSystem'));
 const CaseStudies = lazyWithRetry(() => import('./pages/CaseStudies'));
 const AuditoriaPortfolio = lazyWithRetry(() => import('./pages/AuditoriaPortfolio'));
 const ConsultoriaVientoNorte = lazyWithRetry(() => import('./pages/ConsultoriaVientoNorte'));
+const PocProductOnboarding = lazyWithRetry(() => import('./pages/PocProductOnboarding'));
 const ProcessDetail = lazyWithRetry(() => import('./pages/ProcessDetail'));
 const CompanyDetailRoute = lazyWithRetry(() => import('./pages/CompanyDetailRoute'));
 const ProjectDetailRoute = lazyWithRetry(() => import('./pages/ProjectDetailRoute'));
@@ -136,6 +137,7 @@ function AppRoutes() {
             <Route path="/proyecto/:projectId" element={<ProjectDetailRoute />} />
             <Route path="/auditoria" element={<AuditoriaPortfolio />} />
             <Route path="/consultoria" element={<ConsultoriaVientoNorte />} />
+            <Route path={ROUTES.pocProductOnboarding} element={<PocProductOnboarding />} />
             <Route path="/admin/fotos" element={<AdminPhotos />} />
             <Route path="*" element={<GlobalNotFoundPage />} />
           </Routes>

--- a/src/data/poc-product-modules.ts
+++ b/src/data/poc-product-modules.ts
@@ -1,0 +1,254 @@
+/**
+ * Módulos-producto Viento Norte (referencia X|CMS / Figma Sites).
+ * Cada módulo = producto a medida · local-first · dueño del dato.
+ * Source demo: https://pouch-growl-74881457.figma.site
+ */
+import { portfolioImages } from "../lib/portfolio-image-urls";
+import { CONSULTORIA_DEMO_X_CMS } from "./consultoria-demos";
+
+export const POC_X_CMS_SITE = CONSULTORIA_DEMO_X_CMS.figmaSitesUrl!;
+export const POC_X_CMS_MAKE = CONSULTORIA_DEMO_X_CMS.figmaMakeUrl!;
+
+export type PocModuleId =
+  | "dashboard"
+  | "riesgo"
+  | "inventario"
+  | "pedidos"
+  | "clientes"
+  | "reportes";
+
+export type PocModule = {
+  id: PocModuleId;
+  /** Etiqueta corta (nav chips) */
+  chip: { es: string; en: string };
+  /** Título producto (Apple-style, multi-línea con \n) */
+  title: { es: string; en: string };
+  /** Una frase de job-to-be-done */
+  job: { es: string; en: string };
+  /** Capacidad concreta del módulo */
+  capabilities: { es: string[]; en: string[] };
+  /** Por qué local-first / dueño del dato aplica aquí */
+  ownership: { es: string; en: string };
+  image: string;
+};
+
+/** Principios de negocio VN (no cloud SaaS genérico) */
+export const POC_PRINCIPLES = {
+  es: [
+    {
+      title: "Sin nube obligatoria",
+      body: "El módulo corre en tu perímetro. Sin suscripción SaaS que se lleve el dato.",
+    },
+    {
+      title: "Sin terceros de datos",
+      body: "No entrenamos modelos con tu operación ni revendemos telemetría.",
+    },
+    {
+      title: "Dueño de la empresa",
+      body: "Licencia y código del módulo para la empresa — no un arriendo eterno.",
+    },
+    {
+      title: "Dueño del dato",
+      body: "Tus tablas, backups y export viven contigo. Portable. Auditables.",
+    },
+  ],
+  en: [
+    {
+      title: "No mandatory cloud",
+      body: "The module runs in your perimeter. No SaaS rent that owns the data.",
+    },
+    {
+      title: "No third-party data",
+      body: "We don’t train models on your ops or resell telemetry.",
+    },
+    {
+      title: "Company owns the product",
+      body: "Module license and code for the company — not endless rent.",
+    },
+    {
+      title: "Company owns the data",
+      body: "Your tables, backups, and exports stay with you. Portable. Auditable.",
+    },
+  ],
+} as const;
+
+/**
+ * Módulos reales del stack X|CMS (Figma Make / Sites)
+ * alineados a trayectoria enterprise VN.
+ */
+export const POC_MODULES: readonly PocModule[] = [
+  {
+    id: "dashboard",
+    chip: { es: "Dashboard", en: "Dashboard" },
+    title: {
+      es: "Dashboard.\nTu operación en un aliento.",
+      en: "Dashboard.\nYour ops in one breath.",
+    },
+    job: {
+      es: "CFO y gerencia ven KPIs, ratios y alertas sin abrir diez herramientas.",
+      en: "CFO and leadership see KPIs, ratios, and alerts without ten tools.",
+    },
+    capabilities: {
+      es: [
+        "Dashboard principal y financiero en tiempo real",
+        "KPIs por local / canal",
+        "Roles: Admin, Gerente, Vendedor, Analista",
+      ],
+      en: [
+        "Main and financial dashboards in real time",
+        "KPIs by site / channel",
+        "Roles: Admin, Manager, Sales, Analyst",
+      ],
+    },
+    ownership: {
+      es: "Los números no salen a un BI de terceros: el panel es tuyo.",
+      en: "Numbers don’t leave to a third-party BI — the board is yours.",
+    },
+    image: portfolioImages.consultoria.xCmsDashboard,
+  },
+  {
+    id: "riesgo",
+    chip: { es: "Riesgo", en: "Risk" },
+    title: {
+      es: "Control de riesgo.\nAntes de que duela.",
+      en: "Risk control.\nBefore it hurts.",
+    },
+    job: {
+      es: "Analista de riesgo y CFO priorizan alto / moderado / bajo con alertas automáticas.",
+      en: "Risk analyst and CFO prioritize high / moderate / low with automatic alerts.",
+    },
+    capabilities: {
+      es: [
+        "Alertas de alto riesgo",
+        "Distribución y riesgo por cliente",
+        "Análisis financiero + evaluación de riesgo",
+      ],
+      en: [
+        "High-risk alerts",
+        "Distribution and risk by customer",
+        "Financial analysis + risk evaluation",
+      ],
+    },
+    ownership: {
+      es: "Modelos y umbrales quedan en tu política — no en un black-box cloud.",
+      en: "Models and thresholds stay in your policy — not a cloud black box.",
+    },
+    image: portfolioImages.consultoria.geesDashboard,
+  },
+  {
+    id: "inventario",
+    chip: { es: "Inventario", en: "Inventory" },
+    title: {
+      es: "Inventario.\nStock que se entiende.",
+      en: "Inventory.\nStock you understand.",
+    },
+    job: {
+      es: "Operaciones controla entrada, salida y rotación sin ERP monstruo.",
+      en: "Ops controls in/out and turnover without a monster ERP.",
+    },
+    capabilities: {
+      es: [
+        "Control de inventario y stock",
+        "Inventario y rotación",
+        "Catálogo de productos",
+      ],
+      en: [
+        "Inventory and stock control",
+        "Inventory and turnover",
+        "Product catalog",
+      ],
+    },
+    ownership: {
+      es: "El catálogo y el stock son activos de la empresa, no del proveedor SaaS.",
+      en: "Catalog and stock are company assets — not the SaaS vendor’s.",
+    },
+    image: portfolioImages.sura.componentPipeline,
+  },
+  {
+    id: "pedidos",
+    chip: { es: "Pedidos", en: "Orders" },
+    title: {
+      es: "Pedidos.\nTodos los canales, un lugar.",
+      en: "Orders.\nEvery channel, one place.",
+    },
+    job: {
+      es: "Ventas y e-commerce unifican pedidos pendientes y procesados.",
+      en: "Sales and e-commerce unify pending and processed orders.",
+    },
+    capabilities: {
+      es: [
+        "Pedidos y ventas multi-canal",
+        "Pedidos recientes y pendientes",
+        "Flujo operativo de un día real",
+      ],
+      en: [
+        "Multi-channel orders and sales",
+        "Recent and pending orders",
+        "Real-day operational flow",
+      ],
+    },
+    ownership: {
+      es: "Historial de pedidos exportable y resguardado en tu perímetro.",
+      en: "Order history exportable and held in your perimeter.",
+    },
+    image: portfolioImages.transvip.appMobile,
+  },
+  {
+    id: "clientes",
+    chip: { es: "Clientes", en: "Customers" },
+    title: {
+      es: "Clientes.\nRelación sin ceder la base.",
+      en: "Customers.\nRelationship without giving away the base.",
+    },
+    job: {
+      es: "Comercial y operaciones administran la base de clientes y fidelización.",
+      en: "Sales and ops manage the customer base and loyalty.",
+    },
+    capabilities: {
+      es: [
+        "Gestión de clientes (activos, nuevos, inactivos)",
+        "Gestión de fidelización y tiers",
+        "Riesgo por cliente cuando aplica",
+      ],
+      en: [
+        "Customer management (active, new, inactive)",
+        "Loyalty and tiers",
+        "Per-customer risk when needed",
+      ],
+    },
+    ownership: {
+      es: "La base de clientes no vive en un CRM ajeno con lock-in.",
+      en: "The customer base doesn’t live in a locked-in foreign CRM.",
+    },
+    image: portfolioImages.sura.riaOnboarding,
+  },
+  {
+    id: "reportes",
+    chip: { es: "Reportes", en: "Reports" },
+    title: {
+      es: "Reportes.\nEvidencia para decidir.",
+      en: "Reports.\nEvidence to decide.",
+    },
+    job: {
+      es: "Dirección descarga reportes globales y financieros sin pedir favor al TI.",
+      en: "Leadership downloads global and financial reports without IT favors.",
+    },
+    capabilities: {
+      es: [
+        "Reportes globales y financieros",
+        "Acceso según rol",
+        "Backups y control de seguridad",
+      ],
+      en: [
+        "Global and financial reports",
+        "Role-based access",
+        "Backups and security control",
+      ],
+    },
+    ownership: {
+      es: "Reportes y backups salen a tu archivo — no a un silo del vendor.",
+      en: "Reports and backups go to your archive — not a vendor silo.",
+    },
+    image: portfolioImages.sura.analyticsGa4,
+  },
+] as const;

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -10,6 +10,8 @@ export const ROUTES = {
   privacy: '/privacy',
   designSystem: '/design-system',
   consulting: '/consultoria',
+  /** POC onboarding producto estilo Apple — no embudo prod */
+  pocProductOnboarding: '/poc/product-onboarding',
   audit: '/auditoria',
   adminPhotos: '/admin/fotos',
   /** Grafo de fricción institucional — mantenido con noIndex hasta nueva decisión de visibilidad. */

--- a/src/pages/PocProductOnboarding.tsx
+++ b/src/pages/PocProductOnboarding.tsx
@@ -1,0 +1,287 @@
+/**
+ * POC · Product onboarding estilo Apple (no embudo prod).
+ * Referencias craft: RIA onboarding, X|CMS / GEES demos, Map FigJam rediseño.
+ * Ruta: /#/poc/product-onboarding
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Calendar, ChevronDown } from "lucide-react";
+import { SEOHead } from "../components/atoms/SEOHead";
+import { Button } from "../components/ui/button";
+import { useLanguage } from "../lib/LanguageContext";
+import { freeRadarHasSchedule, openFreeRadarEntry } from "../lib/free-radar-entry";
+import { ROUTES } from "../lib/routes";
+import { cn } from "../lib/utils";
+import { portfolioImages } from "../lib/portfolio-image-urls";
+
+const STEPS = ["welcome", "clarity", "proof", "start"] as const;
+type StepId = (typeof STEPS)[number];
+
+const STEP_MEDIA = {
+  welcome: portfolioImages.sura.riaOnboarding,
+  clarity: portfolioImages.consultoria.xCmsDashboard,
+  proof: portfolioImages.consultoria.geesDashboard,
+  start: portfolioImages.sura.onboardingFlags,
+} as const;
+
+export default function PocProductOnboarding() {
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+  const es = language === "es";
+  const [active, setActive] = useState(0);
+  const scheduleReady = freeRadarHasSchedule();
+
+  const copy = es
+    ? {
+        badge: "POC · no es la landing de producción",
+        skip: "Ir a consultoría",
+        steps: [
+          {
+            kicker: "Viento Norte",
+            title: "Un front office\nque se entiende en un aliento.",
+            body: "Ex Agencia Maraña. UXtech: captación, freemium a11y y evidencia enterprise — sin ruido de nueve botones.",
+          },
+          {
+            kicker: "Claridad",
+            title: "Un path.\nUn job.\nUna agenda real.",
+            body: "Hero → modalidades → onboarding → contacto. Free a11y abre Google Calendar. Sin segunda agenda fantasma.",
+          },
+          {
+            kicker: "Prueba",
+            title: "Craft que ya construiste.",
+            body: "RIA SURA (onboarding multi-país), demos producto, design systems. Esta POC toma ese ritmo visual — no reinventar demos Apple en el funnel principal.",
+          },
+          {
+            kicker: "Empezar",
+            title: "Reserva 30 min\no escribe alcance.",
+            body: scheduleReady
+              ? "Agenda online de Viento Norte (Appointment Schedule). O cierra el embudo en consultoría."
+              : "Configura VITE_A11Y_FREE_SCHEDULE_URL para la agenda. Mientras, el embudo de consultoría sigue vivo.",
+          },
+        ],
+        ctaSchedule: "Abrir agenda Google",
+        ctaFunnel: "Empezar en consultoría",
+        ctaNext: "Continuar",
+        ctaDone: "Listo",
+        hint: "Scroll o flechas · estilo producto",
+      }
+    : {
+        badge: "POC · not production landing",
+        skip: "Go to consulting",
+        steps: [
+          {
+            kicker: "Viento Norte",
+            title: "A front office\nyou get in one breath.",
+            body: "Formerly Agencia Maraña. UXtech: capture, free a11y, enterprise proof — without nine-button noise.",
+          },
+          {
+            kicker: "Clarity",
+            title: "One path.\nOne job.\nOne real calendar.",
+            body: "Hero → packages → onboarding → contact. Free a11y opens Google Calendar. No ghost second schedule.",
+          },
+          {
+            kicker: "Proof",
+            title: "Craft you already shipped.",
+            body: "RIA SURA multi-country onboarding, product demos, design systems. This POC borrows that visual rhythm — not Apple banners in the main funnel.",
+          },
+          {
+            kicker: "Start",
+            title: "Book 30 minutes\nor write scope.",
+            body: scheduleReady
+              ? "Viento Norte online Appointment Schedule. Or finish the consulting funnel."
+              : "Set VITE_A11Y_FREE_SCHEDULE_URL for the schedule. Consulting funnel stays live.",
+          },
+        ],
+        ctaSchedule: "Open Google Calendar",
+        ctaFunnel: "Start consulting",
+        ctaNext: "Continue",
+        ctaDone: "Done",
+        hint: "Scroll or arrows · product style",
+      };
+
+  const go = useCallback(
+    (i: number) => {
+      setActive(Math.max(0, Math.min(STEPS.length - 1, i)));
+      document
+        .getElementById(`poc-step-${STEPS[Math.max(0, Math.min(STEPS.length - 1, i))]}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    },
+    []
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+        e.preventDefault();
+        go(active + 1);
+      }
+      if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+        e.preventDefault();
+        go(active - 1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, go]);
+
+  useEffect(() => {
+    const els = STEPS.map((id) => document.getElementById(`poc-step-${id}`)).filter(
+      Boolean
+    ) as HTMLElement[];
+    if (!els.length) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (!visible?.target.id) return;
+        const idx = STEPS.findIndex((s) => `poc-step-${s}` === visible.target.id);
+        if (idx >= 0) setActive(idx);
+      },
+      { threshold: [0.45, 0.6] }
+    );
+    els.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  const openSchedule = () => {
+    openFreeRadarEntry(navigate, language, "free-radar", { mode: "schedule" });
+  };
+
+  return (
+    <>
+      <SEOHead
+        title={es ? "POC Onboarding producto · Viento Norte" : "POC Product onboarding · Viento Norte"}
+        description={
+          es
+            ? "Prueba de concepto: onboarding de producto estilo Apple para el front office VN."
+            : "Proof of concept: Apple-style product onboarding for VN front office."
+        }
+        noIndex
+      />
+
+      <div className="relative min-h-screen bg-[var(--vn-azul-noche,#0d1b3d)] text-[var(--vn-marfil,#f7f2e7)]">
+        {/* Chrome mínimo */}
+        <header className="fixed inset-x-0 top-0 z-40 flex items-center justify-between px-4 py-3 md:px-8">
+          <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1 text-[11px] font-medium tracking-wide backdrop-blur">
+            {copy.badge}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-white/80 hover:bg-white/10 hover:text-white"
+            onClick={() => navigate(ROUTES.consulting)}
+          >
+            {copy.skip}
+            <ArrowRight className="ml-1 h-3.5 w-3.5" aria-hidden />
+          </Button>
+        </header>
+
+        {/* Dots */}
+        <nav
+          className="fixed right-4 top-1/2 z-40 hidden -translate-y-1/2 flex-col gap-2 md:flex"
+          aria-label={es ? "Pasos" : "Steps"}
+        >
+          {STEPS.map((id, i) => (
+            <button
+              key={id}
+              type="button"
+              aria-label={`${i + 1}`}
+              aria-current={active === i ? "step" : undefined}
+              className={cn(
+                "h-2.5 w-2.5 rounded-full transition-all",
+                active === i ? "scale-125 bg-white" : "bg-white/30 hover:bg-white/60"
+              )}
+              onClick={() => go(i)}
+            />
+          ))}
+        </nav>
+
+        {STEPS.map((id, i) => {
+          const step = copy.steps[i];
+          const media = STEP_MEDIA[id as StepId];
+          const isLast = i === STEPS.length - 1;
+          return (
+            <section
+              key={id}
+              id={`poc-step-${id}`}
+              className="flex min-h-[100dvh] flex-col justify-center px-5 pb-16 pt-20 md:px-16 lg:px-24"
+              aria-labelledby={`poc-title-${id}`}
+            >
+              <div className="mx-auto grid w-full max-w-6xl items-center gap-10 lg:grid-cols-2 lg:gap-16">
+                <div className="space-y-6">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
+                    {step.kicker}
+                  </p>
+                  <h1
+                    id={`poc-title-${id}`}
+                    className="whitespace-pre-line text-4xl font-semibold leading-[1.05] tracking-tight md:text-5xl lg:text-6xl"
+                  >
+                    {step.title}
+                  </h1>
+                  <p className="max-w-md text-base leading-relaxed text-white/70 md:text-lg">
+                    {step.body}
+                  </p>
+                  <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center">
+                    {isLast ? (
+                      <>
+                        {scheduleReady ? (
+                          <Button
+                            size="lg"
+                            className="min-h-[48px] bg-white font-semibold text-[#0d1b3d] hover:bg-white/90"
+                            onClick={openSchedule}
+                          >
+                            <Calendar className="mr-2 h-4 w-4" aria-hidden />
+                            {copy.ctaSchedule}
+                          </Button>
+                        ) : null}
+                        <Button
+                          size="lg"
+                          variant="outline"
+                          className="min-h-[48px] border-white/30 bg-transparent font-semibold text-white hover:bg-white/10"
+                          onClick={() => navigate(ROUTES.consulting)}
+                        >
+                          {copy.ctaFunnel}
+                          <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        size="lg"
+                        className="min-h-[48px] bg-white font-semibold text-[#0d1b3d] hover:bg-white/90"
+                        onClick={() => go(i + 1)}
+                      >
+                        {copy.ctaNext}
+                        <ChevronDown className="ml-2 h-4 w-4" aria-hidden />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                <div className="relative">
+                  <div className="absolute -inset-4 rounded-[2rem] bg-gradient-to-br from-[#1A8FDC]/30 to-transparent blur-2xl" />
+                  <figure className="relative overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-2xl">
+                    <img
+                      src={media}
+                      alt=""
+                      className="aspect-[4/3] w-full object-cover object-top opacity-95"
+                      loading={i === 0 ? "eager" : "lazy"}
+                    />
+                    <figcaption className="sr-only">{step.kicker}</figcaption>
+                  </figure>
+                </div>
+              </div>
+
+              {!isLast && (
+                <p className="mt-12 text-center text-[11px] tracking-wide text-white/35 md:mt-16">
+                  {copy.hint}
+                </p>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/pages/PocProductOnboarding.tsx
+++ b/src/pages/PocProductOnboarding.tsx
@@ -1,112 +1,162 @@
 /**
- * POC · Product onboarding estilo Apple (no embudo prod).
- * Referencias craft: RIA onboarding, X|CMS / GEES demos, Map FigJam rediseño.
- * Ruta: /#/poc/product-onboarding
+ * POC · Onboarding de producto estilo Apple.
+ * Narrativa: cada módulo X|CMS es un producto a medida (sin nube, dueño del dato).
+ * Demo canónica: https://pouch-growl-74881457.figma.site
+ * Ruta: /#/poc/product-onboarding · noIndex · no embudo prod
  */
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowRight, Calendar, ChevronDown } from "lucide-react";
+import {
+  ArrowRight,
+  Calendar,
+  ChevronDown,
+  ExternalLink,
+  Lock,
+  Server,
+  Shield,
+  Building2,
+} from "lucide-react";
 import { SEOHead } from "../components/atoms/SEOHead";
 import { Button } from "../components/ui/button";
 import { useLanguage } from "../lib/LanguageContext";
 import { freeRadarHasSchedule, openFreeRadarEntry } from "../lib/free-radar-entry";
 import { ROUTES } from "../lib/routes";
 import { cn } from "../lib/utils";
-import { portfolioImages } from "../lib/portfolio-image-urls";
+import {
+  POC_MODULES,
+  POC_PRINCIPLES,
+  POC_X_CMS_SITE,
+  type PocModuleId,
+} from "../data/poc-product-modules";
 
-const STEPS = ["welcome", "clarity", "proof", "start"] as const;
-type StepId = (typeof STEPS)[number];
-
-const STEP_MEDIA = {
-  welcome: portfolioImages.sura.riaOnboarding,
-  clarity: portfolioImages.consultoria.xCmsDashboard,
-  proof: portfolioImages.consultoria.geesDashboard,
-  start: portfolioImages.sura.onboardingFlags,
-} as const;
+type Screen =
+  | "intro"
+  | "principles"
+  | PocModuleId
+  | "build"
+  | "start";
 
 export default function PocProductOnboarding() {
   const navigate = useNavigate();
   const { language } = useLanguage();
   const es = language === "es";
-  const [active, setActive] = useState(0);
   const scheduleReady = freeRadarHasSchedule();
+  const principles = POC_PRINCIPLES[language === "en" ? "en" : "es"];
 
-  const copy = es
+  const screens: Screen[] = useMemo(
+    () => [
+      "intro",
+      "principles",
+      ...POC_MODULES.map((m) => m.id),
+      "build",
+      "start",
+    ],
+    []
+  );
+
+  const [active, setActive] = useState(0);
+
+  const t = es
     ? {
-        badge: "POC · no es la landing de producción",
-        skip: "Ir a consultoría",
-        steps: [
-          {
-            kicker: "Viento Norte",
-            title: "Un front office\nque se entiende en un aliento.",
-            body: "Ex Agencia Maraña. UXtech: captación, freemium a11y y evidencia enterprise — sin ruido de nueve botones.",
-          },
-          {
-            kicker: "Claridad",
-            title: "Un path.\nUn job.\nUna agenda real.",
-            body: "Hero → modalidades → onboarding → contacto. Free a11y abre Google Calendar. Sin segunda agenda fantasma.",
-          },
-          {
-            kicker: "Prueba",
-            title: "Craft que ya construiste.",
-            body: "RIA SURA (onboarding multi-país), demos producto, design systems. Esta POC toma ese ritmo visual — no reinventar demos Apple en el funnel principal.",
-          },
-          {
-            kicker: "Empezar",
-            title: "Reserva 30 min\no escribe alcance.",
-            body: scheduleReady
-              ? "Agenda online de Viento Norte (Appointment Schedule). O cierra el embudo en consultoría."
-              : "Configura VITE_A11Y_FREE_SCHEDULE_URL para la agenda. Mientras, el embudo de consultoría sigue vivo.",
-          },
-        ],
-        ctaSchedule: "Abrir agenda Google",
-        ctaFunnel: "Empezar en consultoría",
+        badge: "POC · módulos-producto Viento Norte",
+        skip: "Consultoría",
+        liveDemo: "Abrir demo X|CMS",
+        intro: {
+          kicker: "Modelo de negocio",
+          title: "No vendemos nube.\nConstruimos módulos.",
+          body: "Cada módulo es un producto a medida para la empresa dueña del dato. Trayectoria enterprise (SURA, Transvip, pymes) — empaquetada como software que se instala y se entiende.",
+        },
+        principles: {
+          kicker: "Promesa",
+          title: "Cuatro reglas.\nSin letra chica.",
+          body: "Si el módulo no las cumple, no es Viento Norte.",
+        },
+        build: {
+          kicker: "Cómo se construye",
+          title: "A medida.\nCon craft enterprise.",
+          body: "Partimos del job real (riesgo, inventario, pedidos…). Diseñamos, prototipamos y entregamos el módulo con dueño claro del dato. Referencia viva: X|CMS en Figma Sites.",
+          points: [
+            "Discovery + IA del módulo (qué decide quién)",
+            "UI y flujos con roles reales",
+            "Entrega local-first / perímetro del cliente",
+            "Handoff y evidencia (como en RIA / N2N)",
+          ],
+        },
+        start: {
+          kicker: "Siguiente paso",
+          title: "Elige un módulo.\nLo hacemos tuyo.",
+          body: scheduleReady
+            ? "Agenda 30 min o cierra alcance en consultoría. Sin demo de marketing vacía: hablamos del módulo que necesitas."
+            : "Cierra alcance en consultoría. Configura agenda free a11y para reservar slot online.",
+        },
         ctaNext: "Continuar",
-        ctaDone: "Listo",
-        hint: "Scroll o flechas · estilo producto",
+        ctaSchedule: "Agenda Google · 30 min",
+        ctaFunnel: "Empezar en consultoría",
+        ctaDemo: "Ver X|CMS en vivo",
+        moduleLabel: "Módulo",
+        capabilities: "Incluye",
+        ownership: "Dueño del dato",
+        hint: "Scroll · flechas · un módulo = un producto",
+        chipsAria: "Módulos producto",
       }
     : {
-        badge: "POC · not production landing",
-        skip: "Go to consulting",
-        steps: [
-          {
-            kicker: "Viento Norte",
-            title: "A front office\nyou get in one breath.",
-            body: "Formerly Agencia Maraña. UXtech: capture, free a11y, enterprise proof — without nine-button noise.",
-          },
-          {
-            kicker: "Clarity",
-            title: "One path.\nOne job.\nOne real calendar.",
-            body: "Hero → packages → onboarding → contact. Free a11y opens Google Calendar. No ghost second schedule.",
-          },
-          {
-            kicker: "Proof",
-            title: "Craft you already shipped.",
-            body: "RIA SURA multi-country onboarding, product demos, design systems. This POC borrows that visual rhythm — not Apple banners in the main funnel.",
-          },
-          {
-            kicker: "Start",
-            title: "Book 30 minutes\nor write scope.",
-            body: scheduleReady
-              ? "Viento Norte online Appointment Schedule. Or finish the consulting funnel."
-              : "Set VITE_A11Y_FREE_SCHEDULE_URL for the schedule. Consulting funnel stays live.",
-          },
-        ],
-        ctaSchedule: "Open Google Calendar",
-        ctaFunnel: "Start consulting",
+        badge: "POC · Viento Norte product modules",
+        skip: "Consulting",
+        liveDemo: "Open X|CMS demo",
+        intro: {
+          kicker: "Business model",
+          title: "We don’t sell cloud.\nWe build modules.",
+          body: "Each module is a custom product for the company that owns the data. Enterprise trajectory (SURA, Transvip, SMBs) — packaged as software you install and understand.",
+        },
+        principles: {
+          kicker: "Promise",
+          title: "Four rules.\nNo fine print.",
+          body: "If the module breaks them, it isn’t Viento Norte.",
+        },
+        build: {
+          kicker: "How we build",
+          title: "Custom.\nEnterprise craft.",
+          body: "We start from the real job (risk, inventory, orders…). Design, prototype, and deliver the module with clear data ownership. Live reference: X|CMS on Figma Sites.",
+          points: [
+            "Discovery + module IA (who decides what)",
+            "UI and flows with real roles",
+            "Local-first / client perimeter delivery",
+            "Handoff and proof (RIA / N2N style)",
+          ],
+        },
+        start: {
+          kicker: "Next step",
+          title: "Pick a module.\nWe make it yours.",
+          body: scheduleReady
+            ? "Book 30 minutes or close scope in consulting. No empty marketing demo — we talk about the module you need."
+            : "Close scope in consulting. Configure free a11y calendar for online booking.",
+        },
         ctaNext: "Continue",
-        ctaDone: "Done",
-        hint: "Scroll or arrows · product style",
+        ctaSchedule: "Google Calendar · 30 min",
+        ctaFunnel: "Start consulting",
+        ctaDemo: "See live X|CMS",
+        moduleLabel: "Module",
+        capabilities: "Includes",
+        ownership: "Data owner",
+        hint: "Scroll · arrows · one module = one product",
+        chipsAria: "Product modules",
       };
 
   const go = useCallback(
     (i: number) => {
-      setActive(Math.max(0, Math.min(STEPS.length - 1, i)));
+      const next = Math.max(0, Math.min(screens.length - 1, i));
+      setActive(next);
       document
-        .getElementById(`poc-step-${STEPS[Math.max(0, Math.min(STEPS.length - 1, i))]}`)
+        .getElementById(`poc-screen-${screens[next]}`)
         ?.scrollIntoView({ behavior: "smooth", block: "start" });
     },
-    []
+    [screens]
   );
 
   useEffect(() => {
@@ -125,9 +175,9 @@ export default function PocProductOnboarding() {
   }, [active, go]);
 
   useEffect(() => {
-    const els = STEPS.map((id) => document.getElementById(`poc-step-${id}`)).filter(
-      Boolean
-    ) as HTMLElement[];
+    const els = screens
+      .map((id) => document.getElementById(`poc-screen-${id}`))
+      .filter(Boolean) as HTMLElement[];
     if (!els.length) return;
     const io = new IntersectionObserver(
       (entries) => {
@@ -135,153 +185,368 @@ export default function PocProductOnboarding() {
           .filter((e) => e.isIntersecting)
           .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
         if (!visible?.target.id) return;
-        const idx = STEPS.findIndex((s) => `poc-step-${s}` === visible.target.id);
+        const idx = screens.findIndex((s) => `poc-screen-${s}` === visible.target.id);
         if (idx >= 0) setActive(idx);
       },
-      { threshold: [0.45, 0.6] }
+      { threshold: [0.4, 0.55] }
     );
     els.forEach((el) => io.observe(el));
     return () => io.disconnect();
-  }, []);
+  }, [screens]);
 
   const openSchedule = () => {
     openFreeRadarEntry(navigate, language, "free-radar", { mode: "schedule" });
   };
 
+  const lang = es ? "es" : "en";
+  const principleIcons = [Server, Shield, Building2, Lock];
+
   return (
     <>
       <SEOHead
-        title={es ? "POC Onboarding producto · Viento Norte" : "POC Product onboarding · Viento Norte"}
+        title={
+          es
+            ? "POC · Módulos producto Viento Norte"
+            : "POC · Viento Norte product modules"
+        }
         description={
           es
-            ? "Prueba de concepto: onboarding de producto estilo Apple para el front office VN."
-            : "Proof of concept: Apple-style product onboarding for VN front office."
+            ? "Onboarding de módulos-producto a medida: sin nube, dueño del dato. Referencia X|CMS."
+            : "Custom product-module onboarding: no cloud lock-in, data ownership. X|CMS reference."
         }
         noIndex
       />
 
-      <div className="relative min-h-screen bg-[var(--vn-azul-noche,#0d1b3d)] text-[var(--vn-marfil,#f7f2e7)]">
-        {/* Chrome mínimo */}
-        <header className="fixed inset-x-0 top-0 z-40 flex items-center justify-between px-4 py-3 md:px-8">
-          <span className="rounded-full border border-white/15 bg-black/30 px-3 py-1 text-[11px] font-medium tracking-wide backdrop-blur">
-            {copy.badge}
+      <div className="relative min-h-screen bg-[#050a14] text-[#f7f2e7]">
+        <header className="fixed inset-x-0 top-0 z-50 flex items-center justify-between gap-3 px-4 py-3 md:px-8">
+          <span className="rounded-full border border-white/12 bg-black/40 px-3 py-1 text-[11px] font-medium tracking-wide backdrop-blur-md">
+            {t.badge}
           </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="text-white/80 hover:bg-white/10 hover:text-white"
-            onClick={() => navigate(ROUTES.consulting)}
-          >
-            {copy.skip}
-            <ArrowRight className="ml-1 h-3.5 w-3.5" aria-hidden />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="hidden text-white/75 hover:bg-white/10 hover:text-white sm:inline-flex"
+              onClick={() => window.open(POC_X_CMS_SITE, "_blank", "noopener,noreferrer")}
+            >
+              {t.liveDemo}
+              <ExternalLink className="ml-1.5 h-3.5 w-3.5" aria-hidden />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-white/80 hover:bg-white/10 hover:text-white"
+              onClick={() => navigate(ROUTES.consulting)}
+            >
+              {t.skip}
+              <ArrowRight className="ml-1 h-3.5 w-3.5" aria-hidden />
+            </Button>
+          </div>
         </header>
 
-        {/* Dots */}
-        <nav
-          className="fixed right-4 top-1/2 z-40 hidden -translate-y-1/2 flex-col gap-2 md:flex"
-          aria-label={es ? "Pasos" : "Steps"}
+        {/* Chips de módulos — sticky bajo header cuando hay un módulo activo */}
+        <div
+          className={cn(
+            "fixed inset-x-0 top-12 z-40 border-b border-white/5 bg-[#050a14]/80 px-3 py-2 backdrop-blur-md transition-opacity md:top-14",
+            active >= 2 && active < 2 + POC_MODULES.length
+              ? "opacity-100"
+              : "pointer-events-none opacity-0"
+          )}
         >
-          {STEPS.map((id, i) => (
+          <nav
+            className="mx-auto flex max-w-5xl gap-2 overflow-x-auto pb-1"
+            aria-label={t.chipsAria}
+          >
+            {POC_MODULES.map((m) => {
+              const idx = screens.indexOf(m.id);
+              const on = screens[active] === m.id;
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => go(idx)}
+                  className={cn(
+                    "shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+                    on
+                      ? "bg-white text-[#050a14]"
+                      : "bg-white/8 text-white/70 hover:bg-white/15 hover:text-white"
+                  )}
+                >
+                  {m.chip[lang]}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* Dots desktop */}
+        <nav
+          className="fixed right-4 top-1/2 z-40 hidden -translate-y-1/2 flex-col gap-2 lg:flex"
+          aria-label={es ? "Pantallas" : "Screens"}
+        >
+          {screens.map((id, i) => (
             <button
               key={id}
               type="button"
               aria-label={`${i + 1}`}
               aria-current={active === i ? "step" : undefined}
               className={cn(
-                "h-2.5 w-2.5 rounded-full transition-all",
-                active === i ? "scale-125 bg-white" : "bg-white/30 hover:bg-white/60"
+                "h-2 w-2 rounded-full transition-all",
+                active === i ? "scale-125 bg-white" : "bg-white/25 hover:bg-white/50"
               )}
               onClick={() => go(i)}
             />
           ))}
         </nav>
 
-        {STEPS.map((id, i) => {
-          const step = copy.steps[i];
-          const media = STEP_MEDIA[id as StepId];
-          const isLast = i === STEPS.length - 1;
-          return (
-            <section
-              key={id}
-              id={`poc-step-${id}`}
-              className="flex min-h-[100dvh] flex-col justify-center px-5 pb-16 pt-20 md:px-16 lg:px-24"
-              aria-labelledby={`poc-title-${id}`}
+        {/* INTRO */}
+        <ScreenShell id="intro" dark>
+          <Kicker>{t.intro.kicker}</Kicker>
+          <Title>{t.intro.title}</Title>
+          <Body>{t.intro.body}</Body>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Primary onClick={() => go(1)}>{t.ctaNext}</Primary>
+            <Ghost
+              onClick={() => window.open(POC_X_CMS_SITE, "_blank", "noopener,noreferrer")}
             >
-              <div className="mx-auto grid w-full max-w-6xl items-center gap-10 lg:grid-cols-2 lg:gap-16">
-                <div className="space-y-6">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
-                    {step.kicker}
-                  </p>
-                  <h1
-                    id={`poc-title-${id}`}
-                    className="whitespace-pre-line text-4xl font-semibold leading-[1.05] tracking-tight md:text-5xl lg:text-6xl"
-                  >
-                    {step.title}
-                  </h1>
-                  <p className="max-w-md text-base leading-relaxed text-white/70 md:text-lg">
-                    {step.body}
-                  </p>
-                  <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:items-center">
-                    {isLast ? (
-                      <>
-                        {scheduleReady ? (
-                          <Button
-                            size="lg"
-                            className="min-h-[48px] bg-white font-semibold text-[#0d1b3d] hover:bg-white/90"
-                            onClick={openSchedule}
-                          >
-                            <Calendar className="mr-2 h-4 w-4" aria-hidden />
-                            {copy.ctaSchedule}
-                          </Button>
-                        ) : null}
-                        <Button
-                          size="lg"
-                          variant="outline"
-                          className="min-h-[48px] border-white/30 bg-transparent font-semibold text-white hover:bg-white/10"
-                          onClick={() => navigate(ROUTES.consulting)}
-                        >
-                          {copy.ctaFunnel}
-                          <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-                        </Button>
-                      </>
-                    ) : (
-                      <Button
-                        size="lg"
-                        className="min-h-[48px] bg-white font-semibold text-[#0d1b3d] hover:bg-white/90"
-                        onClick={() => go(i + 1)}
-                      >
-                        {copy.ctaNext}
-                        <ChevronDown className="ml-2 h-4 w-4" aria-hidden />
-                      </Button>
-                    )}
-                  </div>
-                </div>
+              {t.ctaDemo}
+              <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+            </Ghost>
+          </div>
+          <p className="mt-16 text-center text-[11px] tracking-wide text-white/30 md:mt-20">
+            {t.hint}
+          </p>
+        </ScreenShell>
 
-                <div className="relative">
-                  <div className="absolute -inset-4 rounded-[2rem] bg-gradient-to-br from-[#1A8FDC]/30 to-transparent blur-2xl" />
-                  <figure className="relative overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-2xl">
-                    <img
-                      src={media}
-                      alt=""
-                      className="aspect-[4/3] w-full object-cover object-top opacity-95"
-                      loading={i === 0 ? "eager" : "lazy"}
-                    />
-                    <figcaption className="sr-only">{step.kicker}</figcaption>
-                  </figure>
+        {/* PRINCIPLES */}
+        <ScreenShell id="principles" dark>
+          <Kicker>{t.principles.kicker}</Kicker>
+          <Title>{t.principles.title}</Title>
+          <Body>{t.principles.body}</Body>
+          <ul className="mt-10 grid gap-4 sm:grid-cols-2">
+            {principles.map((p, i) => {
+              const Icon = principleIcons[i] ?? Lock;
+              return (
+                <li
+                  key={p.title}
+                  className="rounded-2xl border border-white/10 bg-white/[0.04] p-5"
+                >
+                  <Icon className="mb-3 h-5 w-5 text-[#1A8FDC]" aria-hidden />
+                  <p className="text-base font-semibold tracking-tight">{p.title}</p>
+                  <p className="mt-2 text-sm leading-relaxed text-white/60">{p.body}</p>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="mt-10">
+            <Primary onClick={() => go(2)}>
+              {t.ctaNext}
+              <ChevronDown className="ml-2 h-4 w-4" aria-hidden />
+            </Primary>
+          </div>
+        </ScreenShell>
+
+        {/* MODULES */}
+        {POC_MODULES.map((m, mi) => {
+          const idx = screens.indexOf(m.id);
+          return (
+            <ScreenShell key={m.id} id={m.id} dark split>
+              <div className="space-y-6">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white/45">
+                  {t.moduleLabel} {String(mi + 1).padStart(2, "0")} · {m.chip[lang]}
+                </p>
+                <h2 className="whitespace-pre-line text-4xl font-semibold leading-[1.05] tracking-tight md:text-5xl lg:text-[3.25rem]">
+                  {m.title[lang]}
+                </h2>
+                <p className="max-w-md text-lg leading-relaxed text-white/70">
+                  {m.job[lang]}
+                </p>
+                <div>
+                  <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-white/40">
+                    {t.capabilities}
+                  </p>
+                  <ul className="space-y-2">
+                    {m.capabilities[lang].map((c) => (
+                      <li
+                        key={c}
+                        className="flex gap-2 text-sm text-white/75 before:mt-2 before:h-1 before:w-1 before:shrink-0 before:rounded-full before:bg-[#1A8FDC] before:content-['']"
+                      >
+                        {c}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <p className="rounded-xl border border-[#1A8FDC]/25 bg-[#1A8FDC]/10 px-4 py-3 text-sm leading-relaxed text-white/85">
+                  <span className="font-semibold text-[#7ec8f5]">{t.ownership}: </span>
+                  {m.ownership[lang]}
+                </p>
+                <div className="flex flex-col gap-3 pt-2 sm:flex-row">
+                  <Primary onClick={() => go(idx + 1)}>{t.ctaNext}</Primary>
+                  <Ghost
+                    onClick={() =>
+                      window.open(POC_X_CMS_SITE, "_blank", "noopener,noreferrer")
+                    }
+                  >
+                    {t.ctaDemo}
+                  </Ghost>
                 </div>
               </div>
-
-              {!isLast && (
-                <p className="mt-12 text-center text-[11px] tracking-wide text-white/35 md:mt-16">
-                  {copy.hint}
-                </p>
-              )}
-            </section>
+              <figure className="relative">
+                <div className="absolute -inset-6 rounded-[2rem] bg-gradient-to-br from-[#1A8FDC]/25 to-transparent blur-2xl" />
+                <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-black/50 shadow-2xl">
+                  <img
+                    src={m.image}
+                    alt=""
+                    className="aspect-[4/3] w-full object-cover object-top"
+                    loading="lazy"
+                  />
+                </div>
+              </figure>
+            </ScreenShell>
           );
         })}
+
+        {/* BUILD */}
+        <ScreenShell id="build" dark>
+          <Kicker>{t.build.kicker}</Kicker>
+          <Title>{t.build.title}</Title>
+          <Body>{t.build.body}</Body>
+          <ol className="mt-10 max-w-lg space-y-4">
+            {t.build.points.map((p, i) => (
+              <li key={p} className="flex gap-4 text-base text-white/80">
+                <span className="font-mono text-sm text-[#1A8FDC]">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                {p}
+              </li>
+            ))}
+          </ol>
+          <div className="mt-10">
+            <Primary onClick={() => go(screens.length - 1)}>{t.ctaNext}</Primary>
+          </div>
+        </ScreenShell>
+
+        {/* START */}
+        <ScreenShell id="start" dark>
+          <Kicker>{t.start.kicker}</Kicker>
+          <Title>{t.start.title}</Title>
+          <Body>{t.start.body}</Body>
+          <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            {scheduleReady ? (
+              <Primary onClick={openSchedule}>
+                <Calendar className="mr-2 h-4 w-4" aria-hidden />
+                {t.ctaSchedule}
+              </Primary>
+            ) : null}
+            <Primary onClick={() => navigate(ROUTES.consulting)}>
+              {t.ctaFunnel}
+              <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+            </Primary>
+            <Ghost
+              onClick={() => window.open(POC_X_CMS_SITE, "_blank", "noopener,noreferrer")}
+            >
+              {t.ctaDemo}
+              <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+            </Ghost>
+          </div>
+        </ScreenShell>
       </div>
     </>
+  );
+}
+
+function ScreenShell({
+  id,
+  children,
+  dark,
+  split,
+}: {
+  id: string;
+  children: ReactNode;
+  dark?: boolean;
+  split?: boolean;
+}) {
+  return (
+    <section
+      id={`poc-screen-${id}`}
+      className={cn(
+        "flex min-h-[100dvh] flex-col justify-center px-5 pb-20 pt-24 md:px-16 lg:px-24",
+        dark && "bg-[#050a14]"
+      )}
+    >
+      <div
+        className={cn(
+          "mx-auto w-full max-w-6xl",
+          split && "grid items-center gap-12 lg:grid-cols-2 lg:gap-16"
+        )}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Kicker({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-4 text-xs font-semibold uppercase tracking-[0.22em] text-white/45">
+      {children}
+    </p>
+  );
+}
+
+function Title({ children }: { children: ReactNode }) {
+  return (
+    <h1 className="mb-5 whitespace-pre-line text-4xl font-semibold leading-[1.05] tracking-tight md:text-5xl lg:text-6xl">
+      {children}
+    </h1>
+  );
+}
+
+function Body({ children }: { children: ReactNode }) {
+  return (
+    <p className="max-w-xl text-base leading-relaxed text-white/65 md:text-lg">
+      {children}
+    </p>
+  );
+}
+
+function Primary({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      size="lg"
+      className="min-h-[48px] bg-white font-semibold text-[#050a14] hover:bg-white/90"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+}
+
+function Ghost({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      size="lg"
+      variant="outline"
+      className="min-h-[48px] border-white/25 bg-transparent font-semibold text-white hover:bg-white/10"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Point SEO / OG / structured data / public contact to `https://vientonorte.io`
- Worker CORS + `CONTACT_FROM` + static image base + WebAuthn RP ID for custom domain
- Contact alias `contacto@vientonorte.io` (Email Routing → Gmail already live in Cloudflare)

## Cloudflare (already done via API)
- DNS A/CNAME for GitHub Pages (DNS only)
- Email Routing enabled: MX/SPF/DKIM
- Rules: `contacto@`, `hola@`, catch-all → `gaete.gaona@gmail.com`
- Contact Worker redeployed with new ALLOWED_ORIGIN

## Test plan
- [ ] CI green
- [ ] After merge: https://vientonorte.io/mi-portafolio/ serves new build
- [ ] mailto shows contacto@vientonorte.io
- [ ] Contact form still posts to Worker from vientonorte.io origin
- [ ] Send test mail to contacto@vientonorte.io arrives in Gmail