### PR TITLE
fix(nav): solo logo en mobile (sin wordmark)

### DIFF
--- a/src/components/molecules/SubpageToolbar.tsx
+++ b/src/components/molecules/SubpageToolbar.tsx
@@ -65,12 +65,18 @@ export function SubpageToolbar({
                       : "Viento Norte · Home"
                 }
               >
-                <Logo
-                  size="sm"
-                  showText={showLogoText}
-                  showRole={false}
-                  interactive
-                />
+                {/* Mobile: solo isologo; sm+: wordmark si showLogoText */}
+                <span className="sm:hidden">
+                  <Logo size="sm" showText={false} showRole={false} interactive />
+                </span>
+                <span className="hidden sm:block">
+                  <Logo
+                    size="sm"
+                    showText={showLogoText}
+                    showRole={false}
+                    interactive
+                  />
+                </span>
               </button>
             )}
             <Breadcrumbs links={crumbs} className="mb-0 min-w-0" />

--- a/src/components/organisms/Navigation.tsx
+++ b/src/components/organisms/Navigation.tsx
@@ -303,14 +303,17 @@ export function Navigation({
             aria-label={`Inicio — ${SEO_SITE.brand} · ${SEO_SITE.role}`}
             data-process-label-variant={processLabelVariant}
           >
+            {/* Mobile: solo isologo — libera ancho para utilidades / menú */}
             <span className="min-w-0 sm:hidden">
               <Logo
                 size="sm"
                 interactive
+                showText={false}
                 showRole={false}
                 plate={isScrolled || isMenuOpen || isOnHome ? "default" : "floating"}
               />
             </span>
+            {/* sm+: lockup completo (marca + wordmark) */}
             <span className="hidden min-w-0 sm:block">
               <Logo
                 size="sm"


### PR DESCRIPTION
## Summary
- **Mobile (&lt; sm):** isologo RG sin texto “Viento Norte”
- **sm+:** lockup completo
- Nav principal + SubpageToolbar
- `aria-label` en el link de inicio mantiene marca accesible

## Test plan
- [ ] Viewport &lt; 640px: header sin “Viento Norte”, solo círculo logo
- [ ] Desktop: wordmark visible
- [ ] Deep page toolbar igual en mobile