### PR TITLE
ci(qa)+api: preprod gate, deploy after CI, contact.vientonorte.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,11 @@
 name: Deploy to GitHub Pages
 
+# Gate: only after CI is green on main (no race with failing tests).
+# Manual: workflow_dispatch for emergency redeploy (still runs local build steps).
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -10,19 +14,42 @@ permissions:
   pages: write
   packages: read
   id-token: write
+  actions: read
 
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
+  # Fail closed if CI did not succeed (skip entirely on red CI).
+  guard:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+    steps:
+      - id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "Deploying commit from green CI: ${{ github.event.workflow_run.head_sha }}"
+          else
+            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — deploying ${{ github.ref }} @ ${{ github.sha }}"
+          fi
+
   build-and-deploy:
+    needs: guard
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: https://vientonorte.io/
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.guard.outputs.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -36,6 +63,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.VN_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - run: npm run sync:images
+
+      # Pre-prod technical gates (mirror scripts/preprod-gate.sh L1) before ship
+      - name: Preprod gate — typecheck
+        run: npm run type-check
+
+      - name: Preprod gate — unit tests
+        run: npm test
+
+      - name: Preprod gate — nav
+        run: npm run qa:nav
 
       - name: Build SPA at domain root (base /)
         run: npx vite build
@@ -52,11 +89,22 @@ jobs:
           VITE_A11Y_FREE_SCHEDULE_URL: ${{ secrets.VITE_A11Y_FREE_SCHEDULE_URL }}
           VITE_VIDEO_CALL_URL: ${{ secrets.VITE_VIDEO_CALL_URL }}
 
+      - name: Artifact smoke (domain root)
+        run: |
+          set -euo pipefail
+          test -f dist/index.html
+          grep -q 'id="root"' dist/index.html
+          if grep -qi 'mi-portafolio/assets' dist/index.html; then
+            echo "Stale /mi-portafolio/assets in index" >&2
+            exit 1
+          fi
+          JS=$(find dist/assets -name '*.js' | wc -l | tr -d ' ')
+          test "$JS" -ge 1
+
       - name: SPA fallback + legacy /mi-portafolio redirect
         run: |
           cp dist/index.html dist/404.html
           mkdir -p dist/mi-portafolio
-          # already copied from public/mi-portafolio if present; ensure redirect
           if [ ! -f dist/mi-portafolio/index.html ]; then
             cp public/mi-portafolio/index.html dist/mi-portafolio/index.html
           fi
@@ -76,7 +124,6 @@ jobs:
             echo "WARN: hub ops/ missing" >&2
           fi
 
-      # Primary brand site: org root (CNAME lives on hub today — publish SPA there)
       - name: Publish brand site to vientonorte.github.io root
         env:
           HUB_TOKEN: ${{ secrets.VN_HUB_DEPLOY_TOKEN || secrets.VN_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
@@ -87,24 +134,18 @@ jobs:
           rm -rf /tmp/vn-hub-pub
           git clone --depth 1 "https://x-access-token:${HUB_TOKEN}@github.com/vientonorte/vientonorte.github.io.git" /tmp/vn-hub-pub
           cd /tmp/vn-hub-pub
-          # preserve non-site dirs
-          KEEP="ops data docs pipeline tests scripts img .github .gitignore CNAME README.md CHANGELOG.md package.json package-lock.json"
-          # remove previous SPA artifacts at root (not ops)
           find . -maxdepth 1 -type f \( -name 'index.html' -o -name '404.html' -o -name 'sw.js' -o -name 'manifest.json' -o -name 'robots.txt' -o -name 'sitemap.xml' -o -name 'favicon.*' -o -name 'icon-*.png' -o -name 'profile-photo.jpg' -o -name 'cv-*.pdf' \) -delete || true
           rm -rf assets fonts images resources mi-portafolio 2>/dev/null || true
-          # copy new dist (includes ops if bundled)
           cp -R "$GITHUB_WORKSPACE/dist/." .
-          # ensure CNAME stays brand domain
           echo "vientonorte.io" > CNAME
           git add -A
           if git diff --cached --quiet; then
             echo "No hub changes"
           else
-            git commit -m "deploy: Viento Norte SPA at domain root (from mi-portafolio)"
+            git commit -m "deploy: Viento Norte SPA at domain root (from mi-portafolio, post-CI gate)"
             git push origin HEAD:main
           fi
 
-      # Project Pages still updated so /mi-portafolio/ serves redirect-friendly SPA/shell
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -109,7 +109,11 @@
     "clean": "rm -rf dist coverage",
     "reset": "npm run clean && npm install",
     "prepare": "husky",
-    "smoke:cierre": "bash ~/.grok/skills/seo-vn/scripts/cierre-smoke.sh http://127.0.0.1:5173"
+    "smoke:cierre": "bash ~/.grok/skills/seo-vn/scripts/cierre-smoke.sh http://127.0.0.1:5173",
+    "preprod": "bash scripts/preprod-gate.sh",
+    "preprod:quick": "bash scripts/preprod-gate.sh --quick",
+    "preprod:dev": "bash scripts/preprod-gate.sh --with-dev",
+    "preprod:routes": "bash scripts/preprod-gate.sh --with-routes"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "^1.1.4"

--- a/scripts/preprod-gate.sh
+++ b/scripts/preprod-gate.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# preprod-gate · single entry for FO (mi-portafolio) before merge / deploy
+# Layers: unit → build → static smoke → optional local SEO/ads → optional playwright
+#
+# Usage:
+#   bash scripts/preprod-gate.sh              # full local gate (needs nothing on :5173 for L1-L3)
+#   bash scripts/preprod-gate.sh --quick      # typecheck + unit + build only
+#   bash scripts/preprod-gate.sh --with-dev   # also cierre-smoke against BASE
+#   bash scripts/preprod-gate.sh --with-routes # build + serve + qa-routes (needs playwright)
+#   BASE=http://127.0.0.1:5173 bash scripts/preprod-gate.sh --with-dev
+#
+# Exit: 0 = GO technical · 1 = NO-GO · 2 = env / misconfig
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+QUICK=0
+WITH_DEV=0
+WITH_ROUTES=0
+BASE="${BASE:-http://127.0.0.1:5173}"
+BASE="${BASE%/}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --quick) QUICK=1 ;;
+    --with-dev) WITH_DEV=1 ;;
+    --with-routes) WITH_ROUTES=1 ;;
+    --help|-h)
+      sed -n '2,16p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+PASS=0
+FAIL=0
+SKIP=0
+REPORT=()
+
+ok()   { PASS=$((PASS + 1)); REPORT+=("PASS  $1"); echo "✓ $1"; }
+bad()  { FAIL=$((FAIL + 1)); REPORT+=("FAIL  $1"); echo "✗ $1" >&2; }
+skip() { SKIP=$((SKIP + 1)); REPORT+=("SKIP  $1"); echo "· $1 (skip)"; }
+
+run_step() {
+  local name="$1"
+  shift
+  echo ""
+  echo "── $name ──"
+  if "$@"; then
+    ok "$name"
+    return 0
+  fi
+  bad "$name"
+  return 1
+}
+
+echo "══════════════════════════════════════════"
+echo " VN preprod-gate · FO mi-portafolio"
+echo " ROOT=$ROOT"
+echo " BASE=$BASE  quick=$QUICK dev=$WITH_DEV routes=$WITH_ROUTES"
+echo "══════════════════════════════════════════"
+
+# ── L1: static quality ─────────────────────────────────────────
+run_step "type-check" npm run type-check || true
+run_step "unit tests" npm test || true
+run_step "nav config" npm run qa:nav || true
+
+if [[ "$QUICK" -eq 1 ]]; then
+  echo ""
+  echo "── quick mode: skip build/preview ──"
+else
+  run_step "build" npm run build || true
+
+  # L2: static artifact smoke (no browser)
+  if [[ -d dist && -f dist/index.html ]]; then
+    if grep -q 'id="root"' dist/index.html; then
+      ok "dist has #root"
+    else
+      bad "dist has #root"
+    fi
+    JS_COUNT=$(find dist/assets -name '*.js' 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "${JS_COUNT:-0}" -ge 1 ]]; then
+      ok "dist has JS assets ($JS_COUNT)"
+    else
+      bad "dist has JS assets"
+    fi
+    # domain-root base: assets must be /assets/ not /mi-portafolio/assets/
+    if grep -qE 'src="/assets/[^"]+\.js"' dist/index.html || grep -qE "src='/assets/[^']+\.js'" dist/index.html; then
+      ok "index uses domain-root /assets/"
+    else
+      # vite may use relative assets
+      if grep -qE 'assets/.*\.js' dist/index.html; then
+        ok "index references assets (relative or absolute)"
+      else
+        bad "index missing assets script"
+      fi
+    fi
+    if grep -qi 'mi-portafolio/assets' dist/index.html; then
+      bad "index still points at /mi-portafolio/assets (stale base)"
+    else
+      ok "no stale /mi-portafolio/assets in index"
+    fi
+  else
+    bad "dist/ missing after build"
+  fi
+fi
+
+# ── L3: preview server + curl gates (build artifact) ───────────
+if [[ "$QUICK" -eq 0 && -d dist ]]; then
+  echo ""
+  echo "── preview curl smoke ──"
+  PREVIEW_PORT="${PREVIEW_PORT:-4179}"
+  python3 -m http.server "$PREVIEW_PORT" --directory dist >/tmp/vn-preprod-http.log 2>&1 &
+  HTTP_PID=$!
+  cleanup_http() { kill "$HTTP_PID" 2>/dev/null || true; }
+  trap cleanup_http EXIT
+
+  READY=0
+  for _ in $(seq 1 25); do
+    if curl -fsS "http://127.0.0.1:${PREVIEW_PORT}/" -o /tmp/vn-preprod-index.html; then
+      READY=1
+      break
+    fi
+    sleep 0.3
+  done
+
+  if [[ "$READY" -ne 1 ]]; then
+    bad "preview server :$PREVIEW_PORT"
+  else
+    ok "preview server :$PREVIEW_PORT"
+    if grep -q 'id="root"' /tmp/vn-preprod-index.html; then
+      ok "preview HTML #root"
+    else
+      bad "preview HTML #root"
+    fi
+    # title / brand markers (static shell)
+    if grep -qiE 'viento|norte|UX|consultor' /tmp/vn-preprod-index.html; then
+      ok "preview brand markers in shell"
+    else
+      skip "preview brand markers (SPA shell may be minimal)"
+    fi
+  fi
+
+  cleanup_http
+  trap - EXIT
+fi
+
+# ── L4: Playwright routes (optional) ───────────────────────────
+if [[ "$WITH_ROUTES" -eq 1 ]]; then
+  if [[ ! -d dist ]]; then
+    bad "routes need dist (run without --quick)"
+  else
+    echo ""
+    echo "── playwright routes ──"
+    PREVIEW_PORT="${PREVIEW_PORT:-4179}"
+    npx --yes serve dist -l "$PREVIEW_PORT" >/tmp/vn-preprod-serve.log 2>&1 &
+    SERVE_PID=$!
+    cleanup_serve() { kill "$SERVE_PID" 2>/dev/null || true; }
+    trap cleanup_serve EXIT
+    READY=0
+    for _ in $(seq 1 40); do
+      if curl -fsS "http://127.0.0.1:${PREVIEW_PORT}/" >/dev/null; then
+        READY=1
+        break
+      fi
+      sleep 0.5
+    done
+    if [[ "$READY" -ne 1 ]]; then
+      bad "serve for routes"
+    else
+      if node scripts/qa-routes.mjs "http://127.0.0.1:${PREVIEW_PORT}"; then
+        ok "qa-routes"
+      else
+        bad "qa-routes"
+      fi
+    fi
+    cleanup_serve
+    trap - EXIT
+  fi
+fi
+
+# ── L5: local SEO/Ads cierre-smoke (optional, needs dev server) ─
+if [[ "$WITH_DEV" -eq 1 ]]; then
+  echo ""
+  echo "── cierre-smoke (SEO+Ads local) ──"
+  if curl -sf -o /dev/null --max-time 3 "$BASE/" || curl -sf -o /dev/null --max-time 3 "$BASE"; then
+    SMOKE="$HOME/.grok/skills/seo-vn/scripts/cierre-smoke.sh"
+    if [[ -f "$SMOKE" ]]; then
+      if bash "$SMOKE" "$BASE"; then
+        ok "cierre-smoke $BASE"
+      else
+        bad "cierre-smoke $BASE"
+      fi
+    else
+      bad "cierre-smoke script missing"
+    fi
+  else
+    bad "dev server not up at $BASE (npm run dev)"
+  fi
+fi
+
+# ── summary ────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════"
+echo " preprod-gate summary"
+echo " PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
+for line in "${REPORT[@]}"; do
+  echo "  $line"
+done
+echo "══════════════════════════════════════════"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "NO-GO technical · fix before PR/merge/deploy"
+  echo "Human Test path (H2/H4/H5/S2) still required after this: /ops/AHORA-CLOSE-CHECKLIST.md"
+  exit 1
+fi
+
+echo "GO technical · CI-equivalent local gate green"
+echo "Next: human people-QA + Test path → then ship"
+echo "  /ops/AHORA-CLOSE-CHECKLIST.md · vn-qa · canvas-sprint release"
+exit 0

--- a/scripts/qa-production.sh
+++ b/scripts/qa-production.sh
@@ -1,44 +1,18 @@
 #!/usr/bin/env bash
-# Smoke QA contra GitHub Pages en producción.
+# Smoke QA contra producción (domain root).
+# Default: https://vientonorte.io  (legacy override: BASE_URL=https://vientonorte.github.io)
 set -euo pipefail
 
-BASE_URL="${BASE_URL:-https://vientonorte.github.io/mi-portafolio}"
+BASE_URL="${BASE_URL:-https://vientonorte.io}"
+BASE_URL="${BASE_URL%/}"
 PASS=0
 FAIL=0
-
-check_url() {
-  local label="$1"
-  local pattern="$2"
-  local url="$3"
-
-  if curl -fsSL "$url" | grep -q "$pattern"; then
-    echo "✓ $label"
-    PASS=$((PASS + 1))
-  else
-    echo "✗ $label (missing: $pattern)"
-    FAIL=$((FAIL + 1))
-  fi
-}
-
-check_content() {
-  local label="$1"
-  local pattern="$2"
-  local file="$3"
-
-  if grep -q "$pattern" "$file"; then
-    echo "✓ $label"
-    PASS=$((PASS + 1))
-  else
-    echo "✗ $label (missing: $pattern)"
-    FAIL=$((FAIL + 1))
-  fi
-}
 
 check_http() {
   local label="$1"
   local url="$2"
   local code
-  code=$(curl -fsSL -o /dev/null -w "%{http_code}" "$url" || echo "000")
+  code=$(curl -fsSL -o /dev/null -w "%{http_code}" --max-time 20 "$url" || echo "000")
   if [ "$code" = "200" ]; then
     echo "✓ $label (HTTP $code)"
     PASS=$((PASS + 1))
@@ -48,43 +22,79 @@ check_http() {
   fi
 }
 
+check_html() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "✓ $label"
+    PASS=$((PASS + 1))
+  else
+    echo "✗ $label (missing: $pattern)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_not_html() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "✗ $label (found forbidden: $pattern)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "✓ $label"
+    PASS=$((PASS + 1))
+  fi
+}
+
 echo "QA producción — $BASE_URL"
 echo "---"
 
-HTML=$(curl -fsSL "$BASE_URL/")
-JS_PATH=$(echo "$HTML" | grep -oE '/mi-portafolio/assets/index-[^"]+\.js' | head -1)
-test -n "$JS_PATH" || { echo "✗ No JS bundle in index.html"; exit 1; }
-JS_URL="https://vientonorte.github.io${JS_PATH}"
+HTML_FILE=$(mktemp)
 JS_FILE=$(mktemp)
-CASE_FILE=$(mktemp)
-trap 'rm -f "$JS_FILE" "$CASE_FILE"' EXIT
-curl -fsSL "$JS_URL" -o "$JS_FILE"
+trap 'rm -f "$HTML_FILE" "$JS_FILE"' EXIT
 
-check_url "Hero meta description" "reduce el ruido" "$BASE_URL/"
-check_content "8 proyectos en grid" "sura-ux-enterprise" "$JS_FILE"
-check_content "Testimonios section" "testimonios" "$JS_FILE"
-check_content "Karri flagship" "karri-calculadora" "$JS_FILE"
-check_content "SEO keywords proyecto" "shopper UX" "$JS_FILE"
-check_content "i18n featuredCaseStudies" "featuredCaseStudies" "$JS_FILE"
-check_content "Analytics wiring" "VNTracker" "$JS_FILE"
-check_content "Schema.org" "CreativeWork" "$JS_FILE"
+if ! curl -fsSL --max-time 25 "$BASE_URL/" -o "$HTML_FILE"; then
+  echo "✗ Cannot fetch $BASE_URL/"
+  exit 1
+fi
+echo "✓ fetch home"
 
-CASE_CHUNK_FILE=$(grep -oE 'CaseStudies-[A-Za-z0-9_-]+\.js' "$JS_FILE" | head -1 || true)
-if [ -n "$CASE_CHUNK_FILE" ]; then
-  curl -fsSL "$BASE_URL/assets/$CASE_CHUNK_FILE" -o "$CASE_FILE"
-  check_content "Flagship en /proceso chunk" "flagship" "$CASE_FILE"
-  check_content "Ruta canónica /proceso" "/proceso" "$JS_FILE"
-  check_content "Legacy redirect /cases" "/cases" "$JS_FILE"
+# Domain-root SPA: /assets/… not /mi-portafolio/assets/
+JS_PATH=$(grep -oE '/assets/[^"]+\.js' "$HTML_FILE" | head -1 || true)
+if [[ -z "$JS_PATH" ]]; then
+  JS_PATH=$(grep -oE 'assets/[^"]+\.js' "$HTML_FILE" | head -1 || true)
+  if [[ -n "$JS_PATH" && "$JS_PATH" != /* ]]; then
+    JS_PATH="/$JS_PATH"
+  fi
+fi
+
+if [[ -z "$JS_PATH" ]]; then
+  echo "✗ No JS bundle path in index.html"
+  FAIL=$((FAIL + 1))
 else
-  echo "✗ Flagship en /proceso chunk (CaseStudies chunk not in bundle)"
+  echo "✓ JS path $JS_PATH"
+  PASS=$((PASS + 1))
+  curl -fsSL --max-time 30 "${BASE_URL}${JS_PATH}" -o "$JS_FILE" || {
+    echo "✗ JS bundle fetch failed"
+    FAIL=$((FAIL + 1))
+  }
+fi
+
+check_html "shell #root" 'id="root"' "$HTML_FILE"
+check_not_html "no stale /mi-portafolio/assets in shell" '/mi-portafolio/assets/' "$HTML_FILE"
+
+# Title / meta (org brand — not only personal name as sole brand if VN title shipped)
+if grep -qiE 'viento|norte|UX|consultor' "$HTML_FILE"; then
+  echo "✓ brand/meta markers in shell"
+  PASS=$((PASS + 1))
+else
+  echo "✗ brand/meta markers in shell"
   FAIL=$((FAIL + 1))
 fi
 
-check_http "CV PDF" "$BASE_URL/cv-rodrigo-gaete-ux.pdf"
-check_http "Foto perfil" "$BASE_URL/profile-photo.jpg"
-check_http "PWA manifest" "$BASE_URL/manifest.json"
-
-if echo "$HTML" | grep -q 'og:title'; then
+if grep -q 'og:title\|og:description\|property="og:' "$HTML_FILE"; then
   echo "✓ Open Graph tags"
   PASS=$((PASS + 1))
 else
@@ -92,15 +102,31 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# Bundle signals (if JS fetched)
+if [[ -s "$JS_FILE" ]]; then
+  check_html "HashRouter / consultoria path" 'consultoria' "$JS_FILE"
+  check_html "embudo or onboarding markers" 'onboarding|embudo|consultoria-onboarding' "$JS_FILE"
+  check_html "analytics or tracker wiring" 'VNTracker|gtag|GTM|dataLayer' "$JS_FILE"
+fi
+
+# Critical static URLs
+check_http "home" "$BASE_URL/"
+check_http "robots.txt" "$BASE_URL/robots.txt"
+check_http "sitemap.xml" "$BASE_URL/sitemap.xml"
+check_http "favicon" "$BASE_URL/favicon.svg"
+check_http "ops noindex surface" "$BASE_URL/ops/"
+check_http "ops canvas-state" "$BASE_URL/ops/canvas-state.json"
+check_http "finanzas worker" "https://finanzas.vientonorte.io/"
+
+# SEM path is client-side; we only assert shell loads for hash routes via home
+check_http "github.io redirect host" "https://vientonorte.github.io/"
+
 echo "---"
 echo "Resultado: $PASS passed, $FAIL failed"
+echo "Nota: H2/H4/H5/S2 browser smoke es HUMANO → /ops/AHORA-CLOSE-CHECKLIST.md"
 
 if [ "$FAIL" -gt 0 ]; then
   exit 1
 fi
-
-if [ -z "${VITE_GA_MEASUREMENT_ID:-}" ]; then
-  echo ""
-  echo "ℹ GA4 inactivo: configura el secret en GitHub Actions:"
-  echo "  gh secret set VITE_GA_MEASUREMENT_ID --body 'G-XXXXXXXXXX'"
-fi
+echo "PASS qa:production (technical)"
+exit 0

--- a/src/lib/admin-config.ts
+++ b/src/lib/admin-config.ts
@@ -1,7 +1,7 @@
 /** API del Worker de admin (mismo host que contacto, rutas /api/admin/*) */
 export const ADMIN_API_BASE =
   import.meta.env.VITE_ADMIN_API_URL ??
-  "https://mi-portafolio-contact.vientonorte.workers.dev";
+  "https://contact.vientonorte.io";
 
 export const ADMIN_GITHUB_USER = "vientonorte";
 

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -57,10 +57,13 @@ export function openA11yFreeScheduleOrFallback(fallback: () => void): boolean {
   return false;
 }
 
-/** Relay Cloudflare Worker — POST formulario de contacto */
+/**
+ * Relay Cloudflare Worker — POST formulario de contacto.
+ * Canónico: contact.vientonorte.io · fallback workers.dev si DNS aún no propagó.
+ */
 export const CONTACT_API_URL =
   import.meta.env.VITE_CONTACT_API_URL ??
-  'https://mi-portafolio-contact.vientonorte.workers.dev/api/contact';
+  'https://contact.vientonorte.io/api/contact';
 
 /** CV público — servido desde public/ (GitHub Pages: /mi-portafolio/cv-rodrigo-gaete-ux.pdf) */
 export const CV_ASSET = 'cv-rodrigo-gaete-ux.pdf';

--- a/worker/wrangler.contact.toml
+++ b/worker/wrangler.contact.toml
@@ -6,8 +6,13 @@ compatibility_date = "2024-09-23"
 account_id = "6e96c77c41a11e043c84a7802c6108b8"
 workers_dev = true
 
+# Canónico: contact.vientonorte.io (workers.dev fallback)
+routes = [
+  { pattern = "contact.vientonorte.io", custom_domain = true }
+]
+
 [vars]
-ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173"
+ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173"
 CONTACT_FROM = "contacto@vientonorte.io"
 CONTACT_FROM_NAME = "Rodrigo Gaete · Portfolio"
 CONTACT_INBOX = "gaete.gaona@gmail.com"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -4,8 +4,12 @@ compatibility_date = "2024-09-23"
 account_id = "6e96c77c41a11e043c84a7802c6108b8"
 workers_dev = true
 
+routes = [
+  { pattern = "contact.vientonorte.io", custom_domain = true }
+]
+
 [vars]
-ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173"
+ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173"
 CONTACT_FROM = "contacto@vientonorte.io"
 CONTACT_FROM_NAME = "Rodrigo Gaete · Portfolio"
 # Inbox privado — override con secret si prefieres: wrangler secret put CONTACT_INBOX


### PR DESCRIPTION
## Summary
- Preprod gate scripts + deploy only after CI green (`workflow_run`)
- Default contact/admin API host → `contact.vientonorte.io`
- Production QA retargeted to domain root (`vientonorte.io`)

## Test plan
- [ ] CI green
- [ ] After merge, Deploy workflow rewrites hub root
- [ ] Live SPA at https://vientonorte.io/