### PR TITLE
feat(sobre-mi): Perfil estratégico (réplica en código)

### DIFF
--- a/src/components/organisms/PerfilEstrategico.tsx
+++ b/src/components/organisms/PerfilEstrategico.tsx
@@ -1,0 +1,291 @@
+import {
+  Eye,
+  Brain,
+  Pencil,
+  Rocket,
+  BarChart3,
+  TrendingUp,
+  Compass,
+  Sparkles,
+  Plus,
+  Equal,
+} from "lucide-react";
+import { PageSection } from "../layout/PageSection";
+import { SectionHeader } from "../molecules/SectionHeader";
+import { ProfileAvatar } from "../atoms/ProfileAvatar";
+import { Badge } from "../ui/badge";
+import { useLanguage } from "../../lib/LanguageContext";
+import { cn } from "../../lib/utils";
+import {
+  PERFIL_CYCLE,
+  PERFIL_DOES,
+  PERFIL_EQUATION,
+  PERFIL_FIELDS,
+  PERFIL_IDENTITY,
+  PERFIL_NORTAMIENTO,
+  PERFIL_PROJECTS,
+  PERFIL_QUOTE,
+  PERFIL_TAGLINE,
+  PERFIL_TOOLS,
+} from "../../data/perfil-estrategico";
+
+const STEP_ICONS = [Eye, Brain, Pencil, Rocket, BarChart3, TrendingUp] as const;
+
+/**
+ * Réplica en código del mapa “Perfil estratégico · piso lógico de campo”.
+ * No pega la infografía: HTML semántico, responsive, i18n, foto del sistema.
+ */
+export function PerfilEstrategico() {
+  const { language } = useLanguage();
+  const es = language === "es";
+  const does = PERFIL_DOES[language];
+  const fields = PERFIL_FIELDS[language];
+  const projects = PERFIL_PROJECTS[language];
+  const identity = PERFIL_IDENTITY[language];
+  const equation = PERFIL_EQUATION[language];
+
+  return (
+    <PageSection
+      id="perfil-estrategico"
+      padding="default"
+      width="wide"
+      tone="matte"
+      aria-labelledby="perfil-estrategico-heading"
+    >
+      <SectionHeader
+        badge={es ? "Perfil estratégico" : "Strategic profile"}
+        badgeIcon={Compass}
+        titleId="perfil-estrategico-heading"
+        title={es ? "Piso lógico de campo" : "Field logic floor"}
+        description={
+          es
+            ? "Sociopolítica aplicada a sistemas, tecnología y personas — el ciclo con el que trabajo."
+            : "Sociopolitics applied to systems, technology, and people — the cycle I work with."
+        }
+      />
+
+      <div className="mx-auto max-w-6xl space-y-8">
+        {/* Quote + identity strip */}
+        <blockquote className="rounded-2xl border border-border/60 bg-card/80 px-5 py-4 text-center shadow-sm sm:px-8 sm:py-5">
+          <p className="text-base font-medium leading-relaxed text-foreground sm:text-lg">
+            “{PERFIL_QUOTE[language]}”
+          </p>
+          <footer className="mt-3 text-sm text-muted-foreground">
+            Rodrigo Gaete Gaona ·{" "}
+            {es
+              ? "UX Leader & AI Product Designer · Estratega de sistemas de decisión"
+              : "UX Leader & AI Product Designer · Decision-systems strategist"}
+          </footer>
+        </blockquote>
+
+        {/* Main board: cycle + portrait + does */}
+        <div className="grid gap-8 lg:grid-cols-[1fr_minmax(200px,240px)_1fr] lg:items-center lg:gap-6">
+          {/* Cycle 1–3 mobile/desktop left */}
+          <ol className="order-2 space-y-3 lg:order-1">
+            {PERFIL_CYCLE.slice(0, 3).map((step, i) => {
+              const Icon = STEP_ICONS[i];
+              return (
+                <li
+                  key={step.n}
+                  className="flex gap-3 rounded-xl border border-border/50 bg-background/70 p-3 shadow-sm"
+                >
+                  <span
+                    className={cn(
+                      "flex h-10 w-10 shrink-0 items-center justify-center rounded-full ring-1",
+                      step.accent
+                    )}
+                    aria-hidden
+                  >
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {step.n}. {es ? step.titleEs : step.titleEn}
+                    </p>
+                    <p className="mt-0.5 text-sm leading-snug text-foreground/90">
+                      {es ? step.bodyEs : step.bodyEn}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+
+          {/* Portrait center */}
+          <div className="order-1 mx-auto w-full max-w-[220px] lg:order-2">
+            <div className="relative mx-auto aspect-square max-w-[200px] overflow-hidden rounded-full ring-4 ring-primary/20 shadow-lg">
+              <ProfileAvatar
+                alt={
+                  es
+                    ? "Rodrigo Gaete — perfil estratégico"
+                    : "Rodrigo Gaete — strategic profile"
+                }
+              />
+            </div>
+            <p className="mt-4 text-center text-xs font-semibold uppercase tracking-wider text-primary">
+              {PERFIL_TAGLINE[language]}
+            </p>
+          </div>
+
+          {/* Cycle 4–6 */}
+          <ol className="order-3 space-y-3">
+            {PERFIL_CYCLE.slice(3, 6).map((step, i) => {
+              const Icon = STEP_ICONS[i + 3];
+              return (
+                <li
+                  key={step.n}
+                  className="flex gap-3 rounded-xl border border-border/50 bg-background/70 p-3 shadow-sm"
+                >
+                  <span
+                    className={cn(
+                      "flex h-10 w-10 shrink-0 items-center justify-center rounded-full ring-1",
+                      step.accent
+                    )}
+                    aria-hidden
+                  >
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {step.n}. {es ? step.titleEs : step.titleEn}
+                    </p>
+                    <p className="mt-0.5 text-sm leading-snug text-foreground/90">
+                      {es ? step.bodyEs : step.bodyEn}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+
+        {/* What / projects / identity */}
+        <div className="grid gap-6 md:grid-cols-3">
+          <section
+            className="rounded-2xl border border-border/50 bg-card p-5"
+            aria-labelledby="perfil-que-hace"
+          >
+            <h3
+              id="perfil-que-hace"
+              className="text-sm font-semibold uppercase tracking-wide text-primary"
+            >
+              {es ? "¿Qué hace?" : "What I do"}
+            </h3>
+            <ul className="mt-3 space-y-2.5">
+              {does.map((line) => (
+                <li
+                  key={line}
+                  className="text-sm leading-snug text-muted-foreground before:mr-2 before:text-primary before:content-['·']"
+                >
+                  {line}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section
+            className="rounded-2xl border border-border/50 bg-card p-5"
+            aria-labelledby="perfil-proyectos"
+          >
+            <h3
+              id="perfil-proyectos"
+              className="text-sm font-semibold uppercase tracking-wide text-primary"
+            >
+              {es ? "Proyectos clave" : "Key projects"}
+            </h3>
+            <ul className="mt-3 space-y-2">
+              {projects.map((p) => (
+                <li key={p} className="text-sm leading-snug text-muted-foreground">
+                  {p}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section
+            className="rounded-2xl border border-border/50 bg-card p-5"
+            aria-labelledby="perfil-identidad"
+          >
+            <h3
+              id="perfil-identidad"
+              className="text-sm font-semibold uppercase tracking-wide text-primary"
+            >
+              {es ? "Identidad" : "Identity"}
+            </h3>
+            <ul className="mt-3 space-y-2.5">
+              {identity.map((line) => (
+                <li key={line} className="text-sm leading-snug text-muted-foreground">
+                  {line}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4 flex flex-wrap gap-1.5">
+              {PERFIL_TOOLS.map((t) => (
+                <Badge key={t} variant="secondary" className="text-[10px] font-normal">
+                  {t}
+                </Badge>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        {/* Fields */}
+        <section aria-labelledby="perfil-campos">
+          <h3
+            id="perfil-campos"
+            className="mb-3 text-center text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            {es ? "Campos que integra" : "Fields integrated"}
+          </h3>
+          <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-9">
+            {fields.map((f) => (
+              <li
+                key={f.label}
+                className="rounded-lg border border-border/40 bg-background/80 px-2 py-2.5 text-center"
+              >
+                <p className="text-xs font-semibold text-foreground">{f.label}</p>
+                <p className="mt-0.5 text-[10px] leading-tight text-muted-foreground">
+                  {f.detail}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Equation + nortamiento */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-primary/20 bg-primary/5 px-5 py-6 text-center">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {es ? "Ecuación personal" : "Personal equation"}
+            </p>
+            <p className="mt-3 flex flex-wrap items-center justify-center gap-2 text-sm font-medium sm:text-base">
+              {equation.parts.map((part, i) => (
+                <span key={part} className="inline-flex items-center gap-2">
+                  {i > 0 && <Plus className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />}
+                  <span className="rounded-md bg-background px-2.5 py-1 ring-1 ring-border/60">
+                    {part}
+                  </span>
+                </span>
+              ))}
+              <Equal className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+              <span className="inline-flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-primary-foreground">
+                <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                {equation.result}
+              </span>
+            </p>
+            <p className="mt-3 text-sm text-muted-foreground">{equation.tagline}</p>
+          </div>
+
+          <div className="rounded-2xl border border-border/50 bg-card px-5 py-6 text-center">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Nortamiento
+            </p>
+            <p className="mt-3 text-sm leading-relaxed text-foreground/90">
+              {PERFIL_NORTAMIENTO[language]}
+            </p>
+          </div>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/data/perfil-estrategico.ts
+++ b/src/data/perfil-estrategico.ts
@@ -1,0 +1,171 @@
+/**
+ * Contenido del Perfil Estratégico (réplica en código del mapa de identidad).
+ * Texto real en DOM — no depende de una imagen pegada.
+ */
+export type PerfilStep = {
+  n: number;
+  titleEs: string;
+  titleEn: string;
+  bodyEs: string;
+  bodyEn: string;
+  /** Tailwind accent for the step disc */
+  accent: string;
+};
+
+export const PERFIL_CYCLE: PerfilStep[] = [
+  {
+    n: 1,
+    titleEs: "Observa",
+    titleEn: "Observe",
+    bodyEs: "Analiza el contexto, identifica patrones, actores y tensiones.",
+    bodyEn: "Analyze context; spot patterns, actors, and tensions.",
+    accent: "bg-sky-500/15 text-sky-700 dark:text-sky-300 ring-sky-500/30",
+  },
+  {
+    n: 2,
+    titleEs: "Entiende",
+    titleEn: "Understand",
+    bodyEs: "Comprende estructuras, incentivos y restricciones invisibles.",
+    bodyEn: "Grasp structures, incentives, and hidden constraints.",
+    accent: "bg-lime-500/15 text-lime-700 dark:text-lime-300 ring-lime-500/30",
+  },
+  {
+    n: 3,
+    titleEs: "Diseña",
+    titleEn: "Design",
+    bodyEs: "Define estrategias, modela soluciones, prioriza impacto.",
+    bodyEn: "Define strategy, model solutions, prioritize impact.",
+    accent: "bg-amber-500/15 text-amber-800 dark:text-amber-300 ring-amber-500/30",
+  },
+  {
+    n: 4,
+    titleEs: "Interviene",
+    titleEn: "Intervene",
+    bodyEs: "Implementa en pequeño, valida con usuarios y datos.",
+    bodyEn: "Ship small; validate with users and data.",
+    accent: "bg-violet-500/15 text-violet-700 dark:text-violet-300 ring-violet-500/30",
+  },
+  {
+    n: 5,
+    titleEs: "Mide",
+    titleEn: "Measure",
+    bodyEs: "Mide impacto real, aprende, ajusta y vuelve a iterar.",
+    bodyEn: "Measure real impact, learn, adjust, iterate.",
+    accent: "bg-cyan-500/15 text-cyan-800 dark:text-cyan-300 ring-cyan-500/30",
+  },
+  {
+    n: 6,
+    titleEs: "Escala",
+    titleEn: "Scale",
+    bodyEs: "Escala lo que funciona, documenta y convierte en capacidad.",
+    bodyEn: "Scale what works; document and turn into capability.",
+    accent: "bg-rose-500/15 text-rose-700 dark:text-rose-300 ring-rose-500/30",
+  },
+];
+
+export const PERFIL_FIELDS = {
+  es: [
+    { label: "Diseño", detail: "Experiencia y comportamiento" },
+    { label: "Datos", detail: "Evidencia y medición" },
+    { label: "Tecnología", detail: "Automatización y capacidad" },
+    { label: "Negocio", detail: "Valor y priorización" },
+    { label: "Regulación", detail: "Límites institucionales" },
+    { label: "Privacidad", detail: "Poder sobre los datos" },
+    { label: "IA", detail: "Multiplicación de capacidad" },
+    { label: "Finanzas", detail: "Restricciones y sostenibilidad" },
+    { label: "Comunicación", detail: "Legitimación y alineación" },
+  ],
+  en: [
+    { label: "Design", detail: "Experience and behavior" },
+    { label: "Data", detail: "Evidence and measurement" },
+    { label: "Technology", detail: "Automation and capacity" },
+    { label: "Business", detail: "Value and prioritization" },
+    { label: "Regulation", detail: "Institutional limits" },
+    { label: "Privacy", detail: "Power over data" },
+    { label: "AI", detail: "Capability multiplier" },
+    { label: "Finance", detail: "Constraints and sustainability" },
+    { label: "Communication", detail: "Legitimacy and alignment" },
+  ],
+} as const;
+
+export const PERFIL_DOES = {
+  es: [
+    "Convierte problemas complejos en sistemas de decisión simples y accionables.",
+    "Diseña experiencias centradas en las personas con enfoque en negocio y datos.",
+    "Usa IA, automatización y datos para multiplicar impacto y eficiencia.",
+    "Construye puentes entre tecnología, negocio, diseño y regulación.",
+  ],
+  en: [
+    "Turns complex problems into simple, actionable decision systems.",
+    "Designs people-centered experiences with business and data focus.",
+    "Uses AI, automation, and data to multiply impact and efficiency.",
+    "Builds bridges between technology, business, design, and regulation.",
+  ],
+} as const;
+
+export const PERFIL_PROJECTS = {
+  es: [
+    "Separación de bases de datos · AFP – SURA Investments",
+    "Privacy Dashboard",
+    "Onboarding & flujos (Hazte Cliente SURA)",
+    "Design System & accesibilidad",
+    "Analytics & experimentación",
+  ],
+  en: [
+    "Database separation · AFP – SURA Investments",
+    "Privacy Dashboard",
+    "Onboarding & flows (SURA Hazte Cliente)",
+    "Design system & accessibility",
+    "Analytics & experimentation",
+  ],
+} as const;
+
+export const PERFIL_EQUATION = {
+  es: {
+    parts: ["Curiosidad", "Sistemas", "Estrategia"],
+    result: "Impacto",
+    tagline: "Menos dependencia, más capacidad de maniobra.",
+  },
+  en: {
+    parts: ["Curiosity", "Systems", "Strategy"],
+    result: "Impact",
+    tagline: "Less dependency, more room to maneuver.",
+  },
+} as const;
+
+export const PERFIL_NORTAMIENTO = {
+  es: "Vivir con propósito: crear sistemas que generen valor y libertad para mí y quienes me rodean.",
+  en: "Live with purpose: build systems that create value and freedom for me and those around me.",
+} as const;
+
+export const PERFIL_QUOTE = {
+  es: "No se trata de hacer más. Se trata de diseñar mejores sistemas para tomar mejores decisiones.",
+  en: "It’s not about doing more. It’s about designing better systems for better decisions.",
+} as const;
+
+export const PERFIL_TAGLINE = {
+  es: "Transforma complejidad en capacidad de decisión",
+  en: "Turns complexity into decision-making capacity",
+} as const;
+
+export const PERFIL_IDENTITY = {
+  es: [
+    "Nació para entender sistemas complejos y convertirlos en soluciones simples y útiles.",
+    "Empático, ético y colaborativo. Diseño centrado en personas y en datos.",
+    "Curioso, autodidacta y resiliente — siempre explorando nuevas fronteras.",
+  ],
+  en: [
+    "Wired to understand complex systems and turn them into simple, useful solutions.",
+    "Empathetic, ethical, collaborative. People- and data-centered design.",
+    "Curious, self-taught, resilient — always exploring new frontiers.",
+  ],
+} as const;
+
+export const PERFIL_TOOLS = [
+  "Figma / FigJam",
+  "Analytics / Data",
+  "IA & automatización",
+  "Design Systems",
+  "GitHub / Obsidian",
+  "MacBook / iPad / iPhone",
+] as const;

--- a/src/pages/SobreMi.tsx
+++ b/src/pages/SobreMi.tsx
@@ -1,4 +1,5 @@
 import { About } from '../components/organisms/About';
+import { PerfilEstrategico } from '../components/organisms/PerfilEstrategico';
 import { Skills } from '../components/organisms/Skills';
 import { ProfileScope } from '../components/organisms/ProfileScope';
 import { Experience } from '../components/organisms/Experience';
@@ -42,7 +43,8 @@ const SobreMi = () => {
         url={canonicalFromPath('/sobre-mi')}
       />
       {/*
-        L1 Perfil
+        L1 Perfil reclutador (ficha)
+        L1b Perfil estratégico (ciclo de campo — réplica en código, no imagen pegada)
         L2 Método + alcance
         L3 Timeline (VN / micro1 con CTA a evidencia)
         L4 Evidencias ancladas al cargo (no galería general)
@@ -51,6 +53,7 @@ const SobreMi = () => {
         Enterprise employment SURA/Transvip → /proyectos
       */}
       <About />
+      <PerfilEstrategico />
       <Skills />
       <ProfileScope />
       <Experience />


### PR DESCRIPTION
## Summary
- Nueva sección **`#perfil-estrategico`** en `/#/sobre-mi` (después del hero reclutador).
- **Réplica en código** del mapa de identidad (ciclo 1–6, ¿qué hace?, proyectos, campos, ecuación, nortamiento) — **no** copy-paste de la infografía a `public/images/`.
- Texto real en DOM (a11y + i18n ES/EN), foto vía `ProfileAvatar` del sistema.

## Test plan
- [ ] Local / QA: `https://…/#/sobre-mi` → scroll a **Perfil estratégico**
- [ ] Móvil: ciclo legible, sin overflow horizontal
- [ ] EN: switch idioma y revisar títulos
- [ ] No hay JPG/PNG nuevo del póster en el PR