### PR TITLE
fix(landing): redirect legacy /mi-portafolio/ to root

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="es">
   <head>
+    <script>
+      // Legacy /mi-portafolio/* → root (preserves hash). Soft-404 SPA shell also hits this.
+      (function () {
+        var p = location.pathname || "/";
+        if (p === "/mi-portafolio" || p.indexOf("/mi-portafolio/") === 0) {
+          var h = location.hash || "#/";
+          if (h.charAt(0) !== "#") h = "#" + h;
+          if (h.indexOf("#/mi-portafolio") === 0) {
+            h = "#" + (h.slice("#/mi-portafolio".length) || "/");
+          }
+          location.replace("https://vientonorte.io/" + h + location.search);
+        }
+      })();
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content="Viento Norte · Rodrigo Gaete" />


### PR DESCRIPTION
## Summary
- GH Pages soft-404 served the SPA shell at `/mi-portafolio/`, so the static redirect never ran and the landing looked broken under the legacy URL.
- Early JS in `index.html` sends `/mi-portafolio/#/…` → `https://vientonorte.io/#/…` (preserves hash).
- Already live on hub: `vientonorte.github.io` `0979cec` + `c2c9c44` (inject in index/404 + SW v2 + `.nojekyll`).

## Test plan
- [ ] https://vientonorte.io/mi-portafolio/#/ → https://vientonorte.io/#/
- [ ] https://vientonorte.io/mi-portafolio/#/consultoria → /#/consultoria
- [ ] Hard refresh if SW stale (`vn-site-v2`)
- [ ] Home embudo CTAs on root still OK