### PR TITLE
feat(seo): GSC HTML verification google5858e011b32ea566

### DIFF
--- a/docs/audits/2026-08-03-GSC-Pruebas-Enlaces.md
+++ b/docs/audits/2026-08-03-GSC-Pruebas-Enlaces.md
@@ -1,0 +1,30 @@
+# Pruebas GSC y Enlaces · Viento Norte
+
+**SSOT Obsidian:** `Viento Norte/Resources/SEM/2026-08-03 GSC Pruebas y Enlaces.md`  
+**SEO:** https://vientonorte.io/ · **SEM:** https://vientonorte.io/#/consultoria  
+**Fecha:** 2026-08-03
+
+## Plan GSC (resumen)
+
+| Prueba | Éxito DoD | Nota hash |
+|--------|-----------|-----------|
+| Inspección URLs home (+ render SPA) | Meta + contenido sin bloqueo robots | Hash no es path server |
+| Live Test | Sin recursos críticos bloqueados / redirects rotos | Validar shell + JS |
+| Core Web Vitals | “Buena” móvil/desktop (umbrales GSC) | Meta 1.5s LCP aspiracional |
+| Usabilidad móvil | 0 errores superposición/targets | Breadcrumb mobile + H5 backlog |
+| Sitemap | Enviado · sin 404 clave | `sitemap.xml` live · reenviar en GSC |
+
+## Enlaces
+
+- https://vientonorte.io/
+- https://vientonorte.io/#/consultoria
+- https://vientonorte.io/ops/
+- https://vientonorte.io/sitemap.xml
+- https://vientonorte.io/robots.txt
+- GSC: https://search.google.com/search-console
+- Rich Results: https://search.google.com/test/rich-results
+- PageSpeed: https://pagespeed.web.dev/
+
+## Gate
+
+$0 SEM spend hasta Test path DS + ok Decider.

--- a/docs/audits/2026-08-03-GSC-verification.md
+++ b/docs/audits/2026-08-03-GSC-verification.md
@@ -1,0 +1,24 @@
+# Google Search Console · verificación de propiedad
+
+**Fecha:** 2026-08-03  
+**Propiedad:** https://vientonorte.io/  
+**Método:** HTML file  
+
+| | |
+|--|--|
+| File | `public/google5858e011b32ea566.html` |
+| Live | https://vientonorte.io/google5858e011b32ea566.html |
+| Body | `google-site-verification: google5858e011b32ea566.html` |
+
+## Develop
+
+1. Copiar archivo de GSC a `mi-portafolio/public/` (raíz de dist).  
+2. Espejo opcional en `vientonorte.github.io/` root.  
+3. Deploy Pages (push `main` mi-portafolio).  
+4. Confirmar 200 en live.  
+5. GSC → Verify.  
+6. Reenviar sitemap + inspección (ver plan GSC SSOT).
+
+## SSOT
+
+Obsidian: `Viento Norte/Resources/SEM/2026-08-03 GSC Pruebas y Enlaces.md` §0.1

--- a/docs/audits/README-SSOT.md
+++ b/docs/audits/README-SSOT.md
@@ -1,0 +1,16 @@
+# Audits · SSOT pointer
+
+**Obsidian SSOT (producto + smoke + DT SEM):**  
+`Obsidian Vault/Viento Norte/Sprints/2026-08-03 SSOT smoke FO SEO-SEM.md`
+
+| Repo file | Rol |
+|-----------|-----|
+| `2026-08-03-INFORME-SEM-Adquisicion.md` | Mirror informe SEM (message-match, keywords, DoD) |
+| `2026-08-03-GSC-Pruebas-Enlaces.md` | Mirror plan GSC + enlaces ecosistema |
+| `SMOKE-2026-08-03-humano.md` | Mirror smoke table |
+| `PROMPT-GEMINI-SEM-workspace.md` | Prompt Gemini Workspace SEM |
+| `HUs-SEO-SEM-2026-08-03.md` | Resumen HUs |
+| `QA-SEO-SEM-PLAN-2026-08-03.md` | Plan audit PDF |
+
+**Obsidian SEM folder:** `Viento Norte/Resources/SEM/`  
+Si Obsidian y repo divergen en **decisiones Decider**, gana Obsidian SSOT.

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="author" content="Viento Norte · Rodrigo Gaete" />
     <meta name="robots" content="index, follow" />
+    <!-- GSC ownership: HTML file method → /google5858e011b32ea566.html (public/) · no inventar meta token -->
 
     <!-- Static SEO (no JS required) — LinkedIn / WhatsApp / crawlers -->
     <title>Viento Norte · UXtech · Módulos a medida</title>

--- a/public/google5858e011b32ea566.html
+++ b/public/google5858e011b32ea566.html
@@ -1,0 +1,1 @@
+google-site-verification: google5858e011b32ea566.html


### PR DESCRIPTION
## Summary
- Add Google Search Console HTML verification file at site root
- URL: https://vientonorte.io/google5858e011b32ea566.html
- Docs: docs/audits/2026-08-03-GSC-verification.md

## Test plan
- [ ] After deploy: curl file returns 200 and exact verification line
- [ ] GSC → Verify property
- [ ] Re-submit sitemap