### PR TITLE
fix(qa): visible 404/500/503 + production error smoke

### DIFF
--- a/docs/QA-ERROR-UI.md
+++ b/docs/QA-ERROR-UI.md
@@ -1,0 +1,72 @@
+# QA: errores 404 / 500 / 503 visibles
+
+En **HashRouter + GitHub Pages**, casi todo devuelve HTTP 200 del shell. Los códigos **404 / 500 / 503 que ve el usuario son de la app**, no del servidor. Si solo corremos `curl` de happy-path, **nunca fallan las cargas rotas** y el UI de error parece “desaparecido”.
+
+## Superficies
+
+| Código | Cuándo | Dónde se pinta |
+|--------|--------|----------------|
+| **404** | Ruta hash desconocida / proyecto / proceso no existe | `NotFoundPage` — número grande + `data-error-status="404"` |
+| **404** | Imagen `src` falla (`onError`) | `ResponsiveImage` — badge rojo **404** + “Imagen no encontrada” |
+| **503** | Fallo de chunk lazy post-deploy / SW stale | `ErrorBoundary` — un reload auto, luego UI **503** |
+| **500** | Error de render React no recuperable | `ErrorBoundary` — UI **500** |
+
+## Por qué no los veías
+
+1. **Rutas:** `NotFoundPage` solo decía un párrafo sin el número 404.
+2. **Imágenes:** fallback era un SVG gris sin etiqueta.
+3. **Chunks:** un reload silencioso; si fallaba de nuevo, “Oops” genérico sin 503.
+4. **`qa:production`:** solo comprobaba HTTP 200 (home, robots, bundle). Nunca un asset 404 ni strings de error en el bundle.
+
+## Proceso a producción (orden)
+
+```text
+1. Local
+   npm run qa:error-ui          # unit + markers
+   npm run dev
+   # humano: #/ruta-inexistente → 404
+
+2. Pre-merge
+   npm run preprod:quick        # typecheck + unit + build
+   npm run preprod              # + dist smoke
+
+3. Post-merge Pages
+   npm run qa:production        # domain + assets + probe 404 red + bundle error UI
+   BASE_URL=https://vientonorte.io/qa npm run qa:production   # si QA env
+
+4. Humano 2 min en prod
+   https://vientonorte.io/#/esto-no-existe     → 404 grande
+   Network → bloquear 1 imagen en #/sobre-mi  → badge 404
+```
+
+## Comandos
+
+| Script | Rol |
+|--------|-----|
+| `npm run qa:error-ui` | Gate local de UI de error |
+| `npm run qa:production` | Smoke prod + 404 de red + bundle markers |
+| `npm run preprod` | Gate FO antes de merge |
+
+## Reproducir en local
+
+```bash
+# 404 de ruta
+open 'http://127.0.0.1:5173/#/pagina-que-no-existe'
+
+# 404 de imagen (cualquier ResponsiveImage con src inventado en React DevTools,
+# o temporalmente fuerza src="/__broken__.png")
+
+# 503 chunk (simular)
+# En consola, tras cargar:
+sessionStorage.removeItem('rg-chunk-reload')
+# Forzar error de tipo chunk (ErrorBoundary clasifica por mensaje):
+# throw new Error('Failed to fetch dynamically imported module')
+```
+
+## DoD
+
+- [ ] `#/ruta-falsa` muestra **404** legible en móvil
+- [ ] Imagen rota muestra badge **404** (no solo icono gris)
+- [ ] Fallo de chunk muestra **503** (no pantalla blanca)
+- [ ] `qa:production` falla si falta el bundle o si un probe de asset inventado devuelve 200
+- [ ] `qa:error-ui` verde en CI/local antes de merge de cambios de error UI

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "preprod": "bash scripts/preprod-gate.sh",
     "preprod:quick": "bash scripts/preprod-gate.sh --quick",
     "preprod:dev": "bash scripts/preprod-gate.sh --with-dev",
-    "preprod:routes": "bash scripts/preprod-gate.sh --with-routes"
+    "preprod:routes": "bash scripts/preprod-gate.sh --with-routes",
+    "qa:error-ui": "bash scripts/qa-error-ui.sh"
   },
   "optionalDependencies": {
     "@rolldown/binding-darwin-arm64": "^1.1.4"

--- a/scripts/preprod-gate.sh
+++ b/scripts/preprod-gate.sh
@@ -69,6 +69,7 @@ echo "════════════════════════�
 run_step "type-check" npm run type-check || true
 run_step "unit tests" npm test || true
 run_step "nav config" npm run qa:nav || true
+run_step "error UI (404/500/503)" npm run qa:error-ui || true
 
 if [[ "$QUICK" -eq 1 ]]; then
   echo ""

--- a/scripts/qa-error-ui.sh
+++ b/scripts/qa-error-ui.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Local / preview gate for visible error UI (404 / 500 / 503).
+# Does NOT require production. Run against dev or preview:
+#
+#   npm run dev   # terminal A
+#   npm run qa:error-ui
+#
+# Or: BASE=http://127.0.0.1:4173 npm run qa:error-ui
+#
+# Checks:
+#   - unit tests for ResponsiveImage 404 + ErrorBoundary classification
+#   - bundle / source markers for data-error-status
+#   - curl fake asset → not 200 when BASE is a static server with real FS
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+BASE="${BASE:-http://127.0.0.1:5173}"
+BASE="${BASE%/}"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); echo "✓ $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "✗ $1" >&2; }
+
+echo "══════════════════════════════════════════"
+echo " QA error UI · BASE=$BASE"
+echo "══════════════════════════════════════════"
+
+echo ""
+echo "── unit: ResponsiveImage 404 + lazy chunk classifier ──"
+if npx vitest run \
+  src/__tests__/atoms/ResponsiveImage.test.tsx \
+  src/__tests__/lib/lazy-with-retry.test.ts \
+  src/__tests__/organisms/ErrorBoundary.test.tsx \
+  --reporter=dot 2>&1; then
+  ok "vitest error UI suite"
+else
+  bad "vitest error UI suite"
+fi
+
+echo ""
+echo "── source markers ──"
+if grep -q 'data-error-status' src/components/layout/NotFoundPage.tsx \
+  && grep -q 'data-error-status' src/components/organisms/ErrorBoundary.tsx \
+  && grep -q 'data-error-status' src/components/atoms/ResponsiveImage.tsx; then
+  ok "data-error-status on NotFound / ErrorBoundary / ResponsiveImage"
+else
+  bad "missing data-error-status markers"
+fi
+
+if grep -q '503' src/components/organisms/ErrorBoundary.tsx \
+  && grep -q '500' src/components/organisms/ErrorBoundary.tsx; then
+  ok "ErrorBoundary exposes 500 and 503"
+else
+  bad "ErrorBoundary missing 500/503 codes"
+fi
+
+if grep -q '404' src/components/layout/NotFoundPage.tsx \
+  && grep -q '404' src/components/atoms/ResponsiveImage.tsx; then
+  ok "404 visible in NotFoundPage + ResponsiveImage"
+else
+  bad "404 labels missing"
+fi
+
+echo ""
+echo "── optional live BASE ──"
+if curl -sf --max-time 3 "$BASE/" >/dev/null 2>&1; then
+  ok "BASE reachable $BASE/"
+  code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 \
+    "$BASE/assets/__vn_missing_probe__.js" || echo "000")
+  if [ "$code" != "200" ]; then
+    ok "missing asset probe HTTP $code (!= 200)"
+  else
+    bad "missing asset probe returned 200"
+  fi
+  echo ""
+  echo "Humano (30 s):"
+  echo "  1. Abre ${BASE}/#/ruta-inexistente-vn → debe verse 404 grande"
+  echo "  2. Abre ${BASE}/#/sobre-mi y en DevTools bloquea una imagen → badge 404"
+  echo "  3. En consola: sessionStorage.clear(); throw new Error('Importing a module script failed.')"
+  echo "     (o fuerza chunk fail) → UI 503 tras reintentos"
+else
+  echo "· BASE no responde ($BASE) — salta probe live (arranque npm run dev)"
+fi
+
+echo ""
+echo "Resultado: $PASS passed · $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+echo "PASS qa:error-ui"
+exit 0

--- a/scripts/qa-production.sh
+++ b/scripts/qa-production.sh
@@ -1,25 +1,65 @@
 #!/usr/bin/env bash
-# Smoke QA contra producción (domain root).
-# Default: https://vientonorte.io  (legacy override: BASE_URL=https://vientonorte.github.io)
+# Smoke QA contra producción (domain root) + probes de fallo controlado.
+# Default: https://vientonorte.io
+#
+# Qué cubre (técnico, sin browser):
+#   1. Shell SPA 200 + bundle + brand/meta
+#   2. Assets críticos 200 (favicon, robots, profile, sample images)
+#   3. 404 real de asset ausente (servidor debe devolver != 200)
+#   4. Bundle contiene UI de error (404 / 500 / 503) para fallos client-side
+#   5. Rutas hash conocidas siguen sirviendo el shell (no HTTP 404 de Pages)
+#
+# Qué NO cubre (humano / Playwright):
+#   - Ver el número 404 en #/ruta-inexistente
+#   - Ver badge 404 en imagen rota
+#   - Ver 503 tras chunk stale
+#   → docs/QA-ERROR-UI.md + npm run qa:error-ui (local)
+#
+# Exit 0 = PASS técnico · 1 = FAIL
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-https://vientonorte.io}"
 BASE_URL="${BASE_URL%/}"
 PASS=0
 FAIL=0
+WARN=0
 
 check_http() {
   local label="$1"
   local url="$2"
+  local expect="${3:-200}"
   local code
-  code=$(curl -fsSL -o /dev/null -w "%{http_code}" --max-time 20 "$url" || echo "000")
-  if [ "$code" = "200" ]; then
+  code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 20 "$url" || echo "000")
+  if [ "$code" = "$expect" ]; then
     echo "✓ $label (HTTP $code)"
     PASS=$((PASS + 1))
   else
-    echo "✗ $label (HTTP $code)"
+    echo "✗ $label (HTTP $code, expected $expect) — $url"
     FAIL=$((FAIL + 1))
   fi
+}
+
+# Accept any 4xx as "resource missing" (GH Pages may 404; CDN may 403)
+check_missing() {
+  local label="$1"
+  local url="$2"
+  local code
+  code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 20 "$url" || echo "000")
+  case "$code" in
+    404|403|410)
+      echo "✓ $label (HTTP $code — asset ausente visible en red)"
+      PASS=$((PASS + 1))
+      ;;
+    200)
+      echo "✗ $label (HTTP 200 — se esperaba 404/403 en path inventado)"
+      FAIL=$((FAIL + 1))
+      ;;
+    *)
+      echo "· $label (HTTP $code — no es 200; se acepta como no-disponible)"
+      WARN=$((WARN + 1))
+      PASS=$((PASS + 1))
+      ;;
+  esac
 }
 
 check_html() {
@@ -48,20 +88,24 @@ check_not_html() {
   fi
 }
 
-echo "QA producción — $BASE_URL"
-echo "---"
+echo "══════════════════════════════════════════"
+echo " QA producción — $BASE_URL"
+echo " $(date -u +%Y-%m-%dT%H:%MZ)"
+echo "══════════════════════════════════════════"
 
 HTML_FILE=$(mktemp)
 JS_FILE=$(mktemp)
 trap 'rm -f "$HTML_FILE" "$JS_FILE"' EXIT
 
+echo ""
+echo "── 1. Shell SPA ──"
 if ! curl -fsSL --max-time 25 "$BASE_URL/" -o "$HTML_FILE"; then
   echo "✗ Cannot fetch $BASE_URL/"
   exit 1
 fi
 echo "✓ fetch home"
+PASS=$((PASS + 1))
 
-# Domain-root SPA: /assets/… not /mi-portafolio/assets/
 JS_PATH=$(grep -oE '/assets/[^"]+\.js' "$HTML_FILE" | head -1 || true)
 if [[ -z "$JS_PATH" ]]; then
   JS_PATH=$(grep -oE 'assets/[^"]+\.js' "$HTML_FILE" | head -1 || true)
@@ -76,16 +120,18 @@ if [[ -z "$JS_PATH" ]]; then
 else
   echo "✓ JS path $JS_PATH"
   PASS=$((PASS + 1))
-  curl -fsSL --max-time 30 "${BASE_URL}${JS_PATH}" -o "$JS_FILE" || {
+  if curl -fsSL --max-time 30 "${BASE_URL}${JS_PATH}" -o "$JS_FILE"; then
+    echo "✓ JS bundle fetch ($(wc -c < "$JS_FILE" | tr -d ' ') bytes)"
+    PASS=$((PASS + 1))
+  else
     echo "✗ JS bundle fetch failed"
     FAIL=$((FAIL + 1))
-  }
+  fi
 fi
 
 check_html "shell #root" 'id="root"' "$HTML_FILE"
 check_not_html "no stale /mi-portafolio/assets in shell" '/mi-portafolio/assets/' "$HTML_FILE"
 
-# Title / meta (org brand — not only personal name as sole brand if VN title shipped)
 if grep -qiE 'viento|norte|UX|consultor' "$HTML_FILE"; then
   echo "✓ brand/meta markers in shell"
   PASS=$((PASS + 1))
@@ -102,28 +148,107 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# Bundle signals (if JS fetched)
+echo ""
+echo "── 2. Bundle: rutas + UI de error (client-side 404/5xx) ──"
 if [[ -s "$JS_FILE" ]]; then
   check_html "HashRouter / consultoria path" 'consultoria' "$JS_FILE"
   check_html "embudo or onboarding markers" 'onboarding|embudo|consultoria-onboarding' "$JS_FILE"
   check_html "analytics or tracker wiring" 'VNTracker|gtag|GTM|dataLayer' "$JS_FILE"
+  # Error UI must ship in prod bundle — otherwise failures stay invisible
+  check_html "error UI status marker (data-error-status)" 'data-error-status|error-status' "$JS_FILE"
+  check_html "error UI 404 label" '404' "$JS_FILE"
+  check_html "error UI 500 or 503" '503|500' "$JS_FILE"
+  check_html "chunk load error classifier" 'ChunkLoadError|failed to fetch dynamically|importing a module script' "$JS_FILE"
+  check_html "sobre-mi route present" 'sobre-mi|SobreMi' "$JS_FILE"
+else
+  echo "✗ JS bundle empty — skip content checks"
+  FAIL=$((FAIL + 1))
 fi
 
-# Critical static URLs
+echo ""
+echo "── 3. HTTP critical surfaces (200) ──"
 check_http "home" "$BASE_URL/"
 check_http "robots.txt" "$BASE_URL/robots.txt"
 check_http "sitemap.xml" "$BASE_URL/sitemap.xml"
-check_http "favicon" "$BASE_URL/favicon.svg"
+check_http "favicon.svg" "$BASE_URL/favicon.svg"
+check_http "manifest" "$BASE_URL/manifest.json"
+check_http "profile photo" "$BASE_URL/profile-photo.jpg"
 check_http "ops noindex surface" "$BASE_URL/ops/"
 check_http "ops canvas-state" "$BASE_URL/ops/canvas-state.json"
 check_http "finanzas worker" "https://finanzas.vientonorte.io/"
-
-# SEM path is client-side; we only assert shell loads for hash routes via home
 check_http "github.io redirect host" "https://vientonorte.github.io/"
 
-echo "---"
-echo "Resultado: $PASS passed, $FAIL failed"
-echo "Nota: H2/H4/H5/S2 browser smoke es HUMANO → /ops/AHORA-CLOSE-CHECKLIST.md"
+echo ""
+echo "── 4. Critical content assets (200) ──"
+# Paths used by sobre-mi / method evidence — fail deploy if missing
+for path in \
+  "/images/branding/vn-logo.svg" \
+  "/favicon.ico" \
+  "/icon-192x192.png"
+do
+  # soft: some may not exist; try common set
+  code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 "${BASE_URL}${path}" || echo "000")
+  if [ "$code" = "200" ]; then
+    echo "✓ asset $path (HTTP 200)"
+    PASS=$((PASS + 1))
+  else
+    # Only hard-fail on favicon/icon; logo may live elsewhere
+    if [[ "$path" == "/favicon.ico" || "$path" == "/icon-192x192.png" ]]; then
+      echo "✗ asset $path (HTTP $code)"
+      FAIL=$((FAIL + 1))
+    else
+      echo "· asset $path (HTTP $code) — warn"
+      WARN=$((WARN + 1))
+    fi
+  fi
+done
+
+# Sample public images folder — at least one case image if present
+SAMPLE_IMG=$(curl -sS --max-time 15 "$BASE_URL/images/" 2>/dev/null | head -c 200 || true)
+# Probe known monitas / edu paths used in evidence (soft)
+for path in \
+  "/profile-photo.jpg" \
+  "/images/cases/sura-ria-1.jpg" \
+  "/monitas/01.jpg"
+do
+  code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 "${BASE_URL}${path}" || echo "000")
+  if [ "$code" = "200" ]; then
+    echo "✓ content asset $path"
+    PASS=$((PASS + 1))
+  else
+    echo "· content asset $path (HTTP $code) — warn (may not be in this deploy)"
+    WARN=$((WARN + 1))
+  fi
+done
+
+echo ""
+echo "── 5. Controlled 404 (servidor) ──"
+# Invented path MUST NOT return 200 — proves network layer can signal missing files
+check_missing "fake asset path" "$BASE_URL/assets/__vn_missing_probe_do_not_create__.js"
+check_missing "fake image path" "$BASE_URL/images/__vn_missing_probe__.png"
+
+echo ""
+echo "── 6. Hash routes still get SPA shell (not Pages hard-404) ──"
+# GH Pages serves index for /; hash is client-only. Fetching /#/… is same as /.
+# We assert index is served so client can paint GlobalNotFound for unknown hash.
+check_http "shell for client routing" "$BASE_URL/"
+# Optional path-style (if someone hits without hash) — still expect 200 index or redirect
+code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 "$BASE_URL/sobre-mi" || echo "000")
+if [ "$code" = "200" ] || [ "$code" = "301" ] || [ "$code" = "302" ] || [ "$code" = "404" ]; then
+  # 404 on path-style is OK for HashRouter sites; 200 means SPA fallback configured
+  echo "✓ path /sobre-mi responded HTTP $code (document for HashRouter note)"
+  PASS=$((PASS + 1))
+else
+  echo "· path /sobre-mi HTTP $code"
+  WARN=$((WARN + 1))
+fi
+
+echo ""
+echo "══════════════════════════════════════════"
+echo " Resultado: $PASS passed · $FAIL failed · $WARN warnings"
+echo " Humano: abrir #/ruta-que-no-existe → debe verse 404 grande"
+echo "         docs/QA-ERROR-UI.md · npm run qa:error-ui"
+echo "══════════════════════════════════════════"
 
 if [ "$FAIL" -gt 0 ]; then
   exit 1

--- a/src/__tests__/atoms/ResponsiveImage.test.tsx
+++ b/src/__tests__/atoms/ResponsiveImage.test.tsx
@@ -14,11 +14,18 @@ describe("ResponsiveImage", () => {
     expect(screen.getByRole("img", { name: "Proyecto SURA RIA" })).toBeInTheDocument();
   });
 
-  it("shows error fallback when image fails to load", () => {
+  it("shows visible 404 fallback when image fails to load", () => {
     render(<ResponsiveImage src="/broken.png" alt="Imagen rota" />);
     const img = screen.getByRole("img", { name: "Imagen rota" });
     fireEvent.error(img);
-    expect(screen.getByRole("img", { name: "Imagen rota" })).toBeInTheDocument();
+    const fallback = screen.getByTestId("image-error-404");
+    expect(fallback).toHaveAttribute("data-error-status", "404");
+    expect(fallback).toHaveAttribute(
+      "aria-label",
+      expect.stringMatching(/404/)
+    );
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByText(/Imagen no encontrada/i)).toBeInTheDocument();
   });
 
   it("supports click handler for lightbox triggers", () => {

--- a/src/__tests__/organisms/ErrorBoundary.test.tsx
+++ b/src/__tests__/organisms/ErrorBoundary.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ErrorBoundary } from "@/components/organisms/ErrorBoundary";
+
+function Boom({ message }: { message: string }) {
+  throw new Error(message);
+}
+
+describe("ErrorBoundary", () => {
+  const originalError = console.error;
+
+  beforeEach(() => {
+    console.error = vi.fn();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  it("shows 500 for runtime render errors", () => {
+    render(
+      <ErrorBoundary>
+        <Boom message="unexpected render failure" />
+      </ErrorBoundary>
+    );
+
+    const root = screen.getByTestId("error-status-boundary");
+    expect(root).toHaveAttribute("data-error-status", "500");
+    expect(screen.getByLabelText("Error 500")).toBeInTheDocument();
+    expect(screen.getByText(/Error del servidor de la app/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/unexpected render failure/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows 503 for chunk load errors after auto-reload flag is set", () => {
+    sessionStorage.setItem("rg-chunk-reload", "1");
+
+    render(
+      <ErrorBoundary>
+        <Boom message="Failed to fetch dynamically imported module: ./Page.js" />
+      </ErrorBoundary>
+    );
+
+    const root = screen.getByTestId("error-status-boundary");
+    expect(root).toHaveAttribute("data-error-status", "503");
+    expect(screen.getByLabelText("Error 503")).toBeInTheDocument();
+    expect(screen.getByText(/Contenido no disponible/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/atoms/ResponsiveImage.tsx
+++ b/src/components/atoms/ResponsiveImage.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
+import { ImageOff } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { Skeleton } from "../ui/skeleton";
-
-const ERROR_IMG_SRC =
-  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg==";
 
 export type ImageFit = "cover" | "contain" | "scale-down";
 
@@ -25,6 +23,10 @@ const fitClasses: Record<ImageFit, string> = {
   "scale-down": "object-scale-down object-center",
 };
 
+/**
+ * Image with visible 404 state when load fails.
+ * Soft failures used to show only a faint SVG — now a clear badge.
+ */
 export function ResponsiveImage({
   src,
   alt,
@@ -45,14 +47,29 @@ export function ResponsiveImage({
     return (
       <div
         className={cn(
-          "flex items-center justify-center bg-muted/40 text-muted-foreground",
+          "relative flex flex-col items-center justify-center gap-2 bg-muted/50 text-muted-foreground border border-dashed border-destructive/30",
           className
         )}
         style={wrapperStyle}
         role="img"
-        aria-label={alt}
+        aria-label={`${alt} — error 404, imagen no disponible`}
+        data-error-status="404"
+        data-testid="image-error-404"
+        title={`404 · ${src}`}
       >
-        <img src={ERROR_IMG_SRC} alt="" aria-hidden className="h-10 w-10 opacity-40" />
+        <span
+          className="absolute top-2 right-2 rounded-md bg-destructive text-destructive-foreground text-[10px] font-bold tracking-wide px-1.5 py-0.5 tabular-nums shadow-sm"
+          aria-hidden
+        >
+          404
+        </span>
+        <ImageOff className="h-8 w-8 opacity-50" aria-hidden />
+        <span className="text-xs font-medium text-center px-2 max-w-[90%] line-clamp-2">
+          Imagen no encontrada
+        </span>
+        <span className="text-[10px] font-mono opacity-60 truncate max-w-[90%] px-2">
+          HTTP 404
+        </span>
       </div>
     );
   }

--- a/src/components/layout/NotFoundPage.tsx
+++ b/src/components/layout/NotFoundPage.tsx
@@ -1,39 +1,90 @@
 import { useNavigate } from "react-router-dom";
+import { ArrowLeft, FileQuestion, Home } from "lucide-react";
 import { Button } from "../ui/button";
 import { PageShell } from "./PageShell";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { withHomeCrumb } from "../../lib/breadcrumb-helpers";
+import { ROUTES } from "../../lib/routes";
 
 interface NotFoundPageProps {
   message: string;
   backLabel: string;
   onBack: () => void;
   crumbLabel: string;
+  /** HTTP-style status shown large — default 404 */
+  statusCode?: number;
+  title?: string;
 }
 
+/**
+ * Visible client-side not-found surface.
+ * HashRouter never returns real HTTP 404 for SPA paths — this is the UI signal.
+ */
 export function NotFoundPage({
   message,
   backLabel,
   onBack,
   crumbLabel,
+  statusCode = 404,
+  title,
 }: NotFoundPageProps) {
   const { language } = useLanguage();
   const t = useTranslation(language);
   const navigate = useNavigate();
+  const heading =
+    title ??
+    (language === "en" ? "Page not found" : "Página no encontrada");
 
   return (
     <PageShell
-      crumbs={withHomeCrumb(t.breadcrumbs.home, () => navigate("/"), [
-        { label: t.breadcrumbs.projects, onClick: () => navigate("/proyectos") },
+      crumbs={withHomeCrumb(t.breadcrumbs.home, () => navigate(ROUTES.home), [
+        { label: t.breadcrumbs.projects, onClick: () => navigate(ROUTES.projects) },
         { label: crumbLabel, current: true },
       ])}
     >
-      <div className="container max-w-3xl mx-auto py-24 px-4 text-center">
-        <p className="text-muted-foreground mb-6">{message}</p>
-        <Button type="button" variant="outline" onClick={onBack}>
-          {backLabel}
-        </Button>
+      <div
+        className="container max-w-2xl mx-auto py-16 sm:py-24 px-4 text-center space-y-6"
+        role="alert"
+        aria-live="polite"
+        data-error-status={statusCode}
+        data-testid="error-status-page"
+      >
+        <div className="flex justify-center" aria-hidden>
+          <div className="w-20 h-20 rounded-2xl bg-muted/60 flex items-center justify-center border border-border/60">
+            <FileQuestion className="w-10 h-10 text-muted-foreground" />
+          </div>
+        </div>
+
+        <p
+          className="text-7xl sm:text-8xl font-bold tracking-tight bg-gradient-to-br from-foreground to-muted-foreground bg-clip-text text-transparent tabular-nums"
+          aria-label={language === "en" ? `Error ${statusCode}` : `Error ${statusCode}`}
+        >
+          {statusCode}
+        </p>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
+          <p className="text-muted-foreground max-w-md mx-auto">{message}</p>
+          <p className="text-xs text-muted-foreground/80 font-mono">
+            HTTP {statusCode}
+          </p>
+        </div>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 pt-2">
+          <Button type="button" variant="outline" onClick={onBack} className="gap-2">
+            <ArrowLeft className="h-4 w-4" />
+            {backLabel}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => navigate(ROUTES.home)}
+            className="gap-2"
+          >
+            <Home className="h-4 w-4" />
+            {t.errors.backToHome}
+          </Button>
+        </div>
       </div>
     </PageShell>
   );

--- a/src/components/organisms/ErrorBoundary.tsx
+++ b/src/components/organisms/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component, ReactNode } from "react";
-import { AlertCircle, RefreshCw } from "lucide-react";
+import { AlertCircle, RefreshCw, Home, ServerCrash } from "lucide-react";
 import { Button } from "../ui/button";
 import { isChunkLoadError } from "../../lib/lazy-with-retry";
 
@@ -14,20 +14,18 @@ interface State {
   hasError: boolean;
   error?: Error;
   errorInfo?: React.ErrorInfo;
+  /** 503 = chunk/deploy stale; 500 = runtime */
+  statusCode?: 500 | 503;
+}
+
+function classifyError(error: Error | undefined): 500 | 503 {
+  if (error && isChunkLoadError(error)) return 503;
+  return 500;
 }
 
 /**
- * Error Boundary component to catch and handle React errors gracefully
- * 
- * Usage:
- * <ErrorBoundary>
- *   <YourComponent />
- * </ErrorBoundary>
- * 
- * With custom fallback:
- * <ErrorBoundary fallback={<CustomErrorUI />}>
- *   <YourComponent />
- * </ErrorBoundary>
+ * Error Boundary — always shows a visible HTTP-style status (500 / 503)
+ * so content-load failures are obvious in production and QA.
  */
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
@@ -36,7 +34,10 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error): State {
-    if (isChunkLoadError(error) && !sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+    const statusCode = classifyError(error);
+
+    // One automatic reload for stale chunks after deploy (SW / renamed assets)
+    if (statusCode === 503 && !sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
       try {
         sessionStorage.setItem(CHUNK_RELOAD_KEY, "1");
       } catch {
@@ -45,85 +46,127 @@ export class ErrorBoundary extends Component<Props, State> {
       window.location.reload();
     }
 
-    return { hasError: true, error };
+    return { hasError: true, error, statusCode };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    // Log error to console in development
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
-    
-    // You can also log the error to an error reporting service here
-    // Example: logErrorToService(error, errorInfo);
-    
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
     this.setState({
       error,
-      errorInfo
+      errorInfo,
+      statusCode: classifyError(error),
     });
   }
 
   handleReload = () => {
+    try {
+      sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+    } catch {
+      /* ignore */
+    }
     window.location.reload();
   };
 
   handleReset = () => {
-    this.setState({ hasError: false, error: undefined, errorInfo: undefined });
+    this.setState({
+      hasError: false,
+      error: undefined,
+      errorInfo: undefined,
+      statusCode: undefined,
+    });
+  };
+
+  handleHome = () => {
+    try {
+      sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+    } catch {
+      /* ignore */
+    }
+    window.location.hash = "#/";
+    window.location.reload();
   };
 
   render() {
     if (this.state.hasError) {
-      // Custom fallback if provided
       if (this.props.fallback) {
         return this.props.fallback;
       }
 
-      // Default error UI
+      const status = this.state.statusCode ?? 500;
+      const isChunk = status === 503;
+      const title = isChunk
+        ? "Contenido no disponible"
+        : "Error del servidor de la app";
+      const description = isChunk
+        ? "No se pudo cargar un módulo (chunk). Suele pasar tras un deploy o caché vieja. Recarga para obtener la versión actual."
+        : this.state.error?.message ||
+          "Ha ocurrido un error inesperado al renderizar esta vista.";
+
       return (
-        <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-background to-muted">
+        <div
+          className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-background to-muted"
+          role="alert"
+          aria-live="assertive"
+          data-error-status={status}
+          data-testid="error-status-boundary"
+        >
           <div className="max-w-md w-full text-center space-y-6 p-8 bg-card rounded-lg border shadow-lg">
             <div className="flex justify-center">
               <div className="p-3 bg-destructive/10 rounded-full">
-                <AlertCircle className="h-12 w-12 text-destructive" />
+                {isChunk ? (
+                  <ServerCrash className="h-12 w-12 text-destructive" />
+                ) : (
+                  <AlertCircle className="h-12 w-12 text-destructive" />
+                )}
               </div>
             </div>
-            
+
+            <p
+              className="text-7xl font-bold tracking-tight text-destructive/90 tabular-nums"
+              aria-label={`Error ${status}`}
+            >
+              {status}
+            </p>
+
             <div className="space-y-2">
-              <h2 className="text-2xl font-bold text-foreground">
-                Oops! Algo salió mal
-              </h2>
-              <p className="text-muted-foreground">
-                {this.state.error?.message || "Ha ocurrido un error inesperado."}
+              <h2 className="text-2xl font-bold text-foreground">{title}</h2>
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                {description}
+              </p>
+              <p className="text-xs font-mono text-muted-foreground/80">
+                HTTP {status}
+                {isChunk ? " · chunk / deploy" : " · runtime"}
               </p>
             </div>
 
             {import.meta.env.DEV && this.state.errorInfo && (
-              <details className="text-left mt-4 p-4 bg-muted rounded border">
+              <details className="text-left mt-2 p-4 bg-muted rounded border">
                 <summary className="cursor-pointer font-semibold text-sm mb-2">
                   Detalles técnicos
                 </summary>
-                <pre className="text-xs overflow-auto whitespace-pre-wrap">
+                <pre className="text-xs overflow-auto whitespace-pre-wrap max-h-40">
                   {this.state.error?.stack}
                 </pre>
               </details>
             )}
 
-            <div className="flex gap-3 justify-center pt-4">
-              <Button 
-                variant="outline" 
-                onClick={this.handleReset}
-              >
+            <div className="flex flex-wrap gap-3 justify-center pt-2">
+              <Button variant="outline" onClick={this.handleReset}>
                 Intentar de nuevo
               </Button>
-              <Button 
-                onClick={this.handleReload}
-                className="gap-2"
-              >
+              <Button onClick={this.handleReload} className="gap-2">
                 <RefreshCw className="h-4 w-4" />
-                Recargar página
+                Recargar
+              </Button>
+              <Button variant="secondary" onClick={this.handleHome} className="gap-2">
+                <Home className="h-4 w-4" />
+                Inicio
               </Button>
             </div>
 
-            <p className="text-xs text-muted-foreground pt-4">
-              Si el problema persiste, por favor contacta al administrador.
+            <p className="text-xs text-muted-foreground pt-2">
+              Si el problema persiste, prueba ventana privada o limpia caché del
+              sitio.
             </p>
           </div>
         </div>

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1476,10 +1476,14 @@ export default {
       companyNotFound: 'We could not find that company.',
       projectNotFound: 'We could not find that project.',
       processNotFound: 'Process not found',
-      pageNotFound: 'We could not find this page.',
+      pageNotFound:
+        'We could not find this page. In this SPA the 404 code is from the app (not the server).',
       backToProjects: 'Back to business',
       backToHome: 'Back to home',
       back: 'Back',
+      imageNotFound: 'Image not found',
+      serverError: 'Application server error',
+      contentUnavailable: 'Content unavailable',
     },
     
     // Process Detail

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -1459,10 +1459,14 @@ export default {
       companyNotFound: 'No encontramos esa empresa.',
       projectNotFound: 'No encontramos ese proyecto.',
       processNotFound: 'Proceso no encontrado',
-      pageNotFound: 'No encontramos esta página.',
+      pageNotFound:
+        'No encontramos esta página. En esta SPA el código 404 es de la app (no del servidor).',
       backToProjects: 'Volver a negocios',
       backToHome: 'Volver al inicio',
       back: 'Volver',
+      imageNotFound: 'Imagen no encontrada',
+      serverError: 'Error del servidor de la app',
+      contentUnavailable: 'Contenido no disponible',
     },
 
     mockups: {


### PR DESCRIPTION
## Summary
- **Why you never saw 404/5xx:** HashRouter always serves shell 200; old NotFound was a quiet paragraph, images failed as a grey SVG, chunk failures reloaded silently, and `qa:production` only checked happy-path 200s.
- **UI:** large **404** on missing routes; **404** badge on broken images; **503** (chunk/deploy) and **500** (runtime) in ErrorBoundary.
- **Process:** `npm run qa:error-ui` (local) · expanded `npm run qa:production` (probes missing assets + error UI strings in bundle) · `docs/QA-ERROR-UI.md`.

## Test plan
- [x] `npm run type-check`
- [x] `npm run qa:error-ui` (8 unit tests + markers)
- [ ] Human: `/#/ruta-inexistente` → big 404
- [ ] Human: broken image on sobre-mi → red 404 badge
- [ ] Post-deploy: `npm run qa:production`