### PR TITLE
feat: generate_lead dataLayer path and now-2 DoD docs

### DIFF
--- a/docs/NOW-2-GENERATE-LEAD.md
+++ b/docs/NOW-2-GENERATE-LEAD.md
@@ -1,0 +1,54 @@
+# now-2 · Lead path v0 + `generate_lead`
+
+**Sprint:** `sprint-2026-07-27-ops-loops`  
+**Canvas:** `now-2` · roadmap `p2-generate-lead`  
+**Live:** https://vientonorte.io/mi-portafolio/
+
+## Qué es
+
+Evento de conversión freemium a11y (y submit de contacto free):
+
+| Campo | Valor típico |
+|-------|----------------|
+| `event` | `generate_lead` |
+| `lead_type` | `free_a11y` |
+| `channel` | `google_calendar` \| `contact_form` \| form channel |
+| `origin` | hero-path, consultoria-hero, packages, contact_assistant… |
+| `package_id` | `radar` |
+| `freemium` | `true` |
+
+## Dónde se dispara
+
+1. **`openFreeRadarEntry`** (`src/lib/free-radar-entry.ts`)  
+   - CTAs gratis a11y (hero, consultoría, packages, featured path, auditoría banner)  
+   - Canales: Calendar schedule **o** form prearmado  
+2. **`ContactAssistant` submit OK** si el mensaje/pack es free a11y  
+
+## Transporte analytics
+
+`trackEvent` → **dataLayer.push** (+ `gtag` si existe).  
+Sin GTM/GA configurado, en DEV se loguea; en prod el dataLayer queda listo para el contenedor único.
+
+## DoD now-2 (v0)
+
+- [x] Evento `generate_lead` en código  
+- [x] Unit tests (free-radar + dataLayer)  
+- [x] dataLayer dual-write (GTM-ready)  
+- [ ] Smoke manual: abrir free CTA en `/#/consultoria` → DevTools → `dataLayer` contiene `generate_lead`  
+- [ ] GTM/GA4 tag que escuche `event = generate_lead` (plan-gtm; requiere `VITE_GTM_ID`)  
+- [ ] Lead e2e Google (Calendar/Task) ya en `p2-lead-e2e` done — no rehacer  
+
+## Smoke manual (ops)
+
+```text
+1. https://vientonorte.io/mi-portafolio/#/consultoria
+2. Clic "Gratis · accesibilidad" / free CTA
+3. Console: window.dataLayer.filter(e => e.event === 'generate_lead')
+4. O form contacto free → submit → mismo evento
+```
+
+## Fuera de alcance v0
+
+- R2 / admin fotos  
+- HashRouter migration  
+- Workspace envío SMTP  

--- a/src/__tests__/lib/analytics-generate-lead.test.ts
+++ b/src/__tests__/lib/analytics-generate-lead.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("trackEvent generate_lead", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("pushes generate_lead to dataLayer for GTM", async () => {
+    const dataLayer: unknown[] = [];
+    vi.stubGlobal("window", {
+      dataLayer,
+      gtag: undefined,
+    });
+    // re-bind for modules that use global window
+    Object.defineProperty(globalThis, "window", {
+      value: { dataLayer, gtag: undefined },
+      configurable: true,
+      writable: true,
+    });
+
+    const { trackEvent, analytics } = await import("../../lib/analytics");
+    trackEvent("generate_lead", {
+      category: "conversion",
+      lead_type: "free_a11y",
+      channel: "contact_form",
+    });
+    analytics.generateLead({
+      lead_type: "free_a11y",
+      channel: "google_calendar",
+      origin: "hero-path",
+    });
+
+    const events = dataLayer.filter(
+      (e) => e && typeof e === "object" && (e as { event?: string }).event === "generate_lead"
+    ) as Array<Record<string, unknown>>;
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[0]).toMatchObject({
+      event: "generate_lead",
+      lead_type: "free_a11y",
+      channel: "contact_form",
+    });
+    expect(events[1]).toMatchObject({
+      event: "generate_lead",
+      lead_type: "free_a11y",
+      freemium: true,
+    });
+  });
+});

--- a/src/__tests__/lib/free-radar-entry.test.ts
+++ b/src/__tests__/lib/free-radar-entry.test.ts
@@ -4,9 +4,12 @@ import type { NavigateFunction } from "react-router-dom";
 const openSpy = vi.fn();
 const navigateSpy = vi.fn();
 
+const trackEventSpy = vi.fn();
+const clickHeroFreeAuditSpy = vi.fn();
+
 vi.mock("../../lib/analytics", () => ({
-  trackEvent: vi.fn(),
-  analytics: { clickHeroFreeAudit: vi.fn() },
+  trackEvent: (...args: unknown[]) => trackEventSpy(...args),
+  analytics: { clickHeroFreeAudit: (...args: unknown[]) => clickHeroFreeAuditSpy(...args) },
 }));
 
 vi.mock("../../lib/navigate-to-contact", () => ({
@@ -18,6 +21,8 @@ describe("openFreeRadarEntry", () => {
     vi.resetModules();
     openSpy.mockReset();
     navigateSpy.mockReset();
+    trackEventSpy.mockReset();
+    clickHeroFreeAuditSpy.mockReset();
     vi.stubGlobal("open", openSpy);
   });
 
@@ -90,5 +95,35 @@ describe("openFreeRadarEntry", () => {
     expect(channel).toBe("contact_form");
     expect(navigateSpy).toHaveBeenCalled();
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits generate_lead with free_a11y on form channel", async () => {
+    vi.doMock("../../lib/site-contact", () => ({
+      A11Y_FREE_SCHEDULE_URL: null,
+      openA11yFreeScheduleOrFallback: (fallback: () => void) => {
+        fallback();
+        return false;
+      },
+    }));
+
+    const { openFreeRadarEntry } = await import("../../lib/free-radar-entry");
+    openFreeRadarEntry(
+      navigateSpy as unknown as NavigateFunction,
+      "es",
+      "consultoria-hero",
+      { mode: "auto" }
+    );
+
+    expect(trackEventSpy).toHaveBeenCalledWith(
+      "generate_lead",
+      expect.objectContaining({
+        lead_type: "free_a11y",
+        channel: "contact_form",
+        origin: "consultoria-hero",
+        package_id: "radar",
+        freemium: true,
+      })
+    );
+    expect(clickHeroFreeAuditSpy).toHaveBeenCalled();
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -18,14 +18,21 @@
  * @param params - Additional parameters for the event
  */
 export const trackEvent = (eventName: string, params?: Record<string, unknown>) => {
-  if (typeof window !== "undefined" && window.gtag) {
+  if (typeof window === "undefined") return;
+
+  // GTM dataLayer first (works even before gtag is wired)
+  const w = window as Window & { dataLayer?: unknown[] };
+  w.dataLayer = w.dataLayer ?? [];
+  w.dataLayer.push({
+    event: eventName,
+    ...params,
+  });
+
+  if (typeof window.gtag === "function") {
     window.gtag("event", eventName, params);
-  } else {
-    // Fallback for development/debugging - silent in production
-    if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
-      console.log('[Analytics]', eventName, params);
-    }
+  } else if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log("[Analytics]", eventName, params);
   }
 };
 


### PR DESCRIPTION
## Summary
- `trackEvent` pushes to **dataLayer** (GTM-ready) + gtag when present
- Unit tests: free a11y emits `generate_lead` + dataLayer payload
- Docs: `docs/NOW-2-GENERATE-LEAD.md` (now-2 / p2-generate-lead DoD)

## Context (ops sprint)
- **now-1 closed** with live smoke on vientonorte.io (hub path nav, portfolio, sitemaps, redirects)
- **now-2** lead path v0

## Test plan
- [x] vitest free-radar-entry + analytics-generate-lead
- [ ] CI green
- [ ] Manual (optional): DevTools dataLayer on free CTA

## Note
GTM container ID still manual (`VITE_GTM_ID` / plan-gtm).