### PR TITLE
feat(sobre-mi): radar de perfil en Dónde sumo

### DIFF
--- a/src/components/molecules/ProfileRadar.tsx
+++ b/src/components/molecules/ProfileRadar.tsx
@@ -1,0 +1,233 @@
+import { useId, useMemo, useState } from "react";
+import { useLanguage } from "../../lib/LanguageContext";
+import { PERFIL_FIELD_AXES } from "../../data/perfil-estrategico";
+import { cn } from "../../lib/utils";
+
+const SIZE = 320;
+const CX = SIZE / 2;
+const CY = SIZE / 2;
+const MAX_R = 108;
+const LEVELS = 5;
+
+function polar(i: number, n: number, r: number) {
+  const angle = -Math.PI / 2 + (i * 2 * Math.PI) / n;
+  return {
+    x: CX + r * Math.cos(angle),
+    y: CY + r * Math.sin(angle),
+  };
+}
+
+/**
+ * Radar de campos del perfil estratégico (Dónde sumo).
+ * SVG propio: liviano, a11y con tabla, un eje seleccionado a la vez.
+ */
+export function ProfileRadar({ className }: { className?: string }) {
+  const { language } = useLanguage();
+  const es = language === "es";
+  const gid = useId().replace(/:/g, "");
+  const axes = PERFIL_FIELD_AXES;
+  const n = axes.length;
+  const [activeId, setActiveId] = useState<string>(axes[0]?.id ?? "diseno");
+
+  const gridPolys = useMemo(() => {
+    return Array.from({ length: LEVELS }, (_, level) => {
+      const r = (MAX_R * (level + 1)) / LEVELS;
+      return axes
+        .map((_, i) => {
+          const p = polar(i, n, r);
+          return `${p.x},${p.y}`;
+        })
+        .join(" ");
+    });
+  }, [axes, n]);
+
+  const valuePoly = useMemo(() => {
+    return axes
+      .map((a, i) => {
+        const r = (MAX_R * Math.min(LEVELS, Math.max(0, a.score))) / LEVELS;
+        const p = polar(i, n, r);
+        return `${p.x},${p.y}`;
+      })
+      .join(" ");
+  }, [axes, n]);
+
+  const labels = useMemo(() => {
+    return axes.map((a, i) => {
+      const p = polar(i, n, MAX_R + 22);
+      return { ...a, ...p };
+    });
+  }, [axes, n]);
+
+  const active = axes.find((a) => a.id === activeId) ?? axes[0];
+
+  return (
+    <div className={cn("mx-auto w-full max-w-md", className)}>
+      <div className="relative mx-auto aspect-square w-full max-w-[320px]">
+        <svg
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          className="h-full w-full"
+          role="img"
+          aria-labelledby={`${gid}-title ${gid}-desc`}
+        >
+          <title id={`${gid}-title`}>
+            {es
+              ? "Radar de perfil estratégico — dónde sumo"
+              : "Strategic profile radar — where I add value"}
+          </title>
+          <desc id={`${gid}-desc`}>
+            {axes
+              .map(
+                (a) =>
+                  `${language === "es" ? a.labelEs : a.labelEn}: ${a.score} de 5`
+              )
+              .join(". ")}
+          </desc>
+
+          <defs>
+            <linearGradient id={`${gid}-fill`} x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="var(--primary)" stopOpacity="0.35" />
+              <stop offset="100%" stopColor="var(--primary)" stopOpacity="0.12" />
+            </linearGradient>
+          </defs>
+
+          {/* rings */}
+          {gridPolys.map((pts, i) => (
+            <polygon
+              key={i}
+              points={pts}
+              fill="none"
+              stroke="currentColor"
+              className="text-border"
+              strokeOpacity={0.45}
+              strokeWidth={1}
+            />
+          ))}
+
+          {/* axes */}
+          {axes.map((_, i) => {
+            const p = polar(i, n, MAX_R);
+            return (
+              <line
+                key={i}
+                x1={CX}
+                y1={CY}
+                x2={p.x}
+                y2={p.y}
+                stroke="currentColor"
+                className="text-border"
+                strokeOpacity={0.4}
+                strokeWidth={1}
+              />
+            );
+          })}
+
+          {/* value shape */}
+          <polygon
+            points={valuePoly}
+            fill={`url(#${gid}-fill)`}
+            stroke="var(--primary)"
+            strokeWidth={2}
+            strokeLinejoin="round"
+          />
+
+          {/* vertices */}
+          {axes.map((a, i) => {
+            const r = (MAX_R * a.score) / LEVELS;
+            const p = polar(i, n, r);
+            const on = a.id === activeId;
+            return (
+              <circle
+                key={a.id}
+                cx={p.x}
+                cy={p.y}
+                r={on ? 5 : 3.5}
+                fill={on ? "var(--primary)" : "var(--background)"}
+                stroke="var(--primary)"
+                strokeWidth={2}
+              />
+            );
+          })}
+
+          {/* clickable labels */}
+          {labels.map((a) => {
+            const on = a.id === activeId;
+            const label = es ? a.labelEs : a.labelEn;
+            return (
+              <g key={a.id}>
+                <text
+                  x={a.x}
+                  y={a.y}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fill={on ? "var(--primary)" : "var(--muted-foreground)"}
+                  style={{ fontSize: 11, fontWeight: on ? 700 : 600 }}
+                >
+                  {label}
+                </text>
+                {/* larger hit target */}
+                <circle
+                  cx={a.x}
+                  cy={a.y}
+                  r={16}
+                  fill="transparent"
+                  className="cursor-pointer"
+                  onClick={() => setActiveId(a.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setActiveId(a.id);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${label}: ${a.score}/5`}
+                />
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* Detail panel — one axis at a time */}
+      {active && (
+        <div
+          className="mt-3 rounded-xl border border-border/50 bg-card/80 px-4 py-3 text-center"
+          aria-live="polite"
+        >
+          <p className="text-sm font-semibold text-foreground">
+            {es ? active.labelEs : active.labelEn}
+            <span className="ml-2 font-mono text-xs font-normal text-primary">
+              {active.score}/5
+            </span>
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {es ? active.detailEs : active.detailEn}
+          </p>
+        </div>
+      )}
+
+      {/* SR / progressive table */}
+      <table className="sr-only">
+        <caption>
+          {es ? "Scores del radar de perfil" : "Profile radar scores"}
+        </caption>
+        <thead>
+          <tr>
+            <th>{es ? "Campo" : "Field"}</th>
+            <th>{es ? "Nivel" : "Level"}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {axes.map((a) => (
+            <tr key={a.id}>
+              <td>{es ? a.labelEs : a.labelEn}</td>
+              <td>
+                {a.score} / {LEVELS}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/organisms/ProfileScope.tsx
+++ b/src/components/organisms/ProfileScope.tsx
@@ -3,12 +3,12 @@ import { Globe2, Cpu, LayoutPanelLeft, Map } from "lucide-react";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { TrajectoryRail } from "./TrajectoryRail";
+import { ProfileRadar } from "../molecules/ProfileRadar";
 import { useLanguage } from "../../lib/LanguageContext";
 import { cn } from "../../lib/utils";
 
 /**
- * L2 de card-sort: alcance del perfil.
- * Va DESPUÉS de “Método en una mirada” (Skills), no compite con el wall.
+ * L2 alcance: radar del perfil estratégico + prueba compacta + rail.
  */
 const PROOF = {
   es: [
@@ -78,41 +78,54 @@ export function ProfileScope() {
         title={es ? "Dónde sumo" : "Where I add value"}
         description={
           es
-            ? "Nacional, regional e internacional — en paralelo a Viento Norte."
-            : "National, regional, and international — alongside Viento Norte."
+            ? "Radar del perfil estratégico: campos donde integro diseño, datos, regulación e IA."
+            : "Strategic profile radar: fields where I integrate design, data, regulation, and AI."
         }
       />
 
-      <ul
-        className="mb-8 grid gap-2 sm:grid-cols-3"
-        role="list"
-        aria-label={es ? "Qué suma el perfil" : "What the profile adds up to"}
-      >
-        {proof.map((item, index) => {
-          const Icon = item.icon;
-          return (
-            <motion.li
-              key={item.label}
-              {...fadeUp(0.04 * index)}
-              className={cn(
-                "flex items-center gap-3 rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated px-3 py-3"
-              )}
-            >
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-                <Icon className="h-4 w-4 text-primary" aria-hidden />
-              </span>
-              <span className="min-w-0">
-                <span className="block text-sm font-semibold">{item.label}</span>
-                <span className="block text-xs text-muted-foreground">
-                  {item.detail}
-                </span>
-              </span>
-            </motion.li>
-          );
-        })}
-      </ul>
+      <div className="mx-auto grid max-w-5xl items-start gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)] lg:gap-10">
+        <motion.div {...fadeUp(0)} className="order-2 lg:order-1">
+          <ProfileRadar />
+          <p className="mt-3 text-center text-[11px] text-muted-foreground lg:text-left">
+            {es
+              ? "Toca un eje para el detalle. Escala 1–5 según trayectoria (SURA, DS, a11y, micro1, VN)."
+              : "Tap an axis for detail. Scale 1–5 from trajectory (SURA, DS, a11y, micro1, VN)."}
+          </p>
+        </motion.div>
 
-      <TrajectoryRail />
+        <div className="order-1 space-y-6 lg:order-2">
+          <ul
+            className="grid gap-2 sm:grid-cols-3 lg:grid-cols-1"
+            role="list"
+            aria-label={es ? "Qué suma el perfil" : "What the profile adds up to"}
+          >
+            {proof.map((item, index) => {
+              const Icon = item.icon;
+              return (
+                <motion.li
+                  key={item.label}
+                  {...fadeUp(0.04 * index)}
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated px-3 py-3"
+                  )}
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Icon className="h-4 w-4 text-primary" aria-hidden />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-sm font-semibold">{item.label}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {item.detail}
+                    </span>
+                  </span>
+                </motion.li>
+              );
+            })}
+          </ul>
+
+          <TrajectoryRail />
+        </div>
+      </div>
     </PageSection>
   );
 }

--- a/src/data/perfil-estrategico.ts
+++ b/src/data/perfil-estrategico.ts
@@ -63,29 +63,105 @@ export const PERFIL_CYCLE: PerfilStep[] = [
   },
 ];
 
+/**
+ * Campos del perfil + score 1–5 para radar “Dónde sumo”.
+ * Scores: evidencia de trayectoria (SURA wealth, DS, a11y, micro1, VN).
+ */
+export type PerfilFieldAxis = {
+  id: string;
+  labelEs: string;
+  labelEn: string;
+  detailEs: string;
+  detailEn: string;
+  /** Intensidad 1–5 (eje del radar) */
+  score: number;
+};
+
+export const PERFIL_FIELD_AXES: readonly PerfilFieldAxis[] = [
+  {
+    id: "diseno",
+    labelEs: "Diseño",
+    labelEn: "Design",
+    detailEs: "Experiencia y comportamiento — interfaces de producto",
+    detailEn: "Experience and behavior — product interfaces",
+    score: 5,
+  },
+  {
+    id: "datos",
+    labelEs: "Datos",
+    labelEn: "Data",
+    detailEs: "Evidencia y medición — analytics, embudos, KPIs",
+    detailEn: "Evidence and measurement — analytics, funnels, KPIs",
+    score: 4,
+  },
+  {
+    id: "tecnologia",
+    labelEs: "Tecnología",
+    labelEn: "Technology",
+    detailEs: "Automatización y capacidad — systems, handoff, tools",
+    detailEn: "Automation and capacity — systems, handoff, tools",
+    score: 4,
+  },
+  {
+    id: "negocio",
+    labelEs: "Negocio",
+    labelEn: "Business",
+    detailEs: "Valor y priorización — product/wealth, P0–P2",
+    detailEn: "Value and prioritization — product/wealth, P0–P2",
+    score: 5,
+  },
+  {
+    id: "regulacion",
+    labelEs: "Regulación",
+    labelEn: "Regulation",
+    detailEs: "Límites institucionales — CMF, compliance UX",
+    detailEn: "Institutional limits — CMF, compliance UX",
+    score: 5,
+  },
+  {
+    id: "privacidad",
+    labelEs: "Privacidad",
+    labelEn: "Privacy",
+    detailEs: "Poder sobre los datos — privacy dashboard, minimización",
+    detailEn: "Power over data — privacy dashboard, minimization",
+    score: 4,
+  },
+  {
+    id: "ia",
+    labelEs: "IA",
+    labelEn: "AI",
+    detailEs: "Multiplicación de capacidad — micro1 AI data, anotación/QA",
+    detailEn: "Capability multiplier — micro1 AI data, annotation/QA",
+    score: 4,
+  },
+  {
+    id: "finanzas",
+    labelEs: "Finanzas",
+    labelEn: "Finance",
+    detailEs: "Restricciones y sostenibilidad — wealth / fondos",
+    detailEn: "Constraints and sustainability — wealth / funds",
+    score: 4,
+  },
+  {
+    id: "comunicacion",
+    labelEs: "Comunicación",
+    labelEn: "Communication",
+    detailEs: "Legitimación y alineación — puentes negocio·diseño·tech",
+    detailEn: "Legitimacy and alignment — business·design·tech bridges",
+    score: 4,
+  },
+] as const;
+
+/** @deprecated use PERFIL_FIELD_AXES — kept for callers expecting es/en arrays */
 export const PERFIL_FIELDS = {
-  es: [
-    { label: "Diseño", detail: "Experiencia y comportamiento" },
-    { label: "Datos", detail: "Evidencia y medición" },
-    { label: "Tecnología", detail: "Automatización y capacidad" },
-    { label: "Negocio", detail: "Valor y priorización" },
-    { label: "Regulación", detail: "Límites institucionales" },
-    { label: "Privacidad", detail: "Poder sobre los datos" },
-    { label: "IA", detail: "Multiplicación de capacidad" },
-    { label: "Finanzas", detail: "Restricciones y sostenibilidad" },
-    { label: "Comunicación", detail: "Legitimación y alineación" },
-  ],
-  en: [
-    { label: "Design", detail: "Experience and behavior" },
-    { label: "Data", detail: "Evidence and measurement" },
-    { label: "Technology", detail: "Automation and capacity" },
-    { label: "Business", detail: "Value and prioritization" },
-    { label: "Regulation", detail: "Institutional limits" },
-    { label: "Privacy", detail: "Power over data" },
-    { label: "AI", detail: "Capability multiplier" },
-    { label: "Finance", detail: "Constraints and sustainability" },
-    { label: "Communication", detail: "Legitimacy and alignment" },
-  ],
+  es: PERFIL_FIELD_AXES.map((a) => ({
+    label: a.labelEs,
+    detail: a.detailEs,
+  })),
+  en: PERFIL_FIELD_AXES.map((a) => ({
+    label: a.labelEn,
+    detail: a.detailEn,
+  })),
 } as const;
 
 export const PERFIL_DOES = {


### PR DESCRIPTION
## Summary
- Sección **Dónde sumo** (`#alcance`): **gráfico radar** de los 9 campos del perfil estratégico
- Scores 1–5 anclados a trayectoria (SURA/regulación, diseño, micro1/IA, etc.)
- Toca un eje → panel de detalle
- Tabla sr-only para a11y
- Mantiene chips de prueba (Interfaces / Latam+US / Hoy) + TrajectoryRail

## Test plan
- [ ] `/#/sobre-mi` → **Dónde sumo** muestra radar
- [ ] Click/tap en etiqueta (Diseño, IA…) actualiza detalle
- [ ] Dark/light legible
- [ ] Móvil: radar + lista apilada