### PR TITLE
fix(sobre-mi): narrativa que suma (micro1 + Latam/US + VN)

### DIFF
--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -1,7 +1,7 @@
 import { motion, useReducedMotion } from "motion/react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { User, Download, Globe2, Layers2, Timer } from "lucide-react";
+import { User, Download, Globe2, Cpu, LayoutPanelLeft } from "lucide-react";
 import { ProfileAvatar } from "../atoms/ProfileAvatar";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
@@ -12,46 +12,72 @@ import { analytics } from "../../lib/analytics";
 import { getCvDownloadUrl } from "../../lib/site-contact";
 import { cn } from "../../lib/utils";
 
-/** Roles de craft — no empleo actual (eso va en el título). */
+/** Craft tags — no sustituyen el cargo actual. */
 const roles = {
   es: [
     "Interfaces",
     "Product Design",
     "Design Systems",
+    "AI data",
     "Research",
-    "Sprints",
     "Design Ops",
   ],
   en: [
     "Interfaces",
     "Product Design",
     "Design Systems",
+    "AI data",
     "Research",
-    "Sprints",
     "Design Ops",
   ],
 } as const;
 
 /**
- * Chips de prueba — coherentes con timeline:
- * 7+ craft (VN 2019–) · 3+ lead (mobility→wealth) · impacto regional SURA (pasado).
+ * Tres claims que suman (no se pisan):
+ * 1) Interfaces de empresas (lo que se ve en el wall)
+ * 2) Alcance regional + internacional (SURA Latam + micro1 US)
+ * 3) Práctica actual (VN n2n + micro1 AI)
  */
 const PROOF = {
   es: [
-    { icon: Timer, label: "7+ años", detail: "Craft UX/UI · Viento Norte 2019–" },
-    { icon: Layers2, label: "3+ lead", detail: "Mobility → Wealth (Transvip · SURA)" },
-    { icon: Globe2, label: "Regional", detail: "5+ países · −40% onboarding SURA" },
+    {
+      icon: LayoutPanelLeft,
+      label: "Interfaces",
+      detail: "Empresas CL + wealth regional · wall abajo",
+    },
+    {
+      icon: Globe2,
+      label: "Latam + EE.UU.",
+      detail: "SURA multi-país · micro1 remoto US",
+    },
+    {
+      icon: Cpu,
+      label: "Hoy",
+      detail: "UX Manager VN · AI Trainer micro1",
+    },
   ],
   en: [
-    { icon: Timer, label: "7+ years", detail: "UX/UI craft · Viento Norte 2019–" },
-    { icon: Layers2, label: "3+ lead", detail: "Mobility → Wealth (Transvip · SURA)" },
-    { icon: Globe2, label: "Regional", detail: "5+ countries · −40% SURA onboarding" },
+    {
+      icon: LayoutPanelLeft,
+      label: "Interfaces",
+      detail: "CL product + regional wealth · wall below",
+    },
+    {
+      icon: Globe2,
+      label: "Latam + US",
+      detail: "SURA multi-country · micro1 US remote",
+    },
+    {
+      icon: Cpu,
+      label: "Now",
+      detail: "UX Manager VN · AI Trainer micro1",
+    },
   ],
 } as const;
 
 const LINE = {
-  es: "Interfaces de producto (wealth, mobility, e-comm). Ex UX Lead SURA (hasta jun. 2026).",
-  en: "Product interfaces (wealth, mobility, e-comm). Former UX Lead SURA (through Jun 2026).",
+  es: "Interfaces de producto en empresas reales. Hoy: Viento Norte (n2n) + micro1 (AI data, EE.UU.). Antes: Lead UX SURA (regional, hasta jun. 2026).",
+  en: "Product interfaces for real companies. Now: Viento Norte (n2n) + micro1 (AI data, US). Before: UX Lead SURA (regional, through Jun 2026).",
 } as const;
 
 const TITLE_ROLE = {
@@ -91,8 +117,8 @@ export function About() {
         title={es ? "Evidencia primero." : "Evidence first."}
         description={
           es
-            ? "Pantallas de producto. Poco texto."
-            : "Product screens. Minimal text."
+            ? "Interfaces de empresas · alcance Latam y EE.UU. · poco texto."
+            : "Company interfaces · Latam and US scope · minimal text."
         }
       />
 
@@ -106,6 +132,11 @@ export function About() {
           </h3>
           <p className="mt-0.5 text-center text-sm font-medium text-primary lg:text-left">
             {TITLE_ROLE[language]}
+          </p>
+          <p className="mt-1 text-center text-xs font-medium text-muted-foreground lg:text-left">
+            {es
+              ? "+ AI Trainer · micro1 (EE.UU. · parcial)"
+              : "+ AI Trainer · micro1 (US · part-time)"}
           </p>
           <p className="mt-3 text-center text-sm leading-snug text-muted-foreground lg:text-left">
             {LINE[language]}
@@ -139,7 +170,7 @@ export function About() {
           <ul
             className="grid gap-2 sm:grid-cols-3"
             role="list"
-            aria-label={es ? "Resumen" : "Summary"}
+            aria-label={es ? "Qué suma el perfil" : "What the profile adds up to"}
           >
             {proof.map((item, index) => {
               const Icon = item.icon;

--- a/src/components/organisms/TrajectoryRail.tsx
+++ b/src/components/organisms/TrajectoryRail.tsx
@@ -2,39 +2,72 @@ import { useLanguage } from "../../lib/LanguageContext";
 import { cn } from "../../lib/utils";
 
 /**
- * Arco profesional — el nodo final es el empleo actual (VN).
- * Wealth/SURA queda como etapa pasada, no “ahora”.
+ * Alcance de trabajo — no “base débil → actual”.
+ * Cada nodo suma valor: nacional · regional · internacional · práctica VN.
  */
 const STAGES = {
   es: [
-    { id: "foundation", label: "Base", sub: "Retail · Agencia" },
-    { id: "mobility", label: "Mobility", sub: "Transvip · Karri" },
-    { id: "wealth", label: "Wealth", sub: "SURA · 23–26" },
-    { id: "vn", label: "Viento Norte", sub: "UX Manager · ahora" },
+    {
+      id: "national",
+      label: "Nacional",
+      sub: "Transvip · Karri · e-comm",
+    },
+    {
+      id: "regional",
+      label: "Regional",
+      sub: "SURA · 5+ países",
+    },
+    {
+      id: "international",
+      label: "Internacional",
+      sub: "micro1 · EE.UU. remoto",
+    },
+    {
+      id: "vn",
+      label: "Viento Norte",
+      sub: "UX Manager · n2n",
+    },
   ],
   en: [
-    { id: "foundation", label: "Foundation", sub: "Retail · Agency" },
-    { id: "mobility", label: "Mobility", sub: "Transvip · Karri" },
-    { id: "wealth", label: "Wealth", sub: "SURA · 23–26" },
-    { id: "vn", label: "Viento Norte", sub: "UX Manager · now" },
+    {
+      id: "national",
+      label: "National",
+      sub: "Transvip · Karri · e-comm",
+    },
+    {
+      id: "regional",
+      label: "Regional",
+      sub: "SURA · 5+ countries",
+    },
+    {
+      id: "international",
+      label: "International",
+      sub: "micro1 · US remote",
+    },
+    {
+      id: "vn",
+      label: "Viento Norte",
+      sub: "UX Manager · n2n",
+    },
   ],
 } as const;
 
 export function TrajectoryRail({ className }: { className?: string }) {
   const { language } = useLanguage();
   const stages = STAGES[language];
+  const es = language === "es";
 
   return (
     <nav
-      aria-label={language === "es" ? "Arco profesional" : "Career arc"}
+      aria-label={es ? "Alcance de trabajo" : "Work scope"}
       className={cn("w-full", className)}
     >
       <p className="mb-3 text-center font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground sm:text-left">
-        {language === "es" ? "Arco (no empleo actual en cada nodo)" : "Arc (not every node = current job)"}
+        {es ? "Dónde sumo · no solo un CV lineal" : "Where I ship · not a flat CV"}
       </p>
       <ol className="flex flex-wrap items-stretch justify-between gap-2 sm:gap-0">
         {stages.map((s, i) => {
-          const isNow = i === stages.length - 1;
+          const isHighlight = s.id === "vn" || s.id === "international";
           return (
             <li
               key={s.id}
@@ -49,7 +82,7 @@ export function TrajectoryRail({ className }: { className?: string }) {
               <span
                 className={cn(
                   "relative z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 border-background text-[10px] font-bold",
-                  isNow
+                  isHighlight
                     ? "bg-primary text-primary-foreground ring-2 ring-primary/30"
                     : "bg-primary/15 text-primary"
                 )}
@@ -59,12 +92,12 @@ export function TrajectoryRail({ className }: { className?: string }) {
               <span
                 className={cn(
                   "mt-2 text-center text-xs font-semibold",
-                  isNow ? "text-primary" : "text-foreground"
+                  isHighlight ? "text-primary" : "text-foreground"
                 )}
               >
                 {s.label}
               </span>
-              <span className="text-center text-[10px] text-muted-foreground">
+              <span className="text-center text-[10px] leading-snug text-muted-foreground">
                 {s.sub}
               </span>
             </li>


### PR DESCRIPTION
## Summary
Hero narrative reworked so chips + rail **add up**:
- **Interfaces** (companies / wall)
- **Latam + US** (SURA multi-country + micro1 remote)
- **Hoy** = UX Manager VN + AI Trainer micro1
- Rail: Nacional → Regional → Internacional → Viento Norte (not “Base” retail)

## VB
https://vientonorte.io/qa/#/sobre-mi after Deploy QA on preview branch