### PR TITLE
fix(copy): sin textos meta/IA en Sobre mí

### DIFF
--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -72,12 +72,11 @@ export function About() {
         title={es ? "Perfil" : "Profile"}
         description={
           es
-            ? "Ficha clara para reclutamiento. Evidencia visual en la galería."
-            : "Clear hiring profile. Visual evidence in the gallery."
+            ? "UX Manager en Viento Norte. Interfaces de producto y operaciones digitales."
+            : "UX Manager at Viento Norte. Product interfaces and digital operations."
         }
       />
 
-      {/* Recruiter scan: 2 columnas fijas, sin widgets a la derecha */}
       <motion.div
         {...fadeUp}
         className="mx-auto grid max-w-3xl gap-8 sm:grid-cols-[200px_1fr] sm:items-start sm:gap-10"

--- a/src/components/organisms/Experience.tsx
+++ b/src/components/organisms/Experience.tsx
@@ -35,8 +35,8 @@ export function Experience() {
         title={language === "es" ? "Línea de tiempo" : "Timeline"}
         description={
           language === "es"
-            ? "Impacto + captura. Detalle en cada empresa."
-            : "Impact + capture. Detail per company."
+            ? "Roles, impacto y herramientas por organización."
+            : "Roles, impact, and tools by organization."
         }
         titleId="experience-heading"
       />

--- a/src/components/organisms/MetodoRoEvidence.tsx
+++ b/src/components/organisms/MetodoRoEvidence.tsx
@@ -30,13 +30,13 @@ export function MetodoRoEvidence() {
         titleId="evidencia-vn-heading"
         title={
           es
-            ? "Evidencia del cargo · N2N"
-            : "Role evidence · N2N"
+            ? "Casos Viento Norte"
+            : "Viento Norte cases"
         }
         description={
           es
-            ? "Respaldo visual de: e-comm (Monitas), educación (Edu21), funnels, design ops y FO. Tools: web, CX, Figma, Design Ops."
-            : "Visual backing for: e-comm (Monitas), education (Edu21), funnels, design ops, and FO. Tools: web, CX, Figma, Design Ops."
+            ? "E-comm, educación, funnels y front office — Design Ops y Figma en práctica."
+            : "E-comm, education, funnels, and front office — Design Ops and Figma in practice."
         }
       />
 
@@ -92,9 +92,7 @@ export function MetodoRoEvidence() {
               </CardHeader>
               <CardContent className="pt-0">
                 <p className="text-xs text-muted-foreground">
-                  {es
-                    ? "Evidencia · cargo UX Manager VN"
-                    : "Evidence · UX Manager VN role"}
+                  {es ? "Viento Norte · N2N" : "Viento Norte · N2N"}
                 </p>
               </CardContent>
             </Card>

--- a/src/components/organisms/Micro1ToolEvidence.tsx
+++ b/src/components/organisms/Micro1ToolEvidence.tsx
@@ -28,13 +28,13 @@ export function Micro1ToolEvidence() {
         titleId="micro1-evidence-heading"
         title={
           es
-            ? "Evidencia de tools · Anotación y QA"
-            : "Tool evidence · Annotation and QA"
+            ? "micro1 · captura y calidad"
+            : "micro1 · capture and quality"
         }
         description={
           es
-            ? "Proceso de captura remota (EE.UU.). Sin capturas de títulos AAA (NDA / tooling)."
-            : "Remote capture process (US). No AAA title captures (NDA / tooling)."
+            ? "Captura remota, anotación y QA de grabación en proyectos AAA (EE.UU.)."
+            : "Remote capture, annotation, and recording QA on AAA projects (US)."
         }
       />
 

--- a/src/components/organisms/ProfileScope.tsx
+++ b/src/components/organisms/ProfileScope.tsx
@@ -15,7 +15,7 @@ const PROOF = {
     {
       icon: LayoutPanelLeft,
       label: "Interfaces",
-      detail: "Empresas CL + wealth · wall arriba",
+      detail: "Producto en empresas CL y wealth regional",
     },
     {
       icon: Globe2,
@@ -32,7 +32,7 @@ const PROOF = {
     {
       icon: LayoutPanelLeft,
       label: "Interfaces",
-      detail: "CL product + wealth · wall above",
+      detail: "Product UI for CL companies and regional wealth",
     },
     {
       icon: Globe2,
@@ -78,8 +78,8 @@ export function ProfileScope() {
         title={es ? "Dónde sumo" : "Where I add value"}
         description={
           es
-            ? "Segundo nivel: contexto de mercado tras el método."
-            : "Second level: market context after method."
+            ? "Nacional, regional e internacional — en paralelo a Viento Norte."
+            : "National, regional, and international — alongside Viento Norte."
         }
       />
 

--- a/src/components/organisms/Skills.tsx
+++ b/src/components/organisms/Skills.tsx
@@ -53,8 +53,8 @@ export function Skills() {
         title={es ? "Método en una mirada" : "Method at a glance"}
         description={
           es
-            ? "Fases del craft. Abajo: evidencia de casos VN (no el portafolio enterprise)."
-            : "Craft phases. Below: VN case evidence (not the enterprise portfolio)."
+            ? "Journey, flows, test y design system en el trabajo diario."
+            : "Journey, flows, test, and design system in day-to-day work."
         }
       />
 

--- a/src/components/organisms/TrajectoryRail.tsx
+++ b/src/components/organisms/TrajectoryRail.tsx
@@ -63,7 +63,7 @@ export function TrajectoryRail({ className }: { className?: string }) {
       className={cn("w-full", className)}
     >
       <p className="mb-3 text-center font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground sm:text-left">
-        {es ? "Dónde sumo · no solo un CV lineal" : "Where I ship · not a flat CV"}
+        {es ? "Alcance de trabajo" : "Work scope"}
       </p>
       <ol className="flex flex-wrap items-stretch justify-between gap-2 sm:gap-0">
         {stages.map((s, i) => {


### PR DESCRIPTION
Quita blurbs tipo «Ficha clara para reclutamiento» y notas de arquitectura de página. Copy humano en secciones Sobre mí.