### PR TITLE
feat(seo): HU-01…03 root + SEM meta, JSON-LD, canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-03] — SEO root + SEM `/#/consultoria` (audit QA)
+
+### Fixed
+- **Canonical SEM:** en `/#/consultoria` el `SEOHead` usaba `ROUTES.consultingFunnel` (`/`) → ahora `ROUTES.consulting` → `https://vientonorte.io/#/consultoria` (message-match Ads / Google).
+
+### Changed
+- **Branding SEO home:** title/description dejan “Rodrigo Gaete · UX Lead” y alinean a **Viento Norte · UXtech** (orgánico root).
+- **SEM meta** consultoría: “Elige tu alcance” + keywords design sprint / fintech / flujos UX (ES/EN).
+- Static `index.html`: description hero-aligned · OG/Twitter · **JSON-LD** Organization + WebSite + ProfessionalService · alternate SEM URL.
+- `sitemap.xml` lastmod 2026-08-03; baja prioridad legacy embudo.
+
+### Product (Decider)
+- **Empezar** en home → onboarding embudo in-place (**no** navega a SEM).
+- SEM `/#/consultoria` = entrada paid; Empezar allí → onboarding local.
+- Re-Map «tour fullscreen vs embudo home» **rechazada** (evidencia + DS).
+
+### Docs
+- `docs/audits/QA-SEO-SEM-PLAN-2026-08-03.md` · `docs/audits/HUs-SEO-SEM-2026-08-03.md` · PDF en `docs/audits/`.
+- Gate: **no SEM spend** sin Test del path (Design Sprint VN).
+
+---
+
 ## [2026-07-27] — Agendar a11y gratis con Google Calendar
 
 - **Free Radar / a11y:** CTAs abren Google Calendar Appointment Schedule si hay `VITE_A11Y_FREE_SCHEDULE_URL` (fallback: form prearmado).

--- a/docs/audits/HUs-SEO-SEM-2026-08-03.md
+++ b/docs/audits/HUs-SEO-SEM-2026-08-03.md
@@ -1,0 +1,36 @@
+# HUs · SEO orgánico + SEM oferta
+
+**SoT Obsidian:** `Viento Norte/Sprints/2026-08-03 HUs SEO-SEM path-oferta.md`  
+**DS:** DS-2026-08-03 path-oferta-analytics · **Día:** Map → **Prototype**  
+**Firma Decider 2026-08-03:** P0 HU-01…04 **sí** · copy meta home/SEM **ok** · Empezar home → onboarding (no SEM) · SEM = entrada paid + onboarding local · re-Map tour-vs-embudo **rechazada** · SEM spend $0 hasta Test  
+
+**Prototype 2026-08-03:** HU-01 / HU-02 / HU-03 implementados en código (DoD local). Pendiente: deploy Pages + HU-04 en prod.
+
+## Resumen ejecutivo
+
+| ID | Título | Prio | Superficie |
+|----|--------|------|------------|
+| **HU-01** | SEO root marca Viento Norte | P0 | `https://vientonorte.io/` |
+| **HU-02** | SEM URL — canonical + meta message-match | P0 | `https://vientonorte.io/#/consultoria` |
+| **HU-03** | Sitemap + robots al día | P0 | `sitemap.xml` / `robots.txt` |
+| **HU-04** | Gate SEM sin gastar (Q5) | P0 gate | Doc + QA Decider |
+| **HU-05** | Branding FO coherente ES/EN share | P1 | meta + OG |
+| **HU-P2-01** | URLs sin hash (BrowserRouter) | P2 | infra |
+| **HU-P2-02** | CWV monitor continuo | P2 | Lighthouse/GSC |
+
+## Reglas
+
+1. **Diseño antes de código:** no se declara done por commit exploratorio; se cierra por CA de cada HU.  
+2. **SEM spend = $0** hasta Test del embudo (DS).  
+3. **Lab admin / OB-RIA** no entra en estas HUs (apuesta B, otro slice).  
+4. **Hash `#`** es constraint actual; limpieza de URL = P2.
+
+## Flujo
+
+```
+✅ Firma DoR Decider (2026-08-03)
+  → Prototype HU-01/02/03/05 → deploy
+  → HU-04 checklist Decider → (DS Test path) → SEM opcional
+```
+
+Detalle completo (CA tablas, DoR/DoD, riesgos): vault Obsidian link arriba.

--- a/docs/audits/QA-SEO-SEM-PLAN-2026-08-03.md
+++ b/docs/audits/QA-SEO-SEM-PLAN-2026-08-03.md
@@ -1,0 +1,98 @@
+# Auditoría QA · SEO · SEM — plan aplicado 2026-08-03
+
+**Fuente PDF:** `docs/audits/Auditoria_Vientonorte_QA_SEO_2026-07.pdf`  
+**Decider:** Rö · **Marco:** Design Sprint VN (Map) · no SEM spend sin Test path  
+**Live:**
+
+| Uso | URL canónica |
+|-----|----------------|
+| **SEO orgánico** | https://vientonorte.io/ |
+| **SEM / paid final URL** | https://vientonorte.io/#/consultoria |
+
+---
+
+## 1 · Hallazgos del PDF (resumen)
+
+| Dimensión | Estado pre-fix | Acción PDF |
+|-----------|-----------------|------------|
+| SEO técnico SPA + hash | HashRouter `/#/…` | Meta estáticos + JSON-LD; SSR = P2 |
+| CWV / Lighthouse | CI `lighthouse.yml` existe | Monitoreo GSC + no regresar CLS |
+| SEM captación | URL oferta definida | Message-match + keywords; **no gastar** sin Test |
+| QA / E2E | CI build-smoke | E2E Playwright = parking |
+| Branding | Meta home decía “Rodrigo Gaete · UX Lead” | Alinear a **Viento Norte** FO |
+
+---
+
+## 2 · Aplicado 2026-08-03 (código)
+
+### SEO — `https://vientonorte.io/`
+
+- [x] Title/description **marca VN** (i18n `seo.pages.home` ES/EN) — deja de ser portfolio personal en Helmet
+- [x] Keywords orgánicos FO (pyme, UXtech, módulos, WCAG)
+- [x] Static `index.html`: description alineada a hero live · OG/Twitter · **JSON-LD** Organization + WebSite + ProfessionalService
+- [x] `link rel="alternate"` hacia SEM offer URL
+- [x] `sitemap.xml` lastmod 2026-08-03 · prioridad root 1.0
+
+### SEM — `https://vientonorte.io/#/consultoria`
+
+- [x] **Bugfix:** `canonical` en superficie SEM apuntaba a `ROUTES.consultingFunnel` (`/`) → ahora `ROUTES.consulting` (`/consultoria`) → `https://vientonorte.io/#/consultoria`
+- [x] Title/description message-match (“Elige tu alcance” / diagnóstico·prototipo·proceso·app)
+- [x] Keywords SEM propios (design sprint, arquitectura fintech, flujos UX) vía `seo.pages.consultoria.keywords`
+- [x] `data-role="fo-sem-offer"` (antes `fo-funnel-legacy`)
+- [x] Constantes `SEO_SITE.semOfferUrl` / `seoHomeUrl` en `src/lib/seo.ts`
+
+### Branding (Google + Ads message-match)
+
+| Capa | Canon |
+|------|--------|
+| Marca pública | **Viento Norte** (no wordmark personal en FO B2B) |
+| Root SEO | Módulos / UXtech / dueño del dato |
+| SEM landing | Elige alcance · free a11y · kickoff &lt;24 h |
+| Persona / casos | `/#/sobre-mi`, `/#/proyectos` — no final URL de ads pyme |
+
+---
+
+## 3 · Buenas prácticas Google (checklist)
+
+| Práctica | Estado |
+|----------|--------|
+| Title único y ≤ ~60 chars | Home / consultoria revisados |
+| Meta description ~155–160 | Trim en `SEOHead` |
+| Canonical por superficie | Fix SEM 03 ago |
+| OG + Twitter estáticos (share sin JS) | `index.html` |
+| Structured data JSON-LD | `index.html` @graph |
+| robots + sitemap | `public/robots.txt` · `public/sitemap.xml` |
+| Final URL Ads = landing real | `/#/consultoria` documentada |
+| Message-match anuncio ↔ H1/CTA | Copy hero ya live; meta alineada |
+| No gastar SEM sin path usable | Gate DS (Test) — **sin spend en este PR** |
+| URLs sin hash (path history) | **P2** — requiere BrowserRouter + 404 SPA + retest |
+
+---
+
+## 4 · No aplicado (parking / DS)
+
+| Ítem | Por qué |
+|------|---------|
+| SSR / pre-render por ruta | Scope infra; hash limita indexación profunda |
+| GTM / GA4 full / SEM live | Post-Test embudo (DS rule) |
+| E2E Playwright suite | QA P1; CI smoke ya existe |
+| Lab admin OB-RIA | Pre-Decide B; Sketch/Decide, no SEO |
+| BrowserRouter migration | Mejora URL “limpia”; proyecto aparte |
+
+---
+
+## 5 · Verificación post-deploy
+
+1. View-source `https://vientonorte.io/` → JSON-LD + title VN  
+2. Abrir `/#/consultoria` → DevTools `<link rel="canonical">` = `https://vientonorte.io/#/consultoria`  
+3. Document title SEM ≠ home  
+4. GSC: reenviar sitemap cuando Pages despliegue  
+5. Ads (cuando Test OK): final URL exacta `https://vientonorte.io/#/consultoria`
+
+---
+
+## 6 · Relación Design Sprint
+
+- Map 03 ago: path FO usable + superficies B  
+- SEO/SEM técnico aquí = **habilita** Q5 (message-match antes de gastar)  
+- No reemplaza Test humano ni Decide de lab

--- a/index.html
+++ b/index.html
@@ -24,17 +24,19 @@
     <title>Viento Norte · UXtech · Módulos a medida</title>
     <meta
       name="description"
-      content="Viento Norte — UXtech y front office. Software que se instala, no se alquila la nube. Módulos a medida, dueño del dato. Consultoría y craft enterprise."
+      content="Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. UXtech y front office. Software que se instala, dueño del dato. Consultoría y craft enterprise."
     />
     <meta
       name="keywords"
-      content="Viento Norte, UXtech, consultoría UX, módulos producto, fintech, Design Ops, accesibilidad, dueño del dato, front office"
+      content="Viento Norte, UXtech, consultoría UX, módulos a medida, front office, fintech, Design Ops, accesibilidad WCAG, dueño del dato, design sprint, pyme Chile"
     />
 
-    <!-- Canonical brand root (no /mi-portafolio/) -->
+    <!-- Canonical brand root (no /mi-portafolio/) — SEO orgánico -->
     <link rel="canonical" href="https://vientonorte.io/" />
+    <!-- SEM paid final URL (HashRouter; crawlers + Ads message-match) -->
+    <link rel="alternate" href="https://vientonorte.io/#/consultoria" title="Consultoría · Elige tu alcance" />
 
-    <!-- Open Graph -->
+    <!-- Open Graph (static — no JS required for share/crawlers) -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Viento Norte" />
     <meta property="og:locale" content="es_CL" />
@@ -42,7 +44,7 @@
     <meta property="og:title" content="Viento Norte · UXtech · Módulos a medida" />
     <meta
       property="og:description"
-      content="Software que se instala. Módulos a medida, sin nube obligatoria. Front office y craft enterprise."
+      content="Tecnología para empresas: diagnóstico, prototipo, proceso o app. Software que se instala, dueño del dato."
     />
     <meta
       property="og:image"
@@ -55,15 +57,64 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://vientonorte.io/" />
-    <meta name="twitter:title" content="Viento Norte · UXtech" />
+    <meta name="twitter:title" content="Viento Norte · UXtech · Módulos a medida" />
     <meta
       name="twitter:description"
-      content="Módulos a medida, dueño del dato. Front office y craft enterprise."
+      content="Tecnología para empresas. Módulos a medida, dueño del dato. Front office y craft enterprise."
     />
     <meta
       name="twitter:image"
       content="https://vientonorte.io/images/branding/og-portfolio.png"
     />
+
+    <!-- JSON-LD (Google rich results / Knowledge — static, pre-JS) · Audit QA SEO 2026-07 -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Organization",
+            "@id": "https://vientonorte.io/#organization",
+            "name": "Viento Norte",
+            "url": "https://vientonorte.io/",
+            "logo": "https://vientonorte.io/icon-512x512.png",
+            "description": "UXtech y front office. Módulos a medida, software que se instala, dueño del dato.",
+            "founder": {
+              "@type": "Person",
+              "name": "Rodrigo Gaete",
+              "jobTitle": "UX Lead"
+            },
+            "areaServed": "CL",
+            "sameAs": []
+          },
+          {
+            "@type": "WebSite",
+            "@id": "https://vientonorte.io/#website",
+            "url": "https://vientonorte.io/",
+            "name": "Viento Norte",
+            "description": "Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app funcional.",
+            "publisher": { "@id": "https://vientonorte.io/#organization" },
+            "inLanguage": "es-CL"
+          },
+          {
+            "@type": "ProfessionalService",
+            "@id": "https://vientonorte.io/#consultoria",
+            "name": "Consultoría UX · Viento Norte",
+            "url": "https://vientonorte.io/#/consultoria",
+            "image": "https://vientonorte.io/images/branding/og-portfolio.png",
+            "provider": { "@id": "https://vientonorte.io/#organization" },
+            "areaServed": { "@type": "Country", "name": "Chile" },
+            "serviceType": [
+              "Consultoría UX",
+              "Design Sprint",
+              "Accesibilidad WCAG",
+              "Front office producto"
+            ],
+            "description": "Diagnóstico, prototipo, proceso de equipo o app. Entrada gratis: accesibilidad WCAG 2.2 AA de un flujo crítico."
+          }
+        ]
+      }
+    </script>
 
     <meta name="theme-color" content="#0d1b3d" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#050a14" media="(prefers-color-scheme: dark)" />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,45 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- SEO orgánico · root (prioridad indexación) -->
   <url>
     <loc>https://vientonorte.io/</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <!-- SEM paid final URL · tour oferta (HashRouter; Google indexa con JS o via Search Console) -->
   <url>
     <loc>https://vientonorte.io/#/consultoria</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.95</priority>
   </url>
   <url>
-    <loc>https://vientonorte.io/#/consultoria/embudo</loc>
-    <lastmod>2026-07-28</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://vientonorte.io/#/contacto</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.85</priority>
   </url>
   <url>
     <loc>https://vientonorte.io/#/proyectos</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://vientonorte.io/#/proceso</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
     <loc>https://vientonorte.io/#/sobre-mi</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.65</priority>
+  </url>
+  <!-- Legacy embudo → redirige a home; se mantiene baja prioridad por bookmarks -->
+  <url>
+    <loc>https://vientonorte.io/#/consultoria/embudo</loc>
+    <lastmod>2026-08-03</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
   </url>
 </urlset>

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -25,6 +25,11 @@ interface ConsultoriaLandingHeroProps {
  * Hero consultoría — mínimo conversion:
  * Empezar · Ver opciones · link free sutil.
  * Sin grilla de 4 ofertas (duplicaba #modalidades).
+ *
+ * Decider 2026-08-03 (DS Map · no re-Map):
+ * - Empezar → onboarding en la **misma superficie** (home o SEM), nunca “saltar” a SEM desde home.
+ * - SEM `/#/consultoria` es solo **entrada paid**; home SEO convierte in-place.
+ * - Rechazado: “¿tour módulos fullscreen convierte más que embudo home?”
  */
 export function ConsultoriaLandingHero({
   onStartOnboarding,

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -32,13 +32,14 @@ export default {
     },
     
     seo: {
+      /** Root SEO keywords — Viento Norte brand, not personal portfolio */
       keywords:
-        'Design Ops, UX Lead, regulatory compliance, premium experiences, fintech, mobility, SURA, Transvip, Karri',
+        'Viento Norte, UXtech, UX consulting, custom modules, front office, fintech, Design Ops, WCAG accessibility, own your data, SMB',
       pages: {
         home: {
-          title: 'Rodrigo Gaete · UX Lead',
+          title: 'Viento Norte · UXtech · Custom modules',
           description:
-            'UX Lead using Design Ops as a method: regulated products and mobility. Cases at SURA, Transvip, and Karri.',
+            'Technology for businesses: diagnostic, prototype, team process, or working app. Software you install — own your data. Consulting and enterprise craft.',
         },
         proyectos: {
           title: 'Business · UX Lead',
@@ -81,9 +82,12 @@ export default {
             'Strategic UX/UI audit: risks, SEO quick wins, and a 3-session mentorship plan.',
         },
         consultoria: {
-          title: 'UX Consulting · Viento Norte',
+          /** SEM final URL: https://vientonorte.io/#/consultoria — Ads message-match */
+          title: 'UX Consulting · Choose your scope',
           description:
-            'Free Diagnostic entry: WCAG 2.2 AA on one critical flow. Prototype, team process, or working app. SMBs · kickoff <24h.',
+            'Diagnostic, prototype, team process, or app. Design sprint and UX flows. Free: WCAG 2.2 AA on one critical flow. SMBs · kickoff <24h.',
+          keywords:
+            'UX consulting, design sprint, fintech architecture, UX flows, UXtech, product modules, WCAG accessibility, front office, Viento Norte',
         },
         grafo: {
           title: 'Institutional friction network',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -32,13 +32,14 @@ export default {
     },
     
     seo: {
+      /** Keywords SEO root (orgánico) — marca Viento Norte, no portfolio personal */
       keywords:
-        'Design Ops, UX Lead, cumplimiento regulatorio, experiencias premium, fintech, mobility, SURA, Transvip, Karri',
+        'Viento Norte, UXtech, consultoría UX, módulos a medida, front office, fintech, Design Ops, accesibilidad WCAG, dueño del dato, pyme Chile',
       pages: {
         home: {
-          title: 'Rodrigo Gaete · UX Lead',
+          title: 'Viento Norte · UXtech · Módulos a medida',
           description:
-            'UX Lead con Design Ops como método: productos regulados y mobility. Casos en SURA, Transvip y Karri.',
+            'Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. Software que se instala, dueño del dato. Consultoría y craft enterprise.',
         },
         proyectos: {
           title: 'Negocios · UX Lead',
@@ -81,9 +82,12 @@ export default {
             'Auditoría estratégica UX/UI: riesgos, quick wins SEO y plan de mentoría en 3 sesiones.',
         },
         consultoria: {
-          title: 'Consultoría UX · Viento Norte',
+          /** SEM final URL: https://vientonorte.io/#/consultoria — message-match Ads */
+          title: 'Consultoría UX · Elige tu alcance',
           description:
-            'Entrada gratis a Diagnóstico: WCAG 2.2 AA de un flujo crítico. Prototipo, proceso de equipo o app funcional. Pymes · kickoff <24 h.',
+            'Diagnóstico, prototipo, proceso de equipo o app. Design sprint y flujos UX. Gratis: accesibilidad WCAG 2.2 AA de un flujo. Pymes · kickoff <24 h.',
+          keywords:
+            'consultoría UX, design sprint, arquitectura fintech, flujos UX, UXtech, módulos producto, accesibilidad WCAG, front office, Viento Norte',
         },
         grafo: {
           title: 'Red de fricción institucional',

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -6,6 +6,13 @@ export const SEO_SITE = {
   ogImage: "https://vientonorte.io/images/branding/og-portfolio.png",
   brand: "Viento Norte",
   role: "UXtech · Front office",
+  /** SEO orgánico (root) */
+  seoHomeUrl: "https://vientonorte.io/",
+  /**
+   * SEM paid final URL (HashRouter · Google Ads final URL).
+   * Message-match: landing oferta `/#/consultoria` — no gastar SEM sin Test path.
+   */
+  semOfferUrl: "https://vientonorte.io/#/consultoria",
   /** Legacy path (GitHub project pages / bookmarks) */
   legacyBasePath: "/mi-portafolio",
 } as const;

--- a/src/pages/ConsultoriaVientoNorte.tsx
+++ b/src/pages/ConsultoriaVientoNorte.tsx
@@ -184,7 +184,7 @@ export default function ConsultoriaVientoNorte() {
       <div
         data-surface="consultoria-funnel"
         data-testid="consultoria-funnel"
-        data-role={isHomeSurface ? "fo-home" : "fo-funnel-legacy"}
+        data-role={isHomeSurface ? "fo-home" : "fo-sem-offer"}
         data-first-value-budget-ms={29000}
         data-calendar-sla-ms={30000}
         data-analytics="deferred-no-gtm"
@@ -192,9 +192,13 @@ export default function ConsultoriaVientoNorte() {
         <SEOHead
           {...(isHomeSurface ? t.seo.pages.home : t.seo.pages.consultoria)}
           isHome={isHomeSurface}
-          keywords={t.seo.keywords}
+          keywords={
+            isHomeSurface
+              ? t.seo.keywords
+              : (t.seo.pages.consultoria.keywords ?? t.seo.keywords)
+          }
           url={canonicalFromPath(
-            isHomeSurface ? ROUTES.home : ROUTES.consultingFunnel
+            isHomeSurface ? ROUTES.home : ROUTES.consulting
           )}
         />
 


### PR DESCRIPTION
## Summary
- **HU-01** SEO root: Viento Norte brand meta (not personal portfolio) + static JSON-LD
- **HU-02** SEM `/#/consultoria`: fix canonical → `ROUTES.consulting` + message-match titles/keywords
- **HU-03** sitemap lastmod + priority SEM; docs HUs + plan audit
- Decider: Empezar → onboarding on-surface (not jump home→SEM); SEM spend gated post-Test

## Test plan
- [ ] View-source https://vientonorte.io/ → JSON-LD + title VN
- [ ] `/#/consultoria` → document.title + canonical `#/consultoria`
- [ ] Smoke FO H2/H4/H5/S2 (humano)
- [ ] Firmas multi-device (I15/W11…)

## Deploy
Merge → Actions Deploy Pages → ops AHORA: post-deploy + Test path gate (no SEM $)