### PR TITLE
fix(layout): header offset FO home + SEM offer padding

### DIFF
--- a/src/pages/PocProductOnboarding.tsx
+++ b/src/pages/PocProductOnboarding.tsx
@@ -350,7 +350,7 @@ export default function PocProductOnboarding({
       />
 
       <div
-        className="fixed inset-0 z-[100] flex flex-col bg-[#050a14] text-[#f5f5f7]"
+        className="fixed inset-0 z-[100] flex flex-col bg-[#050a14] text-[#f5f5f7] pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)]"
         data-surface="consultoria-offer"
         data-testid="consultoria-offer"
         data-first-value-budget-ms={OFFER_FIRST_VALUE_BUDGET_MS}
@@ -360,6 +360,7 @@ export default function PocProductOnboarding({
         {/* Progress — more visible (2px + glow) so craft is obvious */}
         <div
           className="offer-progress-track pointer-events-none absolute inset-x-0 top-0 z-[60]"
+          style={{ top: "env(safe-area-inset-top, 0px)" }}
           aria-hidden
         >
           <div
@@ -601,7 +602,10 @@ export default function PocProductOnboarding({
 
         {/* Dots: side desktop · bottom mobile (antes solo md → “no veo cambios”) */}
         <nav
-          className="pointer-events-none absolute inset-x-0 bottom-5 z-[55] flex justify-center gap-2 md:inset-x-auto md:bottom-auto md:right-5 md:top-1/2 md:-translate-y-1/2 md:flex-col md:gap-1.5"
+          className="pointer-events-none absolute inset-x-0 z-[55] flex justify-center gap-2 md:inset-x-auto md:bottom-auto md:right-5 md:top-1/2 md:-translate-y-1/2 md:flex-col md:gap-1.5"
+          style={{
+            bottom: "calc(1.25rem + env(safe-area-inset-bottom, 0px))",
+          }}
           aria-label={t.dotsAria}
         >
           {screens.map((id, i) => {
@@ -646,8 +650,8 @@ function TourScreen({
     <section
       id={`poc-screen-${id}`}
       data-screen={id}
-      className="flex w-full snap-start snap-always flex-col justify-center px-6 py-16 md:px-14 lg:px-20"
-      style={{ minHeight: "100dvh" }}
+      /* min-h-full = alto del scroller (flex-1), no 100dvh: evita doble pad bajo header SEM */
+      className="flex min-h-full w-full snap-start snap-always flex-col justify-center px-6 py-12 md:px-14 md:py-16 lg:px-20"
     >
       <div
         data-scrub

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -390,6 +390,19 @@ html[data-nav="site"] .subpage-toolbar {
 }
 
 /*
+ * Home FO (data-nav=site): header global fixed.
+ * Empuja el embudo bajo el header y alinea el TOC mobile sticky.
+ * No aplica a #/sobre-mi ni otras subpáginas (data-nav=subpage).
+ */
+html[data-nav="site"] [data-surface="consultoria-funnel"] {
+  padding-top: var(--header-height);
+}
+
+html[data-nav="site"] .process-nav-mobile {
+  --process-nav-mobile-top: var(--header-height);
+}
+
+/*
  * Subpáginas (todo excepto /): sin nav global.
  * --header-height = altura del SubpageToolbar para scroll-mt, scrollToSection
  * y que el contenido no quede “bajo” el sticky al anclar.
@@ -439,6 +452,15 @@ main {
 
 html[data-nav="subpage"] main {
   padding-bottom: var(--bottom-nav-total);
+}
+
+/*
+ * SEM offer fullscreen: sin pad de dock (chrome propio fixed inset-0).
+ * Especificidad ≥ html[data-nav=subpage] main — si no, el pad del dock gana.
+ */
+main:has([data-surface="consultoria-offer"]),
+html[data-nav="subpage"] main:has([data-surface="consultoria-offer"]) {
+  padding-bottom: 0;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- Home FO: clear fixed site header (`padding-top: --header-height` on funnel) + process-nav mobile sticky alignment
- SEM `#/consultoria`: safe-area, `min-h-full` screens (not 100dvh), zero main dock pad
- Does **not** change `#/sobre-mi` (recruiter link)

## Test plan
- [ ] `#/` desktop: hero not under header (~40px+ gap)
- [ ] `#/` mobile: process-nav chips under header sticky
- [ ] `#/consultoria`: no double viewport / dock strip
- [ ] `#/sobre-mi`: no visual regression

Local CDP smoke: SMOKE_OK before ship.