### PR TITLE
feat(sobre-mi): visual-first — bento, mockups, less copy

### DIFF
--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -1,238 +1,152 @@
 import { motion, useReducedMotion } from "motion/react";
-import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { User, Download, Globe2, Layers2, Timer } from "lucide-react";
 import { ProfileAvatar } from "../atoms/ProfileAvatar";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
+import { AboutEvidenceBento } from "./AboutEvidenceBento";
+import { TrajectoryRail } from "./TrajectoryRail";
 import { useLanguage } from "../../lib/LanguageContext";
 import { analytics } from "../../lib/analytics";
 import { getCvDownloadUrl } from "../../lib/site-contact";
 import { cn } from "../../lib/utils";
 
 const roles = [
-  "Head UX",
   "Lead UX",
-  "Product Designer",
-  "UI Designer",
-  "User Research",
-  "Design Thinking Facilitator",
+  "Product Design",
+  "Design Systems",
+  "Research",
+  "Sprints",
+  "Brand · UX",
 ];
 
-/** Prueba del título: 3+ años · 2 verticales · impacto regional (datos del portafolio). */
-const PROOF_POINTS = {
+const PROOF = {
   es: [
-    {
-      icon: Timer,
-      label: "3+ años",
-      detail: "Transvip → SURA · Lead / Senior Product",
-    },
-    {
-      icon: Layers2,
-      label: "2 verticales",
-      detail: "Fintech (Wealth) + Mobility",
-    },
-    {
-      icon: Globe2,
-      label: "Impacto regional",
-      detail: "SURA · 5+ países · −40% onboarding",
-    },
+    { icon: Timer, label: "3+ años", detail: "Lead / Senior Product" },
+    { icon: Layers2, label: "2 verticales", detail: "Wealth + Mobility" },
+    { icon: Globe2, label: "Regional", detail: "5+ países · −40% onboarding" },
   ],
   en: [
-    {
-      icon: Timer,
-      label: "3+ years",
-      detail: "Transvip → SURA · Lead / Senior Product",
-    },
-    {
-      icon: Layers2,
-      label: "2 verticals",
-      detail: "Fintech (Wealth) + Mobility",
-    },
-    {
-      icon: Globe2,
-      label: "Regional impact",
-      detail: "SURA · 5+ countries · −40% onboarding",
-    },
+    { icon: Timer, label: "3+ years", detail: "Lead / Senior Product" },
+    { icon: Layers2, label: "2 verticals", detail: "Wealth + Mobility" },
+    { icon: Globe2, label: "Regional", detail: "5+ countries · −40% onboarding" },
   ],
 } as const;
 
-const BIO = {
-  es: [
-    "Rodrigo Gaete — Lead UX Designer. Más de 3 años implementando UX/UI de punta a punta: de Senior Product Designer en mobility (Transvip / Karri) a UX Lead en Wealth Management en SURA Investments.",
-    "Dos verticales, un mismo estándar de método: research, Design Thinking, Design Sprints, design system y arquitectura de información. En fintech, onboarding regulado, auth multi-perfil y plataformas de inversión con alcance regional (5+ países). En mobility, design system web + app, discovery activo y handoff a desarrollo.",
-    "Antes del core fintech/mobility: liderazgo de diseño en Valuesite (AquiVoy Express / KIT UI), agencia (Maraña), retail (Walmart Chile) y desarrollo en Havas Group (mejoras Claro Chile). Docencia en Desafío Latam (carrera UX UI) cierra el arco con transferencia de método.",
-    "El impacto se mide: −40% en onboarding SURA, design system y handoff navegable en Transvip/Karri, +35% activación en Karri, y entrega alineada a WCAG y cumplimiento cuando el producto lo exige — no solo pantallas, criterios de aceptación y evidencia.",
-  ],
-  en: [
-    "Rodrigo Gaete — Lead UX Designer. 3+ years shipping end-to-end UX/UI: from Senior Product Designer in mobility (Transvip / Karri) to UX Lead in Wealth Management at SURA Investments.",
-    "Two verticals, one method standard: research, Design Thinking, Design Sprints, design systems, and information architecture. In fintech — regulated onboarding, multi-profile auth, and investment platforms with regional reach (5+ countries). In mobility — web + app design system, active discovery, and dev handoff.",
-    "Before the fintech/mobility core: design leadership at Valuesite (AquiVoy Express / KIT UI), agency work (Maraña), retail (Walmart Chile), and web development at Havas Group (Claro Chile improvements). Teaching at Desafío Latam (UX UI career) closes the arc with method transfer.",
-    "Impact is measured: −40% SURA onboarding, navigable design system and handoff at Transvip/Karri, +35% activation at Karri, and delivery aligned to WCAG and compliance when the product requires it — not just screens, but acceptance criteria and evidence.",
-  ],
+const LINE = {
+  es: "UX Lead · SURA Investments. Método + evidencia de producto (no bio larga).",
+  en: "UX Lead · SURA Investments. Method + product evidence (no long bio).",
 } as const;
 
 export function About() {
   const { language } = useLanguage();
   const prefersReducedMotion = useReducedMotion();
-  const proof = PROOF_POINTS[language];
-  const bio = BIO[language];
+  const proof = PROOF[language];
+  const es = language === "es";
 
   const fadeUp = (delay = 0) =>
     prefersReducedMotion
       ? {}
       : {
-          initial: { opacity: 0, y: 20 },
+          initial: { opacity: 0, y: 16 },
           whileInView: { opacity: 1, y: 0 },
           viewport: { once: true as const },
-          transition: { duration: 0.6, delay },
+          transition: { duration: 0.45, delay },
         };
-
-  const handleDownloadCV = () => {
-    analytics.downloadCV();
-    window.open(getCvDownloadUrl(), "_blank", "noopener,noreferrer");
-  };
 
   return (
     <PageSection
       id="sobre-mi"
       padding="compact"
-      width="narrow"
+      width="wide"
       tone="muted"
       aria-labelledby="about-heading"
     >
       <SectionHeader
-        badge={language === "es" ? "Sobre mí" : "About me"}
+        badge={es ? "Sobre mí" : "About me"}
         badgeIcon={User}
         titleId="about-heading"
-        title={
-          language === "es"
-            ? "3+ años. 2 verticales. Impacto regional."
-            : "3+ years. 2 verticals. Regional impact."
-        }
+        title={es ? "Evidencia primero." : "Evidence first."}
         description={
-          language === "es"
-            ? "Trayectoria con evidencia de producto — no un párrafo genérico de LinkedIn."
-            : "Product evidence in the track record — not a generic LinkedIn blurb."
+          es
+            ? "Dashboards, mockups y diagramas. Poco texto."
+            : "Dashboards, mockups, diagrams. Minimal text."
         }
       />
 
-      {/* Tres claims del título, con dato del portafolio */}
-      <ul
-        className="mb-8 grid gap-3 sm:grid-cols-3"
-        role="list"
-        aria-label={
-          language === "es"
-            ? "Resumen de trayectoria"
-            : "Career summary"
-        }
-      >
-        {proof.map((item, index) => {
-          const Icon = item.icon;
-          return (
-            <motion.li
-              key={item.label}
-              {...fadeUp(0.05 * index)}
-              className={cn(
-                "rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated p-4",
-                "flex flex-col gap-1.5 text-left"
-              )}
-            >
-              <div className="flex items-center gap-2">
-                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-                  <Icon className="h-4 w-4 text-primary" aria-hidden />
-                </span>
-                <p className="text-sm font-semibold text-foreground">{item.label}</p>
-              </div>
-              <p className="text-xs leading-snug text-muted-foreground sm:text-sm">
-                {item.detail}
-              </p>
-            </motion.li>
-          );
-        })}
-      </ul>
-
-      <div className="space-y-6">
-        <motion.div
-          {...fadeUp(0.1)}
-          className="flex flex-col items-start gap-6 md:flex-row md:gap-8"
-        >
-          <motion.div
-            whileHover={prefersReducedMotion ? undefined : { scale: 1.01 }}
-            className="group mx-auto flex-shrink-0 md:mx-0"
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,220px)_1fr] lg:items-start lg:gap-10">
+        <motion.div {...fadeUp(0)} className="mx-auto w-full max-w-[200px] lg:mx-0">
+          <div className="profile-avatar-frame relative aspect-[4/5] w-full">
+            <ProfileAvatar alt="Rodrigo Gaete — Lead UX Designer" />
+          </div>
+          <h3 className="mt-4 text-center text-base font-semibold tracking-tight lg:text-left">
+            Rodrigo Gaete
+          </h3>
+          <p className="mt-0.5 text-center text-sm font-medium text-primary lg:text-left">
+            Lead UX · SURA
+          </p>
+          <p className="mt-3 text-center text-sm leading-snug text-muted-foreground lg:text-left">
+            {LINE[language]}
+          </p>
+          <Button
+            size="lg"
+            variant="outline"
+            onClick={() => {
+              analytics.downloadCV();
+              window.open(getCvDownloadUrl(), "_blank", "noopener,noreferrer");
+            }}
+            className="mt-4 w-full border-2 group"
           >
-            <div className="profile-avatar-frame relative aspect-[4/5] w-36 md:w-44">
-              <div
-                className="pointer-events-none absolute -inset-1 -z-10 rounded-2xl bg-brand-gradient opacity-0 blur-md transition-opacity duration-500 group-hover:opacity-20"
-                aria-hidden="true"
-              />
-              <ProfileAvatar alt="Rodrigo Gaete — Lead UX Designer" />
-            </div>
-          </motion.div>
-
-          <div className="min-w-0 flex-1 text-center md:text-left">
-            <h3 className="text-lg font-semibold tracking-tight text-foreground md:text-xl">
-              Rodrigo Gaete — Lead UX Designer
-            </h3>
-            <p className="mt-1 text-sm font-medium text-primary">
-              {language === "es"
-                ? "UX Lead · SURA Investments · Wealth Management regional"
-                : "UX Lead · SURA Investments · Regional Wealth Management"}
-            </p>
-
-            <div className="mt-4 space-y-3 text-base leading-relaxed text-muted-foreground md:text-[1.05rem]">
-              {bio.map((paragraph) => (
-                <p key={paragraph.slice(0, 48)}>{paragraph}</p>
-              ))}
-            </div>
-
-            <Button
-              size="lg"
-              variant="outline"
-              onClick={handleDownloadCV}
-              className="mt-6 group border-2 transition-all hover:border-primary hover:bg-primary/5"
-            >
-              <Download className="mr-2 h-5 w-5 transition-transform group-hover:translate-y-0.5" />
-              {language === "es" ? "Descargar CV" : "Download CV"}
-            </Button>
+            <Download className="mr-2 h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+            {es ? "CV PDF" : "CV PDF"}
+          </Button>
+          <div className="mt-4 flex flex-wrap justify-center gap-1.5 lg:justify-start">
+            {roles.map((role) => (
+              <Badge
+                key={role}
+                variant="secondary"
+                className="px-2 py-0.5 text-[11px] font-medium"
+              >
+                {role}
+              </Badge>
+            ))}
           </div>
         </motion.div>
 
-        <motion.div {...fadeUp(0.2)}>
-          <Card className="border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-none">
-            <CardContent className="p-6">
-              <h3 className="mb-4 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-                {language === "es" ? "Roles que desempeño" : "Roles I perform"}
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                {roles.map((role, index) => (
-                  <motion.div
-                    key={role}
-                    {...(prefersReducedMotion
-                      ? {}
-                      : {
-                          initial: { opacity: 0, scale: 0.9 },
-                          whileInView: { opacity: 1, scale: 1 },
-                          viewport: { once: true },
-                          transition: { delay: 0.15 + index * 0.04 },
-                        })}
-                    whileHover={
-                      prefersReducedMotion ? undefined : { scale: 1.04, y: -1 }
-                    }
-                  >
-                    <Badge
-                      variant="secondary"
-                      className="cursor-default px-3 py-1.5 text-sm transition-colors hover:bg-primary/10"
-                    >
-                      {role}
-                    </Badge>
-                  </motion.div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
+        <div className="min-w-0 space-y-6">
+          <ul
+            className="grid gap-2 sm:grid-cols-3"
+            role="list"
+            aria-label={es ? "Resumen" : "Summary"}
+          >
+            {proof.map((item, index) => {
+              const Icon = item.icon;
+              return (
+                <motion.li
+                  key={item.label}
+                  {...fadeUp(0.04 * index)}
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated px-3 py-3"
+                  )}
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Icon className="h-4 w-4 text-primary" aria-hidden />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-sm font-semibold">{item.label}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {item.detail}
+                    </span>
+                  </span>
+                </motion.li>
+              );
+            })}
+          </ul>
+
+          <TrajectoryRail />
+          <AboutEvidenceBento />
+        </div>
       </div>
     </PageSection>
   );

--- a/src/components/organisms/AboutEvidenceBento.tsx
+++ b/src/components/organisms/AboutEvidenceBento.tsx
@@ -1,0 +1,49 @@
+import { useLanguage } from "../../lib/LanguageContext";
+import { ABOUT_VISUAL_TILES } from "../../data/about-visuals";
+import { cn } from "../../lib/utils";
+
+/**
+ * Bento de evidencia visual — dashboards, mockups, diagramas.
+ * Menos copy: la imagen es el mensaje.
+ */
+export function AboutEvidenceBento() {
+  const { language } = useLanguage();
+  const es = language === "es";
+
+  return (
+    <section
+      aria-label={es ? "Evidencia visual de trabajo" : "Visual work evidence"}
+      className="mt-8"
+    >
+      <p className="mb-3 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+        {es ? "Evidencia · no slides" : "Evidence · not slides"}
+      </p>
+      <ul className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3" role="list">
+        {ABOUT_VISUAL_TILES.map((tile) => (
+          <li
+            key={tile.id}
+            className={cn(
+              "group relative min-h-[120px] overflow-hidden rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated sm:min-h-[140px]",
+              tile.span
+            )}
+          >
+            <img
+              src={tile.src}
+              alt={tile.alt[language]}
+              loading="lazy"
+              decoding="async"
+              className="absolute inset-0 h-full w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.03]"
+            />
+            <div
+              className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/90 via-background/20 to-transparent"
+              aria-hidden
+            />
+            <span className="absolute bottom-2 left-2 right-2 text-[11px] font-medium tracking-wide text-foreground drop-shadow-sm sm:text-xs">
+              {tile.label[language]}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/organisms/Experience.tsx
+++ b/src/components/organisms/Experience.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { getExperiences } from "../../data/experience-data";
+import { EXPERIENCE_COVER } from "../../data/about-visuals";
 import { CompanyLogo } from "../atoms/CompanyLogo";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
@@ -29,14 +30,21 @@ export function Experience() {
       <SectionHeader
         badge={t.badge}
         badgeIcon={Briefcase}
-        title={t.title}
-        description={t.description}
+        title={language === "es" ? "Línea de tiempo" : "Timeline"}
+        description={
+          language === "es"
+            ? "Impacto + captura. Detalle en cada empresa."
+            : "Impact + capture. Detail per company."
+        }
         titleId="experience-heading"
       />
 
       <ol className="space-y-0" role="list" aria-label={t.title}>
         {experiences.map((exp, index) => {
           const isLast = index === experiences.length - 1;
+          const cover = exp.companyId
+            ? EXPERIENCE_COVER[exp.companyId]
+            : undefined;
 
           return (
             <li
@@ -61,111 +69,84 @@ export function Experience() {
               </div>
 
               <motion.article
-                initial={{ opacity: 0, y: 20 }}
+                initial={{ opacity: 0, y: 16 }}
                 whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true, margin: "-50px" }}
-                transition={{ duration: 0.5, delay: index * 0.06 }}
+                viewport={{ once: true, margin: "-40px" }}
+                transition={{ duration: 0.4, delay: index * 0.04 }}
                 className="min-w-0 flex-1"
               >
                 <Card
                   className={cn(
-                    "transition-shadow hover:shadow-lg",
+                    "overflow-hidden transition-shadow hover:shadow-lg",
                     exp.isCurrent && "border-2 border-primary/50 bg-primary/5"
                   )}
                 >
-                  <CardHeader>
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="flex flex-1 items-start gap-4">
-                        <CompanyLogo
-                          src={exp.logo}
-                          alt={`${exp.company} logo`}
-                          size="md"
-                        />
+                  {cover ? (
+                    <div className="relative aspect-[21/9] max-h-40 w-full overflow-hidden border-b border-border/40 bg-muted sm:max-h-48">
+                      <img
+                        src={cover}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        className="h-full w-full object-cover object-top"
+                      />
+                      <div
+                        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/50 to-transparent"
+                        aria-hidden
+                      />
+                    </div>
+                  ) : null}
 
-                        <div className="min-w-0 flex-1 space-y-1.5">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <Badge
-                              variant="outline"
-                              className="border-primary/25 font-mono text-[10px] uppercase tracking-[0.14em] text-primary"
-                            >
-                              {exp.stage}
+                  <CardHeader className="pb-2">
+                    <div className="flex flex-1 items-start gap-3 sm:gap-4">
+                      <CompanyLogo
+                        src={exp.logo}
+                        alt={`${exp.company} logo`}
+                        size="md"
+                      />
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="border-primary/25 font-mono text-[10px] uppercase tracking-[0.14em] text-primary"
+                          >
+                            {exp.stage}
+                          </Badge>
+                          {exp.isCurrent && (
+                            <Badge className="bg-green-500 text-white hover:bg-green-600">
+                              {t.current}
                             </Badge>
-                            {exp.isCurrent && (
-                              <Badge className="bg-green-500 text-white hover:bg-green-600">
-                                {t.current}
-                              </Badge>
-                            )}
-                          </div>
-                          <CardTitle className="text-lg sm:text-xl">{exp.position}</CardTitle>
-                          <CardDescription className="text-base font-medium text-foreground/80">
-                            {exp.company}
-                          </CardDescription>
-                          <p className="text-xs text-muted-foreground">
-                            {exp.period}
-                            <span aria-hidden="true"> · </span>
-                            {exp.location}
-                          </p>
+                          )}
                         </div>
+                        <CardTitle className="text-base sm:text-lg">
+                          {exp.position}
+                        </CardTitle>
+                        <CardDescription className="text-sm font-medium text-foreground/80">
+                          {exp.company}
+                          <span className="text-muted-foreground">
+                            {" "}
+                            · {exp.period}
+                          </span>
+                        </CardDescription>
                       </div>
                     </div>
                   </CardHeader>
 
-                  <CardContent className="space-y-4">
-                    {/* Relato por etapa: contexto → rol → impacto */}
-                    <dl className="space-y-3 border-b border-border/60 pb-4">
-                      <div>
-                        <dt className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-                          {t.contextLabel}
-                        </dt>
-                        <dd className="mt-1 text-sm leading-relaxed text-foreground/90">
-                          {exp.context}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-                          {t.roleLabel}
-                        </dt>
-                        <dd className="mt-1 text-sm leading-relaxed text-foreground/90">
-                          {exp.role}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-                          {t.impactLabel}
-                        </dt>
-                        <dd className="mt-1 text-sm font-semibold leading-relaxed text-primary">
-                          {exp.impact}
-                        </dd>
-                      </div>
-                    </dl>
-
-                    <div>
-                      <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-                        {t.evidenceLabel}
+                  <CardContent className="space-y-3 pt-0">
+                    <p className="text-sm font-semibold leading-snug text-primary">
+                      {exp.impact}
+                    </p>
+                    {/* Una sola línea de evidencia — no muro de bullets */}
+                    {exp.achievements[0] ? (
+                      <p className="text-sm leading-snug text-muted-foreground">
+                        {exp.achievements[0]}
                       </p>
-                      <ul className="space-y-1.5" role="list" aria-label={t.evidenceLabel}>
-                        {exp.achievements.map((achievement, i) => (
-                          <motion.li
-                            key={i}
-                            initial={{ opacity: 0, x: -10 }}
-                            whileInView={{ opacity: 1, x: 0 }}
-                            viewport={{ once: true }}
-                            transition={{ delay: 0.08 + i * 0.04 }}
-                            className="flex items-start gap-2"
-                          >
-                            <span className="mt-1 shrink-0 text-primary" aria-hidden="true">
-                              •
-                            </span>
-                            <span className="text-sm text-muted-foreground">{achievement}</span>
-                          </motion.li>
-                        ))}
-                      </ul>
-                    </div>
+                    ) : null}
 
                     {exp.tools && exp.tools.length > 0 && (
-                      <div className="flex flex-wrap gap-2 pt-1">
-                        {exp.tools.map((tool) => (
-                          <Badge key={tool} variant="secondary" className="text-xs">
+                      <div className="flex flex-wrap gap-1.5">
+                        {exp.tools.slice(0, 5).map((tool) => (
+                          <Badge key={tool} variant="secondary" className="text-[11px]">
                             {tool}
                           </Badge>
                         ))}

--- a/src/components/organisms/Skills.tsx
+++ b/src/components/organisms/Skills.tsx
@@ -1,84 +1,104 @@
-import { 
-  Palette, 
-  Users, 
-  Layers, 
-  Lightbulb, 
-  Sparkles,
-  Rocket,
-  CheckCircle2,
-  Box
-} from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { SectionHeader } from "../molecules/SectionHeader";
-import { SkillCard } from "../molecules/SkillCard";
+import { PageSection } from "../layout/PageSection";
+import { METHOD_STRIP } from "../../data/about-visuals";
+import { useLanguage } from "../../lib/LanguageContext";
+import { Badge } from "../ui/badge";
 
-const skills = [
-  {
-    icon: Palette,
-    title: "Diseño UI",
-    description: "Figma (experto), Frameworks, Accesibilidad, Design Systems",
-  },
-  {
-    icon: Users,
-    title: "User Research",
-    description: "Research de producto y usuarios, Testing, Validación continua",
-  },
-  {
-    icon: Lightbulb,
-    title: "Design Thinking",
-    description: "Facilitación de workshops, ideación, marco de trabajo ágil",
-  },
-  {
-    icon: Layers,
-    title: "Design Sprints",
-    description: "Sprint de desarrollo, prototipado rápido, validación ágil",
-  },
-  {
-    icon: Rocket,
-    title: "Product Design",
-    description: "Sprint de desarrollo, MVPs, Handoff, desarrollo evolutivo",
-  },
-  {
-    icon: CheckCircle2,
-    title: "Implementación UX",
-    description: "Lineamientos de experiencia e interfaz en contextos enterprise",
-  },
-  {
-    icon: Box,
-    title: "Design Systems",
-    description: "Creación y gestión de sistemas de diseño escalables y consistentes",
-  },
-  {
-    icon: Users,
-    title: "Docencia UX/UI",
-    description: "Enseñanza de diseño UX y UI, mentoring de nuevos diseñadores",
-  },
-];
+const CHIPS = {
+  es: [
+    "Figma",
+    "Design systems",
+    "Research",
+    "Design Thinking",
+    "Sprints",
+    "WCAG",
+    "Handoff",
+    "Analytics",
+    "Product",
+    "Brand UX",
+  ],
+  en: [
+    "Figma",
+    "Design systems",
+    "Research",
+    "Design Thinking",
+    "Sprints",
+    "WCAG",
+    "Handoff",
+    "Analytics",
+    "Product",
+    "Brand UX",
+  ],
+} as const;
 
+/** Skills visuales: tira de método + chips. Sin párrafos. */
 export function Skills() {
+  const { language } = useLanguage();
+  const es = language === "es";
+  const chips = CHIPS[language];
+
   return (
-    <section 
+    <PageSection
       id="habilidades"
-      className="py-20 md:py-28 px-4"
+      padding="compact"
+      width="wide"
+      tone="default"
       aria-labelledby="skills-heading"
     >
-      <div className="container max-w-7xl mx-auto">
-        <SectionHeader
-          badge="Expertise"
-          badgeIcon={Sparkles}
-          title="Habilidades & Metodologías"
-          description="Stack completo de herramientas, metodologías y frameworks para diseño de experiencias centradas en el usuario"
-        />
+      <SectionHeader
+        badge="Stack"
+        badgeIcon={Sparkles}
+        titleId="skills-heading"
+        title={es ? "Método en una mirada" : "Method at a glance"}
+        description={
+          es ? "Artefactos reales del craft." : "Real craft artifacts."
+        }
+      />
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
-          {skills.map((skill, index) => (
-            <SkillCard
-              key={skill.title}
-              {...skill}
-              index={index}
+      <ul
+        className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5 md:gap-3"
+        role="list"
+        aria-label={es ? "Métodos" : "Methods"}
+      >
+        {METHOD_STRIP.map((item) => (
+          <li
+            key={item.id}
+            className="group relative aspect-[4/3] overflow-hidden rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated"
+          >
+            <img
+              src={item.src}
+              alt=""
+              loading="lazy"
+              decoding="async"
+              className="absolute inset-0 h-full w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.04]"
             />
-          ))}
-        </div>
+            <div
+              className="absolute inset-0 bg-gradient-to-t from-background/85 via-transparent to-transparent"
+              aria-hidden
+            />
+            <span className="absolute bottom-2 left-2 text-xs font-semibold text-foreground">
+              {item.label[language]}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div
+        className="mt-6 flex flex-wrap gap-2"
+        role="list"
+        aria-label={es ? "Herramientas" : "Tools"}
+      >
+        {chips.map((chip) => (
+          <Badge
+            key={chip}
+            variant="outline"
+            className="border-border/80 px-3 py-1.5 text-sm font-medium"
+          >
+            {chip}
+          </Badge>
+        ))}
       </div>
-    </section>
+    </PageSection>
   );
 }

--- a/src/components/organisms/TrajectoryRail.tsx
+++ b/src/components/organisms/TrajectoryRail.tsx
@@ -1,0 +1,62 @@
+import { useLanguage } from "../../lib/LanguageContext";
+import { cn } from "../../lib/utils";
+
+const STAGES = {
+  es: [
+    { id: "retail", label: "Retail", sub: "Walmart" },
+    { id: "agency", label: "Agencia", sub: "Havas · Maraña" },
+    { id: "mobility", label: "Mobility", sub: "Transvip · Karri" },
+    { id: "wealth", label: "Wealth", sub: "SURA · Lead" },
+  ],
+  en: [
+    { id: "retail", label: "Retail", sub: "Walmart" },
+    { id: "agency", label: "Agency", sub: "Havas · Maraña" },
+    { id: "mobility", label: "Mobility", sub: "Transvip · Karri" },
+    { id: "wealth", label: "Wealth", sub: "SURA · Lead" },
+  ],
+} as const;
+
+/** Diagrama de arco profesional — 4 nodos, sin párrafos. */
+export function TrajectoryRail({ className }: { className?: string }) {
+  const { language } = useLanguage();
+  const stages = STAGES[language];
+
+  return (
+    <nav
+      aria-label={language === "es" ? "Arco profesional" : "Career arc"}
+      className={cn("w-full", className)}
+    >
+      <ol className="flex flex-wrap items-stretch justify-between gap-2 sm:gap-0">
+        {stages.map((s, i) => (
+          <li
+            key={s.id}
+            className="relative flex min-w-[42%] flex-1 flex-col items-center px-1 sm:min-w-0"
+          >
+            {i < stages.length - 1 ? (
+              <span
+                className="absolute left-[calc(50%+14px)] right-[calc(-50%+14px)] top-3 hidden h-px bg-gradient-to-r from-primary/50 to-primary/20 sm:block"
+                aria-hidden
+              />
+            ) : null}
+            <span
+              className={cn(
+                "relative z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 border-background text-[10px] font-bold",
+                i === stages.length - 1
+                  ? "bg-primary text-primary-foreground ring-2 ring-primary/30"
+                  : "bg-primary/15 text-primary"
+              )}
+            >
+              {i + 1}
+            </span>
+            <span className="mt-2 text-center text-xs font-semibold text-foreground">
+              {s.label}
+            </span>
+            <span className="text-center text-[10px] text-muted-foreground">
+              {s.sub}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/data/about-visuals.ts
+++ b/src/data/about-visuals.ts
@@ -1,0 +1,138 @@
+import { portfolioImages } from "../lib/portfolio-image-urls";
+
+/** Visual evidence for /sobre-mi — images first, captions short. */
+export type AboutVisualTile = {
+  id: string;
+  src: string;
+  alt: { es: string; en: string };
+  label: { es: string; en: string };
+  /** bento span classes */
+  span: string;
+  kind: "dashboard" | "mockup" | "diagram" | "method";
+};
+
+export const ABOUT_VISUAL_TILES: AboutVisualTile[] = [
+  {
+    id: "sura-dash",
+    src: portfolioImages.sura.iaAutomationDashboard,
+    alt: {
+      es: "Dashboard IA y automatización SURA Investments",
+      en: "SURA Investments IA automation dashboard",
+    },
+    label: { es: "SURA · Dashboard", en: "SURA · Dashboard" },
+    span: "sm:col-span-2 sm:row-span-2",
+    kind: "dashboard",
+  },
+  {
+    id: "sura-onboard",
+    src: portfolioImages.sura.riaOnboarding,
+    alt: {
+      es: "Onboarding RIA multi-país",
+      en: "Multi-country RIA onboarding",
+    },
+    label: { es: "Onboarding −40%", en: "Onboarding −40%" },
+    span: "sm:col-span-1",
+    kind: "mockup",
+  },
+  {
+    id: "transvip-app",
+    src: portfolioImages.transvip.appDesktop,
+    alt: {
+      es: "App Transvip desktop",
+      en: "Transvip desktop app",
+    },
+    label: { es: "Transvip · App", en: "Transvip · App" },
+    span: "sm:col-span-1",
+    kind: "mockup",
+  },
+  {
+    id: "transvip-mobile",
+    src: portfolioImages.transvip.appMobile,
+    alt: {
+      es: "App Transvip mobile",
+      en: "Transvip mobile app",
+    },
+    label: { es: "Mobile", en: "Mobile" },
+    span: "sm:col-span-1",
+    kind: "mockup",
+  },
+  {
+    id: "karri-okr",
+    src: portfolioImages.karri.okrsBoard,
+    alt: {
+      es: "OKRs y sprint Karri",
+      en: "Karri OKRs and sprint",
+    },
+    label: { es: "Karri · OKRs", en: "Karri · OKRs" },
+    span: "sm:col-span-1",
+    kind: "diagram",
+  },
+  {
+    id: "sura-flow",
+    src: portfolioImages.sura.celulaEvolutivaFlow,
+    alt: {
+      es: "Flujo célula evolutiva",
+      en: "Evolutionary cell flow",
+    },
+    label: { es: "Diagrama", en: "Diagram" },
+    span: "sm:col-span-1",
+    kind: "diagram",
+  },
+  {
+    id: "xcms",
+    src: portfolioImages.consultoria.xCmsDashboard,
+    alt: {
+      es: "Dashboard X|CMS consultoría",
+      en: "X|CMS consulting dashboard",
+    },
+    label: { es: "X|CMS", en: "X|CMS" },
+    span: "sm:col-span-1",
+    kind: "dashboard",
+  },
+  {
+    id: "ds",
+    src: portfolioImages.uxTools.designSystem,
+    alt: {
+      es: "Design system tokens y componentes",
+      en: "Design system tokens and components",
+    },
+    label: { es: "Design system", en: "Design system" },
+    span: "sm:col-span-1",
+    kind: "method",
+  },
+];
+
+/** Cover image per experience companyId (timeline). */
+export const EXPERIENCE_COVER: Record<string, string> = {
+  "sura-investments": portfolioImages.sura.webPrototype,
+  transvip: portfolioImages.transvip.figmaPrototype,
+  karri: portfolioImages.karri.deliveryBrand,
+};
+
+export const METHOD_STRIP = [
+  {
+    id: "journey",
+    src: portfolioImages.uxTools.journeyMap,
+    label: { es: "Journey", en: "Journey" },
+  },
+  {
+    id: "flow",
+    src: portfolioImages.uxTools.userFlow,
+    label: { es: "Flows", en: "Flows" },
+  },
+  {
+    id: "test",
+    src: portfolioImages.uxTools.usabilityTest,
+    label: { es: "Test", en: "Test" },
+  },
+  {
+    id: "system",
+    src: portfolioImages.uxTools.designSystem,
+    label: { es: "System", en: "System" },
+  },
+  {
+    id: "value",
+    src: portfolioImages.framework.uxValueChain,
+    label: { es: "Cadena", en: "Value chain" },
+  },
+] as const;


### PR DESCRIPTION
## Summary
- **About**: photo + 1 line + proof chips + trajectory rail + **evidence bento** (SURA dashboards, Transvip mockups, Karri OKRs, diagrams, X|CMS)
- **Skills**: method strip images + chips (no paragraph cards)
- **Experience**: cover mockup when available, impact-first, one evidence line

## Why
Recruiter / Team-Work scan: less words, more product evidence.

## Test plan
- [ ] `#/sobre-mi` desktop: bento loads, no overflow
- [ ] Mobile: 2-col tiles, timeline covers
- [ ] EN/ES labels
- [ ] CV download still works
- [ ] Images lazy-load, no layout jump