### PR TITLE
fix(sobre-mi): layout reclutador + galería interfaces

### DIFF
--- a/src/components/molecules/SubpageToolbar.tsx
+++ b/src/components/molecules/SubpageToolbar.tsx
@@ -75,10 +75,32 @@ export function SubpageToolbar({
             )}
             <Breadcrumbs links={crumbs} className="mb-0 min-w-0" />
           </div>
-          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
+          {/* Idioma + tema siempre visibles (reclutador / a11y de contraste).
+              Mobile: 44×44. sm+: idioma con label ES/EN legible. */}
+          <div
+            className="flex shrink-0 items-center gap-1.5 sm:gap-2"
+            role="group"
+            aria-label={
+              language === "es"
+                ? "Idioma y accesibilidad visual"
+                : "Language and visual accessibility"
+            }
+          >
             {trailing}
-            <ThemeToggle className={MOBILE_HEADER_CONTROL_CLASS} />
-            <LanguageToggle compact className={MOBILE_HEADER_CONTROL_CLASS} />
+            <ThemeToggle
+              className={MOBILE_HEADER_CONTROL_CLASS}
+            />
+            <span className="sm:hidden">
+              <LanguageToggle compact className={MOBILE_HEADER_CONTROL_CLASS} />
+            </span>
+            <span className="hidden sm:inline-flex">
+              <LanguageToggle
+                className={cn(
+                  MOBILE_HEADER_CONTROL_CLASS,
+                  "h-11 w-auto min-w-[4.5rem] gap-1.5 px-3"
+                )}
+              />
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -2,18 +2,16 @@ import { motion, useReducedMotion } from "motion/react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { User, Download } from "lucide-react";
-// Badge used for craft tags
 import { ProfileAvatar } from "../atoms/ProfileAvatar";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
-import { InterfaceWall } from "./InterfaceWall";
 import { useLanguage } from "../../lib/LanguageContext";
 import { analytics } from "../../lib/analytics";
 import { getCvDownloadUrl } from "../../lib/site-contact";
 
 /**
- * L1 card-sort: identidad + evidencia visual.
- * Método (Skills) y Alcance (ProfileScope) van después en SobreMi.
+ * L1 identidad — layout reclutador: foto + ficha clara.
+ * Sin rail, sin chips de alcance, sin wall (van en secciones propias).
  */
 const roles = {
   es: [
@@ -35,8 +33,8 @@ const roles = {
 } as const;
 
 const LINE = {
-  es: "Interfaces de producto en empresas reales. Hoy: Viento Norte (n2n) + micro1 (AI data, EE.UU.). Antes: Lead UX SURA (regional, hasta jun. 2026).",
-  en: "Product interfaces for real companies. Now: Viento Norte (n2n) + micro1 (AI data, US). Before: UX Lead SURA (regional, through Jun 2026).",
+  es: "Interfaces de producto en empresas reales. Hoy: Viento Norte (n2n) y micro1 (AI data, EE.UU.). Antes: UX Lead SURA (regional, hasta jun. 2026).",
+  en: "Product interfaces for real companies. Now: Viento Norte (n2n) and micro1 (AI data, US). Before: UX Lead SURA (regional, through Jun 2026).",
 } as const;
 
 const TITLE_ROLE = {
@@ -63,7 +61,7 @@ export function About() {
     <PageSection
       id="sobre-mi"
       padding="compact"
-      width="wide"
+      width="content"
       tone="muted"
       aria-labelledby="about-heading"
     >
@@ -71,67 +69,73 @@ export function About() {
         badge={es ? "Sobre mí" : "About me"}
         badgeIcon={User}
         titleId="about-heading"
-        title={es ? "Evidencia primero." : "Evidence first."}
+        title={es ? "Perfil" : "Profile"}
         description={
           es
-            ? "Identidad + pantallas. Método y alcance vienen después."
-            : "Identity + screens. Method and scope come next."
+            ? "Ficha clara para reclutamiento. Evidencia visual en la galería."
+            : "Clear hiring profile. Visual evidence in the gallery."
         }
       />
 
+      {/* Recruiter scan: 2 columnas fijas, sin widgets a la derecha */}
       <motion.div
         {...fadeUp}
-        className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center sm:flex-row sm:items-start sm:text-left"
+        className="mx-auto grid max-w-3xl gap-8 sm:grid-cols-[200px_1fr] sm:items-start sm:gap-10"
       >
-        <div className="w-full max-w-[200px] shrink-0">
-          <div className="profile-avatar-frame relative aspect-[4/5] w-full">
+        <div className="mx-auto w-full max-w-[200px] sm:mx-0">
+          <div className="profile-avatar-frame relative aspect-[4/5] w-full overflow-hidden rounded-2xl ring-1 ring-border/60">
             <ProfileAvatar alt={`Rodrigo Gaete — ${TITLE_ROLE[language]}`} />
           </div>
         </div>
-        <div className="min-w-0 flex-1">
-          <h3 className="text-base font-semibold tracking-tight md:text-lg">
+
+        <div className="min-w-0 text-center sm:text-left">
+          <h3 className="text-xl font-semibold tracking-tight sm:text-2xl">
             Rodrigo Gaete
           </h3>
-          <p className="mt-0.5 text-sm font-medium text-primary">
+          <p className="mt-1 text-base font-medium text-primary">
             {TITLE_ROLE[language]}
           </p>
-          <p className="mt-1 text-xs font-medium text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             {es
-              ? "+ AI Trainer · micro1 (EE.UU. · parcial)"
+              ? "+ AI Trainer · micro1 (EE.UU. · jornada parcial)"
               : "+ AI Trainer · micro1 (US · part-time)"}
           </p>
-          <p className="mt-3 text-sm leading-snug text-muted-foreground">
+          <p className="mt-4 max-w-prose text-sm leading-relaxed text-muted-foreground sm:text-[0.95rem]">
             {LINE[language]}
           </p>
-          <Button
-            size="lg"
-            variant="outline"
-            onClick={() => {
-              analytics.downloadCV();
-              window.open(getCvDownloadUrl(), "_blank", "noopener,noreferrer");
-            }}
-            className="mt-4 border-2 group"
-          >
-            <Download className="mr-2 h-4 w-4 transition-transform group-hover:translate-y-0.5" />
-            CV PDF
-          </Button>
-          <div className="mt-4 flex flex-wrap justify-center gap-1.5 sm:justify-start">
-            {roleList.map((role) => (
-              <Badge
-                key={role}
-                variant="secondary"
-                className="px-2 py-0.5 text-[11px] font-medium"
-              >
-                {role}
-              </Badge>
-            ))}
+
+          <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-start">
+            <Button
+              size="lg"
+              variant="outline"
+              onClick={() => {
+                analytics.downloadCV();
+                window.open(getCvDownloadUrl(), "_blank", "noopener,noreferrer");
+              }}
+              className="border-2 group min-h-11"
+            >
+              <Download className="mr-2 h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+              CV PDF
+            </Button>
           </div>
+
+          <ul
+            className="mt-5 flex flex-wrap justify-center gap-1.5 sm:justify-start"
+            aria-label={es ? "Competencias" : "Skills"}
+          >
+            {roleList.map((role) => (
+              <li key={role}>
+                <Badge
+                  variant="secondary"
+                  className="px-2.5 py-1 text-[11px] font-medium"
+                >
+                  {role}
+                </Badge>
+              </li>
+            ))}
+          </ul>
         </div>
       </motion.div>
-
-      <div className="mt-10 border-t border-border/50 pt-8">
-        <InterfaceWall />
-      </div>
     </PageSection>
   );
 }

--- a/src/components/organisms/InterfaceWall.tsx
+++ b/src/components/organisms/InterfaceWall.tsx
@@ -1,101 +1,88 @@
+import { LayoutGrid } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Badge } from "../ui/badge";
+import { PageSection } from "../layout/PageSection";
+import { SectionHeader } from "../molecules/SectionHeader";
+import { ResponsiveImage } from "../atoms/ResponsiveImage";
 import { useLanguage } from "../../lib/LanguageContext";
 import { INTERFACE_WALL } from "../../data/interface-wall";
-import { cn } from "../../lib/utils";
 
 /**
- * S1 — muro de interfaces (menos copy, más pantallas).
- * Práctica Viento Norte + roles enterprise.
+ * Galería L2 — mismo patrón visual que Projects / CaseStudyCard:
+ * grid 1→2→3, imagen 16:9, card elevada, tags. Sin bento caótico.
  */
 export function InterfaceWall() {
   const { language } = useLanguage();
   const es = language === "es";
 
   return (
-    <section
+    <PageSection
       id="interfaces"
+      padding="compact"
+      width="wide"
+      tone="matte"
       aria-labelledby="interface-wall-heading"
-      className="scroll-mt-[calc(var(--header-height)+0.75rem)]"
     >
-      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-            {es ? "Viento Norte · UX Manager" : "Viento Norte · UX Manager"}
-          </p>
-          <h3
-            id="interface-wall-heading"
-            className="mt-1 text-lg font-semibold tracking-tight sm:text-xl"
-          >
-            {es ? "Interfaces" : "Interfaces"}
-          </h3>
-          <p className="mt-1 max-w-xl text-sm text-muted-foreground">
-            {es
-              ? "Pantallas reales: enterprise regional + práctica nacional."
-              : "Real screens: regional enterprise + national practice."}
-          </p>
-        </div>
-        <ul className="flex gap-2 text-[11px] font-medium" role="list">
-          <li className="rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-primary">
-            {es ? "Transnacional" : "Global"}
-          </li>
-          <li className="rounded-full border border-border bg-muted/40 px-2.5 py-1 text-muted-foreground">
-            {es ? "Nacional" : "National"}
-          </li>
-        </ul>
-      </div>
+      <SectionHeader
+        badge={es ? "Galería" : "Gallery"}
+        badgeIcon={LayoutGrid}
+        titleId="interface-wall-heading"
+        title={es ? "Interfaces de producto" : "Product interfaces"}
+        description={
+          es
+            ? "Mismo ritmo que proyectos: captura 16:9, marca y alcance."
+            : "Same rhythm as projects: 16:9 capture, brand, and scope."
+        }
+      />
 
       <ul
-        className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 md:gap-3"
+        className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
         role="list"
-        aria-label={es ? "Muro de interfaces" : "Interface wall"}
+        aria-label={es ? "Galería de interfaces" : "Interface gallery"}
       >
         {INTERFACE_WALL.map((tile) => (
-          <li
-            key={tile.id}
-            className={cn(
-              "group relative overflow-hidden rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated",
-              tile.featured
-                ? "col-span-2 min-h-[160px] sm:min-h-[200px] md:min-h-[220px]"
-                : "min-h-[120px] sm:min-h-[140px]"
-            )}
-          >
-            <img
-              src={tile.src}
-              alt={`${tile.brand[language]} — ${tile.label[language]}`}
-              loading="lazy"
-              decoding="async"
-              className="absolute inset-0 h-full w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.03]"
-            />
-            <div
-              className="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/95 via-background/35 to-transparent"
-              aria-hidden
-            />
-            <div className="absolute bottom-0 left-0 right-0 p-2.5 sm:p-3">
-              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                {tile.brand[language]}
-                <span className="mx-1 opacity-40" aria-hidden>
-                  ·
-                </span>
-                <span
-                  className={
-                    tile.scope === "global" ? "text-primary" : "text-foreground/70"
-                  }
-                >
-                  {tile.scope === "global"
-                    ? es
-                      ? "Global"
-                      : "Global"
-                    : es
-                      ? "Nacional"
-                      : "National"}
-                </span>
-              </p>
-              <p className="text-xs font-semibold text-foreground sm:text-sm">
-                {tile.label[language]}
-              </p>
-            </div>
+          <li key={tile.id} className="min-w-0">
+            <Card className="flex h-full flex-col overflow-hidden border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-none transition-shadow hover:shadow-md">
+              <ResponsiveImage
+                src={tile.src}
+                alt={`${tile.brand[language]} — ${tile.label[language]}`}
+                fit="cover"
+                aspectRatio="16 / 9"
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                className="bg-muted"
+                imgClassName="object-top transition-transform duration-500 group-hover:scale-105"
+              />
+              <CardHeader className="space-y-2 pb-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant={tile.scope === "global" ? "default" : "secondary"}
+                    className="text-[10px] uppercase tracking-wide"
+                  >
+                    {tile.scope === "global"
+                      ? es
+                        ? "Transnacional"
+                        : "Global"
+                      : es
+                        ? "Nacional"
+                        : "National"}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {tile.brand[language]}
+                  </span>
+                </div>
+                <CardTitle className="text-base font-semibold leading-snug sm:text-lg">
+                  {tile.label[language]}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <p className="text-xs text-muted-foreground">
+                  {es ? "Evidencia de UI · práctica / empresa" : "UI evidence · practice / company"}
+                </p>
+              </CardContent>
+            </Card>
           </li>
         ))}
       </ul>
-    </section>
+    </PageSection>
   );
 }

--- a/src/pages/SobreMi.tsx
+++ b/src/pages/SobreMi.tsx
@@ -1,6 +1,7 @@
 import { About } from '../components/organisms/About';
 import { Skills } from '../components/organisms/Skills';
 import { ProfileScope } from '../components/organisms/ProfileScope';
+import { InterfaceWall } from '../components/organisms/InterfaceWall';
 import { Experience } from '../components/organisms/Experience';
 import { Contact } from '../components/organisms/Contact';
 
@@ -38,14 +39,16 @@ const SobreMi = () => {
         keywords={t.seo.keywords}
         url={canonicalFromPath('/sobre-mi')}
       />
-      {/* Card-sort L1 → L2 → L3
-          1 Identidad + wall de interfaces
-          2 Método (craft)
-          3 Alcance (mercado / Latam+US / micro1) — segundo nivel tras método
-          4 Timeline · 5 Contacto */}
+      {/* Card-sort recruiter
+          L1 Identidad (ficha)
+          L2a Método
+          L2b Alcance
+          L2c Galería interfaces (mismo patrón Projects)
+          L3 Timeline · Contacto */}
       <About />
       <Skills />
       <ProfileScope />
+      <InterfaceWall />
       <Experience />
       <Contact />
     </PageShell>


### PR DESCRIPTION
## 1 Hero
Clean recruiter scan: photo + role + CV. Language/theme always visible in SubpageToolbar (ES/EN label on desktop).

## 2 Interfaces
No more chaotic bento. Same pattern as Projects: cards, 16:9, 3-col grid, badges for Global/Nacional. Placed L2 after Method + Scope.