### PR TITLE
chore: switch production URLs and contact to vientonorte.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta property="og:title" content="Rodrigo Gaete · UX Lead" />
     <meta property="og:description" content="Diseño que reduce el ruido: cumplimiento regulatorio y experiencias premium." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://vientonorte.github.io/mi-portafolio/" />
+    <meta property="og:url" content="https://vientonorte.io/mi-portafolio/" />
     <meta name="theme-color" content="#171717" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     

--- a/src/data/projects-data.ts
+++ b/src/data/projects-data.ts
@@ -741,7 +741,7 @@ const uxToolsProject: EnhancedProject = {
   description: "Colección de herramientas y recursos para diseñadores UX. Incluye frameworks, plantillas, y utilidades prácticas para optimizar el flujo de trabajo en proyectos de diseño de experiencia de usuario.",
   image: "https://images.unsplash.com/photo-1581291518633-83b4ebd1d83e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&w=1080",
   tags: ["Tools", "UX Resources", "Web Development", "Design Systems"],
-  externalLink: "https://vientonorte.github.io/uxtools/",
+  externalLink: "https://vientonorte.io/uxtools/",
   
   processes: [
     {

--- a/src/data/value-content-arsenal.ts
+++ b/src/data/value-content-arsenal.ts
@@ -443,7 +443,7 @@ export const VALUE_PROOF_ITEMS: ValueProofItem[] = [
     id: "uxtools-suite",
     kind: "poc",
     imagePath: img((i) => i.uxTools.designSystem),
-    href: "https://vientonorte.github.io/uxtools/",
+    href: "https://vientonorte.io/uxtools/",
     external: true,
     bundleId: "radar",
     copy: {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,9 +1,9 @@
 import type { Language } from "./i18n";
 
 export const SEO_SITE = {
-  baseUrl: "https://vientonorte.github.io/mi-portafolio",
+  baseUrl: "https://vientonorte.io/mi-portafolio",
   ogImage:
-    "https://vientonorte.github.io/mi-portafolio/images/branding/og-portfolio.png",
+    "https://vientonorte.io/mi-portafolio/images/branding/og-portfolio.png",
   brand: "Rodrigo Gaete",
   role: "UX Lead",
 } as const;

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -1,7 +1,7 @@
 /** Contacto canónico — Viento Norte / Rodrigo Gaete */
 
 /** Alias público (Email Routing → inbox privado). No publicar Gmail en el sitio. */
-export const PUBLIC_CONTACT_EMAIL = 'contacto@vientonorte.cl';
+export const PUBLIC_CONTACT_EMAIL = 'contacto@vientonorte.io';
 
 /**
  * Inbox real para FormSubmit (action del form, no se muestra en UI).

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -15,7 +15,7 @@ function projectUrl(projectId: string): string {
 
 function absoluteImageUrl(image: string): string {
   if (image.startsWith("http")) return image;
-  if (image.startsWith("/")) return `https://vientonorte.github.io${image}`;
+  if (image.startsWith("/")) return `https://vientonorte.io${image}`;
   return `${SITE_URL}/${image}`;
 }
 
@@ -31,7 +31,7 @@ export function buildPortfolioStructuredData(language: Language) {
     jobTitle: SEO_SITE.role,
     description: hero.valueProp,
     url: SITE_URL,
-    image: "https://vientonorte.github.io/mi-portafolio/images/branding/og-portfolio.png",
+    image: "https://vientonorte.io/mi-portafolio/images/branding/og-portfolio.png",
     email: SITE_CONTACT.email,
     sameAs: [SITE_CONTACT.linkedin, SITE_CONTACT.github],
     knowsAbout: hero.specialties,

--- a/src/lib/viento-norte-links.ts
+++ b/src/lib/viento-norte-links.ts
@@ -1,4 +1,4 @@
 /** Enlaces externos del ecosistema Viento Norte (fuera del HashRouter). */
 export const VIENTO_NORTE_LINKS = {
-  uxtools: "https://vientonorte.github.io/uxtools/",
+  uxtools: "https://vientonorte.io/uxtools/",
 } as const;

--- a/src/pages/AuditoriaPortfolio.tsx
+++ b/src/pages/AuditoriaPortfolio.tsx
@@ -702,7 +702,7 @@ export default function AuditoriaPortfolio() {
               <ul className="flex items-center justify-center gap-6 text-sm list-none p-0 m-0 flex-wrap">
                 <li>
                   <a
-                    href="https://vientonorte.github.io/mi-portafolio/"
+                    href="https://vientonorte.io/mi-portafolio/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-primary hover:text-primary/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"

--- a/worker/src/admin/images.js
+++ b/worker/src/admin/images.js
@@ -28,7 +28,7 @@ function buildImageRecord(entry, manifest, env) {
   const overridden = Boolean(override?.url);
   return {
     id: entry.id,
-    url: override?.url || `${(env.STATIC_IMAGE_BASE || 'https://vientonorte.github.io/mi-portafolio/').replace(/\/$/, '')}/${entry.path.startsWith('profile') ? '' : 'images/'}${entry.path}`,
+    url: override?.url || `${(env.STATIC_IMAGE_BASE || 'https://vientonorte.io/mi-portafolio/').replace(/\/$/, '')}/${entry.path.startsWith('profile') ? '' : 'images/'}${entry.path}`,
     alt: override?.alt || entry.alt,
     path: entry.path,
     category: entry.category,

--- a/worker/src/admin/passkey.js
+++ b/worker/src/admin/passkey.js
@@ -26,7 +26,7 @@ function getRpId(request, env) {
   try {
     return new URL(origin).hostname;
   } catch {
-    return 'vientonorte.github.io';
+    return 'vientonorte.io';
   }
 }
 

--- a/worker/src/contact.js
+++ b/worker/src/contact.js
@@ -21,8 +21,8 @@ async function sendViaFormSubmit(inbox, payload) {
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      Referer: 'https://vientonorte.github.io/mi-portafolio/',
-      Origin: 'https://vientonorte.github.io',
+      Referer: 'https://vientonorte.io/mi-portafolio/',
+      Origin: 'https://vientonorte.io',
     },
     body: JSON.stringify({
       name: payload.safeName,

--- a/worker/wrangler.contact.toml
+++ b/worker/wrangler.contact.toml
@@ -7,8 +7,8 @@ account_id = "6e96c77c41a11e043c84a7802c6108b8"
 workers_dev = true
 
 [vars]
-ALLOWED_ORIGIN = "https://vientonorte.github.io,http://localhost:3000,http://localhost:5173"
-CONTACT_FROM = "contacto@vientonorte.cl"
+ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173"
+CONTACT_FROM = "contacto@vientonorte.io"
 CONTACT_FROM_NAME = "Rodrigo Gaete · Portfolio"
 CONTACT_INBOX = "gaete.gaona@gmail.com"
 

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -5,14 +5,14 @@ account_id = "6e96c77c41a11e043c84a7802c6108b8"
 workers_dev = true
 
 [vars]
-ALLOWED_ORIGIN = "https://vientonorte.github.io,http://localhost:3000,http://localhost:5173"
-CONTACT_FROM = "contacto@vientonorte.cl"
+ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173"
+CONTACT_FROM = "contacto@vientonorte.io"
 CONTACT_FROM_NAME = "Rodrigo Gaete · Portfolio"
 # Inbox privado — override con secret si prefieres: wrangler secret put CONTACT_INBOX
 CONTACT_INBOX = "gaete.gaona@gmail.com"
 ADMIN_GITHUB_USER = "vientonorte"
-STATIC_IMAGE_BASE = "https://vientonorte.github.io/mi-portafolio"
-WEBAUTHN_RP_ID = "vientonorte.github.io"
+STATIC_IMAGE_BASE = "https://vientonorte.io/mi-portafolio"
+WEBAUTHN_RP_ID = "vientonorte.io"
 # R2_PUBLIC_BASE = "https://pub-xxxx.r2.dev"  # tras habilitar acceso público al bucket
 
 # Secrets (wrangler secret put):


### PR DESCRIPTION
## Summary
- SEO / OG / structured data / public contact → `https://vientonorte.io`
- Worker CORS, CONTACT_FROM, STATIC_IMAGE_BASE, WebAuthn RP ID for custom domain
- Public alias `contacto@vientonorte.io` (Email Routing → Gmail already configured in Cloudflare)

## Already live outside this PR
- DNS A + CNAME www (DNS only) → GitHub Pages
- HTTPS on `vientonorte.io` / `www`
- Email Routing: MX/SPF/DKIM + rules `contacto@`, `hola@`, catch-all → Gmail
- Contact Worker redeployed with new origins

## Test plan
- [ ] CI green
- [ ] After merge: production build on https://vientonorte.io/mi-portafolio/
- [ ] mailto = contacto@vientonorte.io
- [ ] Contact form from vientonorte.io origin
- [ ] Test email to contacto@vientonorte.io reaches Gmail