### PR TITLE
fix(sobre-mi): evidencia cargo VN + tools micro1 (Anotación/QA)

### DIFF
--- a/src/components/organisms/Experience.tsx
+++ b/src/components/organisms/Experience.tsx
@@ -2,7 +2,7 @@ import { motion } from "motion/react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Briefcase, ChevronRight } from "lucide-react";
+import { Briefcase, ChevronRight, Link2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
@@ -11,6 +11,7 @@ import { EXPERIENCE_COVER } from "../../data/about-visuals";
 import { CompanyLogo } from "../atoms/CompanyLogo";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
+import { scrollToSection } from "../../lib/scroll-to-section";
 import { cn } from "../../lib/utils";
 
 export function Experience() {
@@ -18,6 +19,7 @@ export function Experience() {
   const { language } = useLanguage();
   const t = useTranslation(language).experience;
   const experiences = getExperiences(language);
+  const es = language === "es";
 
   return (
     <PageSection
@@ -136,16 +138,20 @@ export function Experience() {
                     <p className="text-sm font-semibold leading-snug text-primary">
                       {exp.impact}
                     </p>
-                    {/* Una sola línea de evidencia — no muro de bullets */}
-                    {exp.achievements[0] ? (
-                      <p className="text-sm leading-snug text-muted-foreground">
-                        {exp.achievements[0]}
-                      </p>
-                    ) : null}
+                    <ul className="space-y-1.5" role="list">
+                      {exp.achievements.slice(0, 3).map((line) => (
+                        <li
+                          key={line.slice(0, 48)}
+                          className="text-sm leading-snug text-muted-foreground"
+                        >
+                          · {line}
+                        </li>
+                      ))}
+                    </ul>
 
                     {exp.tools && exp.tools.length > 0 && (
                       <div className="flex flex-wrap gap-1.5">
-                        {exp.tools.slice(0, 5).map((tool) => (
+                        {exp.tools.map((tool) => (
                           <Badge key={tool} variant="secondary" className="text-[11px]">
                             {tool}
                           </Badge>
@@ -153,17 +159,34 @@ export function Experience() {
                       </div>
                     )}
 
-                    {exp.companyId && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="gap-1 px-0 text-primary hover:text-primary"
-                        onClick={() => navigate(`/empresa/${exp.companyId}`)}
-                      >
-                        {t.viewCases}
-                        <ChevronRight className="h-4 w-4" />
-                      </Button>
-                    )}
+                    <div className="flex flex-wrap gap-3 pt-1">
+                      {exp.evidenceSectionId ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="gap-1 px-0 text-primary hover:text-primary"
+                          onClick={() => scrollToSection(exp.evidenceSectionId!)}
+                        >
+                          <Link2 className="h-4 w-4" aria-hidden />
+                          {exp.evidenceCta
+                            ? exp.evidenceCta[language]
+                            : es
+                              ? "Ver evidencia"
+                              : "View evidence"}
+                        </Button>
+                      ) : null}
+                      {exp.companyId ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="gap-1 px-0 text-primary hover:text-primary"
+                          onClick={() => navigate(`/empresa/${exp.companyId}`)}
+                        >
+                          {t.viewCases}
+                          <ChevronRight className="h-4 w-4" />
+                        </Button>
+                      ) : null}
+                    </div>
                   </CardContent>
                 </Card>
               </motion.article>

--- a/src/components/organisms/MetodoRoEvidence.tsx
+++ b/src/components/organisms/MetodoRoEvidence.tsx
@@ -1,4 +1,4 @@
-import { BookOpen } from "lucide-react";
+import { Briefcase } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { PageSection } from "../layout/PageSection";
@@ -8,9 +8,9 @@ import { useLanguage } from "../../lib/LanguageContext";
 import { METODO_RO_CASES } from "../../data/metodo-ro-cases";
 
 /**
- * Evidencia de casos del Método Ro en Viento Norte.
- * No es galería general del portafolio (eso es /proyectos).
- * Va justo después de “Método en una mirada”.
+ * Evidencia del cargo UX Manager · Viento Norte
+ * (bullets: Monitas, Edu21, funnels, design ops, FO).
+ * No es galería general del portafolio enterprise (SURA/Transvip → /proyectos).
  */
 export function MetodoRoEvidence() {
   const { language } = useLanguage();
@@ -18,31 +18,51 @@ export function MetodoRoEvidence() {
 
   return (
     <PageSection
-      id="metodo-ro-casos"
+      id="evidencia-vn"
       padding="compact"
       width="wide"
       tone="matte"
-      aria-labelledby="metodo-ro-heading"
+      aria-labelledby="evidencia-vn-heading"
     >
       <SectionHeader
-        badge={es ? "Método Ro · Viento Norte" : "Método Ro · Viento Norte"}
-        badgeIcon={BookOpen}
-        titleId="metodo-ro-heading"
-        title={es ? "Evidencia de casos" : "Case evidence"}
+        badge={es ? "UX Manager · Viento Norte" : "UX Manager · Viento Norte"}
+        badgeIcon={Briefcase}
+        titleId="evidencia-vn-heading"
+        title={
+          es
+            ? "Evidencia del cargo · N2N"
+            : "Role evidence · N2N"
+        }
         description={
           es
-            ? "Artefactos de la práctica VN (asesorías). No reemplaza Proyectos enterprise."
-            : "VN practice artifacts (advisory). Does not replace enterprise Projects."
+            ? "Respaldo visual de: e-comm (Monitas), educación (Edu21), funnels, design ops y FO. Tools: web, CX, Figma, Design Ops."
+            : "Visual backing for: e-comm (Monitas), education (Edu21), funnels, design ops, and FO. Tools: web, CX, Figma, Design Ops."
         }
       />
+
+      <ul
+        className="mb-6 flex flex-wrap gap-2"
+        aria-label={es ? "Tools del cargo" : "Role tools"}
+      >
+        {(es
+          ? ["Desarrollo web", "CX", "Figma", "Design Ops", "N2N"]
+          : ["Web dev", "CX", "Figma", "Design Ops", "N2N"]
+        ).map((tool) => (
+          <li key={tool}>
+            <Badge variant="secondary" className="text-xs">
+              {tool}
+            </Badge>
+          </li>
+        ))}
+      </ul>
 
       <ul
         className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
         role="list"
         aria-label={
           es
-            ? "Casos Método Ro en Viento Norte"
-            : "Método Ro cases at Viento Norte"
+            ? "Evidencia UI/UX del cargo Viento Norte"
+            : "UI/UX evidence for Viento Norte role"
         }
       >
         {METODO_RO_CASES.map((item) => (
@@ -73,8 +93,8 @@ export function MetodoRoEvidence() {
               <CardContent className="pt-0">
                 <p className="text-xs text-muted-foreground">
                   {es
-                    ? "Caso · Método Ro · Viento Norte"
-                    : "Case · Método Ro · Viento Norte"}
+                    ? "Evidencia · cargo UX Manager VN"
+                    : "Evidence · UX Manager VN role"}
                 </p>
               </CardContent>
             </Card>
@@ -85,5 +105,4 @@ export function MetodoRoEvidence() {
   );
 }
 
-/** @deprecated Use MetodoRoEvidence — kept so old imports don't break mid-refactor */
 export { MetodoRoEvidence as InterfaceWall };

--- a/src/components/organisms/Micro1ToolEvidence.tsx
+++ b/src/components/organisms/Micro1ToolEvidence.tsx
@@ -1,0 +1,76 @@
+import { Cpu, CheckCircle2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Badge } from "../ui/badge";
+import { PageSection } from "../layout/PageSection";
+import { SectionHeader } from "../molecules/SectionHeader";
+import { useLanguage } from "../../lib/LanguageContext";
+import { MICRO1_TOOL_EVIDENCE } from "../../data/micro1-tool-evidence";
+
+/**
+ * Evidencia de tools micro1: Anotación + QA de grabación (+ captura).
+ * Sin screenshots de juego (herramientas / contenido propietarios).
+ */
+export function Micro1ToolEvidence() {
+  const { language } = useLanguage();
+  const es = language === "es";
+
+  return (
+    <PageSection
+      id="evidencia-micro1"
+      padding="compact"
+      width="wide"
+      tone="default"
+      aria-labelledby="micro1-evidence-heading"
+    >
+      <SectionHeader
+        badge="micro1 · AI"
+        badgeIcon={Cpu}
+        titleId="micro1-evidence-heading"
+        title={
+          es
+            ? "Evidencia de tools · Anotación y QA"
+            : "Tool evidence · Annotation and QA"
+        }
+        description={
+          es
+            ? "Proceso de captura remota (EE.UU.). Sin capturas de títulos AAA (NDA / tooling)."
+            : "Remote capture process (US). No AAA title captures (NDA / tooling)."
+        }
+      />
+
+      <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list">
+        {MICRO1_TOOL_EVIDENCE.map((item) => (
+          <li key={item.id}>
+            <Card className="flex h-full flex-col border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-none">
+              <CardHeader className="space-y-2 pb-2">
+                <Badge variant="secondary" className="w-fit text-[10px] uppercase tracking-wide">
+                  {item.tool[language]}
+                </Badge>
+                <CardTitle className="text-base font-semibold leading-snug sm:text-lg">
+                  {item.tool[language]}
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">{item.summary[language]}</p>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col gap-3 pt-0">
+                <ol className="space-y-2" role="list">
+                  {item.steps[language].map((step, i) => (
+                    <li key={step} className="flex gap-2 text-sm text-foreground/90">
+                      <span className="font-mono text-[10px] text-primary tabular-nums">
+                        {String(i + 1).padStart(2, "0")}
+                      </span>
+                      <span>{step}</span>
+                    </li>
+                  ))}
+                </ol>
+                <p className="mt-auto flex items-start gap-2 border-t border-border/50 pt-3 text-xs font-medium text-primary">
+                  <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                  {item.output[language]}
+                </p>
+              </CardContent>
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </PageSection>
+  );
+}

--- a/src/data/experience-data.ts
+++ b/src/data/experience-data.ts
@@ -24,20 +24,36 @@ export interface ExperienceEntry {
   achievements: string[];
   tools?: string[];
   companyId?: string;
+  /** Ancla a sección de evidencia visual en /sobre-mi (no /empresa). */
+  evidenceSectionId?: string;
+  evidenceCta?: { es: string; en: string };
 }
 
 type LocalizedExperience = {
-  es: Omit<ExperienceEntry, "logo" | "companyId" | "isCurrent">;
-  en: Omit<ExperienceEntry, "logo" | "companyId" | "isCurrent">;
+  es: Omit<
+    ExperienceEntry,
+    "logo" | "companyId" | "isCurrent" | "evidenceSectionId" | "evidenceCta"
+  >;
+  en: Omit<
+    ExperienceEntry,
+    "logo" | "companyId" | "isCurrent" | "evidenceSectionId" | "evidenceCta"
+  >;
   logo?: string;
   companyId?: string;
   isCurrent?: boolean;
+  evidenceSectionId?: string;
+  evidenceCta?: { es: string; en: string };
 };
 
 const experienceCatalog: LocalizedExperience[] = [
   {
     isCurrent: true,
     logo: portfolioImages.brands.micro1,
+    evidenceSectionId: "evidencia-micro1",
+    evidenceCta: {
+      es: "Ver evidencia · Anotación y QA de grabación",
+      en: "View evidence · Annotation and recording QA",
+    },
     es: {
       company: "micro1",
       position: "AI Trainer / Gameplay Data Capture Specialist · Jornada parcial",
@@ -52,7 +68,7 @@ const experienceCatalog: LocalizedExperience[] = [
       achievements: [
         "Captura remota de datos de gameplay con atención a exactitud y detalle",
         "Organización y anotación de sesiones; storage y handoff seguros",
-        "Comunicación escrita y verbal con el equipo remoto del cliente; plazos y requisitos variables",
+        "QA de grabación: validación de integridad, sync y handoff antes de transferencia",
       ],
       tools: ["Captura de datos remota", "Anotación", "QA de grabación"],
     },
@@ -70,7 +86,7 @@ const experienceCatalog: LocalizedExperience[] = [
       achievements: [
         "Remote gameplay data capture with accuracy and detail",
         "Session organization and annotation; secure storage and handoff",
-        "Written and verbal communication with the customer's remote team; deadlines and evolving requirements",
+        "Recording QA: integrity, sync, and handoff checks before transfer",
       ],
       tools: ["Remote data capture", "Annotation", "Recording QA"],
     },
@@ -78,6 +94,11 @@ const experienceCatalog: LocalizedExperience[] = [
   {
     isCurrent: true,
     logo: portfolioImages.brands.vientoNorte,
+    evidenceSectionId: "evidencia-vn",
+    evidenceCta: {
+      es: "Ver evidencia · Monitas, Edu21, funnels, FO",
+      en: "View evidence · Monitas, Edu21, funnels, FO",
+    },
     es: {
       company: "Viento Norte",
       position: "UX Manager · Jornada completa",
@@ -500,6 +521,8 @@ export function getExperiences(language: Language): ExperienceEntry[] {
     logo: item.logo,
     companyId: item.companyId,
     isCurrent: item.isCurrent,
+    evidenceSectionId: item.evidenceSectionId,
+    evidenceCta: item.evidenceCta,
   }));
 }
 

--- a/src/data/metodo-ro-cases.ts
+++ b/src/data/metodo-ro-cases.ts
@@ -77,4 +77,18 @@ export const METODO_RO_CASES: MetodoRoCase[] = [
     artifact: { es: "Auditoría contraste", en: "Contrast audit" },
     phase: { es: "Validar", en: "Validate" },
   },
+  {
+    id: "vn-xcms",
+    src: portfolioImages.consultoria.xCmsDashboard,
+    caseName: { es: "Viento Norte · FO", en: "Viento Norte · FO" },
+    artifact: { es: "Dashboard X|CMS (dueño del dato)", en: "X|CMS dashboard (data ownership)" },
+    phase: { es: "Entregar", en: "Deliver" },
+  },
+  {
+    id: "vn-gees",
+    src: portfolioImages.consultoria.geesDashboard,
+    caseName: { es: "Viento Norte · FO", en: "Viento Norte · FO" },
+    artifact: { es: "Dashboard ops / enterprise", en: "Ops / enterprise dashboard" },
+    phase: { es: "Entregar", en: "Deliver" },
+  },
 ];

--- a/src/data/micro1-tool-evidence.ts
+++ b/src/data/micro1-tool-evidence.ts
@@ -1,0 +1,95 @@
+/**
+ * Evidencia de tools micro1 (sin capturas de juego — NDA / proprietary tooling).
+ * Cards de proceso honestas: qué se hace en Anotación y QA de grabación.
+ */
+export type Micro1ToolEvidence = {
+  id: string;
+  tool: { es: string; en: string };
+  summary: { es: string; en: string };
+  steps: { es: string[]; en: string[] };
+  output: { es: string; en: string };
+};
+
+export const MICRO1_TOOL_EVIDENCE: Micro1ToolEvidence[] = [
+  {
+    id: "capture",
+    tool: {
+      es: "Captura de datos remota",
+      en: "Remote data capture",
+    },
+    summary: {
+      es: "Sesiones AAA con herramientas in-house: grabación sistemática y metadatos de sesión.",
+      en: "AAA sessions with in-house tools: systematic recording and session metadata.",
+    },
+    steps: {
+      es: [
+        "Setup de pipeline de captura según guideline del proyecto",
+        "Grabación de gameplay con checklist de cobertura",
+        "Sync y empaquetado de archivos para handoff",
+      ],
+      en: [
+        "Capture pipeline setup per project guideline",
+        "Gameplay recording with coverage checklist",
+        "File sync and packaging for handoff",
+      ],
+    },
+    output: {
+      es: "Paquete de sesión listo para anotación",
+      en: "Session package ready for annotation",
+    },
+  },
+  {
+    id: "annotation",
+    tool: {
+      es: "Anotación",
+      en: "Annotation",
+    },
+    summary: {
+      es: "Etiquetado de eventos, estados y acciones con criterio de exactitud para entrenamiento.",
+      en: "Labeling events, states, and actions with accuracy criteria for training.",
+    },
+    steps: {
+      es: [
+        "Revisión frame/segmento con taxonomía del proyecto",
+        "Anotación de acciones, UI in-game y edge cases",
+        "Doble check de consistencia entre sesiones",
+      ],
+      en: [
+        "Frame/segment review against project taxonomy",
+        "Annotation of actions, in-game UI, and edge cases",
+        "Consistency double-check across sessions",
+      ],
+    },
+    output: {
+      es: "Dataset anotado catalogado y versionado",
+      en: "Cataloged, versioned annotated dataset",
+    },
+  },
+  {
+    id: "recording-qa",
+    tool: {
+      es: "QA de grabación",
+      en: "Recording QA",
+    },
+    summary: {
+      es: "Validación de integridad, sync A/V y criterios de aceptación antes de transferir.",
+      en: "Integrity, A/V sync, and acceptance checks before transfer.",
+    },
+    steps: {
+      es: [
+        "Smoke de archivo: duración, codec, corrupción",
+        "QA de sync y cobertura vs checklist de misión",
+        "Rechazo / re-captura si no cumple guideline",
+      ],
+      en: [
+        "File smoke: duration, codec, corruption",
+        "Sync and coverage QA vs mission checklist",
+        "Reject / re-capture if guideline fails",
+      ],
+    },
+    output: {
+      es: "Handoff con sello de QA o ticket de re-captura",
+      en: "Handoff with QA stamp or re-capture ticket",
+    },
+  },
+];

--- a/src/pages/SobreMi.tsx
+++ b/src/pages/SobreMi.tsx
@@ -1,8 +1,9 @@
 import { About } from '../components/organisms/About';
 import { Skills } from '../components/organisms/Skills';
-import { MetodoRoEvidence } from '../components/organisms/MetodoRoEvidence';
 import { ProfileScope } from '../components/organisms/ProfileScope';
 import { Experience } from '../components/organisms/Experience';
+import { MetodoRoEvidence } from '../components/organisms/MetodoRoEvidence';
+import { Micro1ToolEvidence } from '../components/organisms/Micro1ToolEvidence';
 import { Contact } from '../components/organisms/Contact';
 
 import { SEOHead } from '../components/atoms/SEOHead';
@@ -40,19 +41,20 @@ const SobreMi = () => {
         url={canonicalFromPath('/sobre-mi')}
       />
       {/*
-        Card-sort:
         L1 Perfil
-        L2a Método en una mirada
-        L2b Evidencia Método Ro · VN (NO galería general portafolio)
-        L2c Alcance
-        L3 Timeline · Contacto
-        Enterprise SURA/Transvip/Karri → /proyectos
+        L2 Método + alcance
+        L3 Timeline (VN / micro1 con CTA a evidencia)
+        L4 Evidencias ancladas al cargo (no galería general)
+           - #evidencia-vn  → UX Manager VN (Monitas, Edu21, funnels, FO)
+           - #evidencia-micro1 → Anotación + QA grabación
+        Enterprise employment SURA/Transvip → /proyectos
       */}
       <About />
       <Skills />
-      <MetodoRoEvidence />
       <ProfileScope />
       <Experience />
+      <MetodoRoEvidence />
+      <Micro1ToolEvidence />
       <Contact />
     </PageShell>
   );


### PR DESCRIPTION
## Intent
La grilla de capturas respalda el **cargo UX Manager VN** (e-comm, Edu21, funnels, Design Ops, FO) — no galería general.

## Also
micro1 tools **Anotación** y **QA de grabación** con evidencia de proceso (sin screenshots AAA/NDA).

## UX
Timeline CTAs → scroll a `#evidencia-vn` / `#evidencia-micro1`.