### PR TITLE
feat(kickoff): admin passkey, APIs, MCP y marca VN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-13] — Kick-off consultora: landing + APIs + MCP + admin BD
+
+### Added
+- **APIs de negocio** en el Worker (`/api/health`, `/api/services`, `/api/cases`, `/api/company`, `/api/leads`, `/api/booking`, `/api/diagnostico`).
+- **MCP JSON-RPC** en `POST /mcp` (`list_services`, `get_cases`, `get_company_info`, `submit_lead`, `book_call`, `request_diagnostico`). Escritura con `VN_API_KEY`.
+- **Admin data browser** en `#/admin`: overview, tablas de leads/agenda/diagnósticos (cambio de estado) y catálogo de servicios/casos. Auth GitHub/passkey existente.
+- Persistencia de leads del formulario de contacto en `ADMIN_KV`.
+
+### Changed
+- Confirmación de contacto: «desde **vientonorte.io**», voz Viento Norte (ya no “portafolio” / “te responderé”).
+- Booking: `book_call` + registro opcional en `/api/booking` si hay identidad de sesión. Journey: `docs/BOOKING-JOURNEY.md`.
+- HashRouter emite `page_view` al dataLayer. Receta GTM: `docs/GTM-KICKOFF.md`.
+- Home: value prop y strip de modalidades alineados a UXtech / dueño del dato.
+- SEO i18n home: `Viento Norte · UXtech` (Helmet ya coincidía con `index.html`).
+- Privacidad: declara almacenamiento de leads en el Worker.
+- Rutas: `consultingFunnel` = `/` (canon FO). Alias legacy `/consultoria/embudo`.
+
+### Docs
+- `docs/API-KICKOFF.md`
+
+---
+
 ## [2026-08-03] — SEO root + SEM `/#/consultoria` (audit QA)
 
 ### Fixed

--- a/docs/API-KICKOFF.md
+++ b/docs/API-KICKOFF.md
@@ -1,0 +1,83 @@
+# APIs + MCP + Admin · Kick-off Viento Norte
+
+**Fecha:** 2026-08-13  
+**Host:** `https://contact.vientonorte.io` (alias `mi-portafolio-contact.vientonorte.workers.dev`)
+
+Arquitectura: **Landing → APIs → MCP → Admin UI** sobre las mismas colecciones KV.
+
+## Decisiones (cerradas con evidencia del repo)
+
+| Pregunta | Decisión |
+|----------|----------|
+| Backend | Worker Cloudflare existente (no el proxy Vertex de `backend/`) |
+| Persistencia | `ADMIN_KV` (listas JSON). D1 queda para un sprint posterior |
+| APIs de este sprint | health, services, cases, company, leads, booking, diagnostico + admin |
+| MCP | JSON-RPC en `POST /mcp`. Lectura pública. Escritura con `VN_API_KEY` |
+| Admin UI | Mismo repo, `#/admin`, auth GitHub/passkey ya existente |
+| Edición | Cambio de estado (leads / bookings / diagnósticos). Catálogo solo lectura |
+
+## Públicos
+
+| Método | Ruta | Auth |
+|--------|------|------|
+| GET | `/api/health` | no |
+| GET | `/api/services` | no |
+| GET | `/api/cases` | no |
+| GET | `/api/company` | no |
+| POST | `/api/contact` | consentimiento + persist lead |
+| POST | `/api/leads` | consentimiento |
+| POST | `/api/booking` | no (registra + devuelve Calendar) |
+| POST | `/api/diagnostico` | no |
+
+## Admin (cookie de sesión)
+
+| Método | Ruta |
+|--------|------|
+| GET | `/api/admin/overview` |
+| GET | `/api/admin/leads?q=&status=` |
+| PATCH | `/api/admin/leads/:id` `{ status, notes }` |
+| GET/PATCH | `/api/admin/bookings` · `/api/admin/diagnosticos` |
+| GET | `/api/admin/services` · `/api/admin/cases` |
+
+UI: `https://vientonorte.io/#/admin` — **no está en la nav**. noIndex + robots. Sin sesión solo se ve un gate de **passkey**. GitHub queda en «Primera vez» (bootstrap). Los datos viven en el Worker (cookie HttpOnly); el HTML no lista leads si no hay sesión.
+
+## MCP
+
+```
+POST /mcp
+Content-Type: application/json
+X-VN-API-KEY: <secret>   # solo tools de escritura
+```
+
+Tools:
+
+- `list_services` · `get_cases` · `get_company_info` (públicas)
+- `submit_lead` · `book_call` · `request_diagnostico` (API key)
+
+Secret:
+
+```bash
+cd worker
+npx wrangler secret put VN_API_KEY
+npx wrangler deploy
+```
+
+Cliente de ejemplo (Claude / Cursor / Grok): URL `https://contact.vientonorte.io/mcp`.
+
+## Deploy
+
+El worker completo (`wrangler.toml`) necesita KV. El deploy `wrangler.contact.toml` es solo relay de mail y **no** persiste tablas.
+
+```bash
+cd worker
+npx wrangler deploy
+```
+
+## QA local
+
+```bash
+cd worker && npx wrangler dev
+curl -s http://127.0.0.1:8787/api/health
+curl -s http://127.0.0.1:8787/api/services
+curl -s http://127.0.0.1:8787/mcp
+```

--- a/docs/BOOKING-JOURNEY.md
+++ b/docs/BOOKING-JOURNEY.md
@@ -1,0 +1,31 @@
+# Booking UX · journey map (kick-off)
+
+Marca: **Viento Norte** · superficie: **vientonorte.io** (no “portafolio”).
+
+```
+Descubrir → Decidir → Agendar → Confirmar → Follow-up
+   web         pack      Calendar      Google + mail     Admin / call
+```
+
+| Paso | Actor | Superficie | Evento | Dato |
+|------|-------|------------|--------|------|
+| 1. Descubrir | Visitante | Hero / modalidades / `#contacto` | `page_view` | path HashRouter |
+| 2. Decidir 30 min | Visitante | CTA «Abrir agenda» o form | `generate_lead` (`channel=google_calendar` o `contact_form`) | origin, package |
+| 3. Agendar | Visitante | Google Appointment Schedule | `book_call` | origin; si hay nombre+email de sesión → `POST /api/booking` |
+| 4a. Confirmar Calendar | Google | Mail de Calendar al visitante | (fuera de VN) | slot |
+| 4b. Confirmar web | Worker | Mail VN si usó el form | `submit_contact_form` | lead en KV |
+| 5. Follow-up | VN | `#/admin` Bookings / Leads | PATCH estado | nuevo → contactado |
+
+## Copy de confirmación (canon)
+
+- **Sí:** «Recibimos tu consulta desde **vientonorte.io**. Viento Norte te responde…»
+- **No:** «desde el portafolio» / «Te responderé» (voz personal)
+
+## Degradación
+
+Sin URL de Calendar → mismo mensaje freemium en el asistente.  
+Sin identidad en sesión → Calendar abre igual; no se inventa un booking anónimo.
+
+## Fuera de este mapa
+
+Crear el evento en Google Calendar por API (Appointment Schedule ya lo hace). D1. MCP `book_call` es el mismo POST.

--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -1,0 +1,50 @@
+# GTM kick-off · wire de conversión
+
+**Estado código:** dataLayer + `initGTM` listos.  
+**Estado prod:** sin `VITE_GTM_ID` en GitHub Secrets → el HTML live **no** carga `gtm.js`.
+
+No hay `GTM-XXXX` en el vault. El contenedor se crea una vez en tagmanager.google.com (cuenta Viento Norte).
+
+## 1. Crear contenedor (humano, 2 min)
+
+1. [Google Tag Manager](https://tagmanager.google.com/) → cuenta **Viento Norte** → contenedor **vientonorte.io** (Web).
+2. Copiar el ID `GTM-XXXXXXX`.
+3. En el repo:
+
+```bash
+gh secret set VITE_GTM_ID -R vientonorte/mi-portafolio -b 'GTM-XXXXXXX'
+# opcional, mismo contenedor + GA4:
+# gh secret set VITE_GA_MEASUREMENT_ID -R vientonorte/mi-portafolio -b 'G-XXXXXXXX'
+```
+
+4. Redeploy Pages (`workflow_dispatch` Deploy to GitHub Pages). El build ya pasa `VITE_GTM_ID` a Vite.
+
+## 2. Tags de conversión (mismo contenedor)
+
+Trigger tipo **Custom Event** · `Event name` = nombre de `dataLayer.event`:
+
+| Evento | Uso | Conversión |
+|--------|-----|------------|
+| `generate_lead` | Free a11y / Calendar o form | **Sí** (lead) |
+| `submit_contact_form` | Form / asistente OK | **Sí** si `success=true` |
+| `book_call` | Click agenda 30 min | **Sí** (micro) |
+| `page_view` | HashRouter path | No (métrica) |
+| `hero_path_card` | Camino hero | No |
+| `home_package_select` | Pack home | No |
+
+Variables de capa de datos: `lead_type`, `channel`, `origin`, `package_id`, `page_path`.
+
+GA4: un tag **GA4 Event** por conversión, event name igual al custom event (o `generate_lead` → GA4 `generate_lead`).
+
+## 3. QA
+
+```text
+vientonorte.io → DevTools → window.dataLayer
+Clic agenda o envío de form
+Filtrar event === 'generate_lead' | 'book_call' | 'submit_contact_form'
+GTM Preview: el tag de conversión se dispara
+```
+
+## Anti-patrón
+
+No pegar el snippet GTM a mano en `index.html`. El ID entra por env de build y `AnalyticsProvider` llama `initGTM`.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,10 @@ Allow: /
 
 Sitemap: https://vientonorte.io/sitemap.xml
 
-# Superficies no indexables
+# Superficies no indexables (hash no es path HTTP; listamos ambos por defensa)
+Disallow: /admin
+Disallow: /admin/
 Disallow: /#/admin
+Disallow: /#/admin/fotos
 Disallow: /#/grafo
 Disallow: /ops/

--- a/scripts/qa-routes.mjs
+++ b/scripts/qa-routes.mjs
@@ -22,6 +22,7 @@ const STATIC_ROUTES = [
   '/consultoria',
   '/consultoria/embudo',
   '/consultoria/modulos/dashboard',
+  '/admin',
   '/admin/fotos',
   '/cases',
   '/cases/process/ux-analytics',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { ScrollManager } from './components/layout/ScrollManager';
 import { NotFoundPage } from './components/layout/NotFoundPage';
 import { QaEnvBanner } from './components/molecules/QaEnvBanner';
 import { isDeepPortfolioPage } from './lib/page-depth';
-import { isConsultingOfferPath, LEGACY_ROUTES, ROUTES } from './lib/routes';
+import { isAdminPath, isConsultingOfferPath, LEGACY_ROUTES, ROUTES } from './lib/routes';
 import { useLanguage } from './lib/LanguageContext';
 import { useTranslation } from './lib/i18n';
 import type { PocModuleId } from './data/poc-product-modules';
@@ -36,6 +36,7 @@ const ProcessDetail = lazyWithRetry(() => import('./pages/ProcessDetail'));
 const CompanyDetailRoute = lazyWithRetry(() => import('./pages/CompanyDetailRoute'));
 const ProjectDetailRoute = lazyWithRetry(() => import('./pages/ProjectDetailRoute'));
 const AdminPhotos = lazyWithRetry(() => import('./pages/AdminPhotos'));
+const AdminHub = lazyWithRetry(() => import('./pages/AdminHub'));
 const FrameworkDetail = lazyWithRetry(() => import('./pages/FrameworkDetail'));
 
 const OFFER_MODULE_IDS = new Set([
@@ -133,6 +134,8 @@ function AppRoutes() {
   const isDeepPage = isDeepPortfolioPage(pathname);
   /** Tour fullscreen: sin dock/header del sitio (chrome propio del tour). */
   const isOfferLanding = isConsultingOfferPath(pathname);
+  /** Panel interno: sin nav pública (seguridad por diseño). */
+  const isAdmin = isAdminPath(pathname);
 
   return (
     <PortfolioChrome>
@@ -141,7 +144,7 @@ function AppRoutes() {
       <a href="#main" className="skip-link">
         Ir al contenido principal
       </a>
-      {!isDeepPage && !isOfferLanding && <RouterNavigation />}
+      {!isDeepPage && !isOfferLanding && !isAdmin && <RouterNavigation />}
       <main id="main" tabIndex={-1}>
         <Suspense fallback={<PageSkeleton />}>
           <Routes>
@@ -175,14 +178,15 @@ function AppRoutes() {
               element={<Navigate to={ROUTES.consulting} replace />}
             />
             <Route path={ROUTES.demoXcms} element={<DemoXcmsCampaign />} />
+            <Route path={ROUTES.admin} element={<AdminHub />} />
             <Route path="/admin/fotos" element={<AdminPhotos />} />
             <Route path="*" element={<GlobalNotFoundPage />} />
           </Routes>
         </Suspense>
       </main>
       {/* Footer de links/copyright retirado: contacto y UX Tools en nav; privacidad en header */}
-      {!isDeepPage && !isOfferLanding && <BottomNav />}
-      {isDeepPage && !isOfferLanding && <DeepPageNav />}
+      {!isDeepPage && !isOfferLanding && !isAdmin && <BottomNav />}
+      {isDeepPage && !isOfferLanding && !isAdmin && <DeepPageNav />}
     </PortfolioChrome>
   );
 }

--- a/src/__tests__/lib/admin-config.test.ts
+++ b/src/__tests__/lib/admin-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { ADMIN_ROUTES } from "@/lib/admin-config";
+import { ROUTES } from "@/lib/routes";
+
+describe("admin kickoff routes", () => {
+  it("exposes data-browser endpoints on the same Worker host", () => {
+    expect(ADMIN_ROUTES.overview).toMatch(/\/api\/admin\/overview$/);
+    expect(ADMIN_ROUTES.leads).toMatch(/\/api\/admin\/leads$/);
+    expect(ADMIN_ROUTES.bookings).toMatch(/\/api\/admin\/bookings$/);
+    expect(ADMIN_ROUTES.diagnosticos).toMatch(/\/api\/admin\/diagnosticos$/);
+    expect(ADMIN_ROUTES.services).toMatch(/\/api\/admin\/services$/);
+    expect(ADMIN_ROUTES.cases).toMatch(/\/api\/admin\/cases$/);
+    expect(ADMIN_ROUTES.health).toMatch(/\/api\/health$/);
+  });
+
+  it("keeps the admin hub off the public nav", () => {
+    expect(ROUTES.admin).toBe("/admin");
+    expect(ROUTES.adminPhotos.startsWith(ROUTES.admin)).toBe(true);
+  });
+});

--- a/src/__tests__/lib/routes.test.ts
+++ b/src/__tests__/lib/routes.test.ts
@@ -6,6 +6,7 @@ import {
   isConsultingOfferPath,
   isConsultingFunnelPath,
   isConsultingPath,
+  isAdminPath,
 } from '@/lib/routes';
 
 describe('routes', () => {
@@ -38,5 +39,14 @@ describe('routes', () => {
 
     expect(isConsultingPath('/')).toBe(true);
     expect(isConsultingPath('/consultoria')).toBe(true);
+  });
+
+  it('admin hub and photos are admin paths', () => {
+    expect(ROUTES.admin).toBe('/admin');
+    expect(ROUTES.adminPhotos).toBe('/admin/fotos');
+    expect(isAdminPath('/admin')).toBe(true);
+    expect(isAdminPath('/admin/fotos')).toBe(true);
+    expect(isAdminPath('/contacto')).toBe(false);
+    expect(isAdminPath('/proyectos')).toBe(false);
   });
 });

--- a/src/components/layout/ScrollManager.tsx
+++ b/src/components/layout/ScrollManager.tsx
@@ -1,5 +1,6 @@
-import { useLayoutEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
+import { trackPageView } from "../../lib/analytics";
 import { runRouteScrollToTop } from "../../lib/navigate-to-section";
 import type { SectionScrollState } from "../../lib/navigate-to-section";
 
@@ -16,6 +17,10 @@ function normalizePath(path: string): string {
 export function ScrollManager() {
   const location = useLocation();
   const prevPathRef = useRef(normalizePath(location.pathname));
+
+  useEffect(() => {
+    trackPageView(location.pathname + location.hash, document.title);
+  }, [location.pathname, location.hash]);
 
   useLayoutEffect(() => {
     const path = normalizePath(location.pathname);

--- a/src/components/organisms/Hero.tsx
+++ b/src/components/organisms/Hero.tsx
@@ -133,6 +133,12 @@ export function Hero(_props: HeroProps) {
               </span>
               <span className="block text-foreground">{t.headlineFocus}</span>
             </motion.h1>
+            <motion.p
+              variants={itemVariants}
+              className="mt-5 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg"
+            >
+              {t.valueProp}
+            </motion.p>
           </div>
 
           <motion.div variants={itemVariants} className="w-full">

--- a/src/lib/ImageManifestProvider.tsx
+++ b/src/lib/ImageManifestProvider.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import { ADMIN_ROUTES } from "./admin-config";
 import { ImageManifestContext } from "./image-manifest-context";
 import { fetchAndApplyManifest } from "./image-overrides";
-import { ROUTES } from "./routes";
+import { isAdminPath } from "./routes";
 
 /** Manifest remoto solo en admin (evita CORS en GitHub Pages hasta ACAO en el Worker). */
 const PUBLIC_MANIFEST_ENABLED = import.meta.env.VITE_IMAGE_MANIFEST_PUBLIC === "true";
@@ -11,8 +11,7 @@ const PUBLIC_MANIFEST_ENABLED = import.meta.env.VITE_IMAGE_MANIFEST_PUBLIC === "
 export function ImageManifestProvider({ children }: { children: ReactNode }) {
   const [version, setVersion] = useState(0);
   const location = useLocation();
-  const isAdminRoute =
-    (location.pathname.replace(/\/+$/, "") || "/") === ROUTES.adminPhotos;
+  const isAdminRoute = isAdminPath(location.pathname);
   const shouldFetch = isAdminRoute || PUBLIC_MANIFEST_ENABLED;
 
   useEffect(() => {

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -36,7 +36,49 @@ async function adminFetch<T>(
   return data;
 }
 
-export function startGithubLogin(returnTo = "/admin/fotos") {
+export type AdminCollection = "leads" | "bookings" | "diagnosticos";
+
+export interface AdminRecord {
+  id: string;
+  createdAt?: string;
+  updatedAt?: string;
+  status?: string;
+  name?: string | { es?: string; en?: string };
+  title?: string | { es?: string; en?: string };
+  email?: string;
+  message?: string;
+  intent?: string;
+  source?: string;
+  notes?: string;
+  calendarUrl?: string;
+  friction?: string;
+  company?: string;
+  url?: string;
+  kind?: string;
+  active?: boolean;
+  published?: boolean;
+  response?: { es?: string; en?: string };
+  [key: string]: unknown;
+}
+
+export interface AdminOverview {
+  today: { leads: number; bookings: number; diagnosticos: number };
+  week: { leads: number; bookings: number; diagnosticos: number };
+  totals: {
+    leads: number;
+    bookings: number;
+    diagnosticos: number;
+    services: number;
+    cases: number;
+  };
+  recent: {
+    leads: AdminRecord[];
+    bookings: AdminRecord[];
+    diagnosticos: AdminRecord[];
+  };
+}
+
+export function startGithubLogin(returnTo = "/admin") {
   const url = new URL(ADMIN_ROUTES.githubStart);
   url.searchParams.set("return_to", returnTo);
   window.location.href = url.toString();
@@ -108,6 +150,39 @@ export async function passkeyLoginFinish(body: AuthenticationResponseJSON): Prom
     method: "POST",
     body: JSON.stringify(body),
   });
+}
+
+export async function getAdminOverview(): Promise<AdminOverview> {
+  const data = await adminFetch<{ overview: AdminOverview }>(ADMIN_ROUTES.overview);
+  return data.overview;
+}
+
+export async function listAdminCollection(
+  collection: AdminCollection,
+  params: { q?: string; status?: string } = {}
+): Promise<AdminRecord[]> {
+  const url = new URL(ADMIN_ROUTES[collection]);
+  if (params.q) url.searchParams.set("q", params.q);
+  if (params.status) url.searchParams.set("status", params.status);
+  const data = await adminFetch<{ items: AdminRecord[] }>(url.toString());
+  return data.items;
+}
+
+export async function patchAdminRecord(
+  collection: AdminCollection,
+  id: string,
+  patch: { status?: string; notes?: string }
+): Promise<AdminRecord> {
+  const data = await adminFetch<{ item: AdminRecord }>(
+    `${ADMIN_ROUTES[collection]}/${encodeURIComponent(id)}`,
+    { method: "PATCH", body: JSON.stringify(patch) }
+  );
+  return data.item;
+}
+
+export async function listAdminCatalog(kind: "services" | "cases"): Promise<AdminRecord[]> {
+  const data = await adminFetch<{ items: AdminRecord[] }>(ADMIN_ROUTES[kind]);
+  return data.items;
 }
 
 export function registryToAdminPreview(entry: ImageRegistryEntry): AdminImageRecord {

--- a/src/lib/admin-config.ts
+++ b/src/lib/admin-config.ts
@@ -15,4 +15,11 @@ export const ADMIN_ROUTES = {
   logout: `${ADMIN_API_BASE}/api/admin/auth/logout`,
   images: `${ADMIN_API_BASE}/api/admin/images`,
   manifest: `${ADMIN_API_BASE}/api/images/manifest`,
+  overview: `${ADMIN_API_BASE}/api/admin/overview`,
+  leads: `${ADMIN_API_BASE}/api/admin/leads`,
+  bookings: `${ADMIN_API_BASE}/api/admin/bookings`,
+  diagnosticos: `${ADMIN_API_BASE}/api/admin/diagnosticos`,
+  services: `${ADMIN_API_BASE}/api/admin/services`,
+  cases: `${ADMIN_API_BASE}/api/admin/cases`,
+  health: `${ADMIN_API_BASE}/api/health`,
 } as const;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -184,10 +184,18 @@ export const analytics = {
  * @param title - Page title
  */
 export const trackPageView = (path: string, title?: string) => {
-  if (typeof window !== "undefined" && window.gtag) {
-    window.gtag("config", "GA_MEASUREMENT_ID", {
+  if (typeof window === "undefined") return;
+  const w = window as Window & { dataLayer?: unknown[] };
+  w.dataLayer = w.dataLayer ?? [];
+  w.dataLayer.push({
+    event: "page_view",
+    page_path: path,
+    page_title: title ?? document.title,
+  });
+  if (typeof window.gtag === "function") {
+    window.gtag("event", "page_view", {
       page_path: path,
-      page_title: title
+      page_title: title ?? document.title,
     });
   }
 };

--- a/src/lib/free-radar-entry.ts
+++ b/src/lib/free-radar-entry.ts
@@ -19,6 +19,7 @@ import {
   A11Y_FREE_SCHEDULE_URL,
   openA11yFreeScheduleOrFallback,
 } from "./site-contact";
+import { recordBookingIntent } from "./vn-booking";
 
 export const FREE_RADAR_ENTRY_MESSAGE: Record<Language, string> = {
   es: `Hola Viento Norte — quiero la revisión gratis de accesibilidad de un flujo.
@@ -101,6 +102,11 @@ export function openFreeRadarEntry(
   if (mode === "schedule" || mode === "auto") {
     if (A11Y_FREE_SCHEDULE_URL) {
       trackGenerateLead(origin, "google_calendar");
+      void recordBookingIntent({
+        origin,
+        intent: "radar-free",
+        notes: "Agenda 30 min · revisión de un flujo (vientonorte.io)",
+      });
       openA11yFreeScheduleOrFallback(openMessage);
       return "google_calendar";
     }

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -99,8 +99,8 @@ export default {
             'UX pattern in SURA Investments: predictive fund search with progressive disclosure and WCAG 2.2 AA — product evidence, not a case study.',
         },
         admin: {
-          title: 'Photo admin',
-          description: 'Private portfolio image editor.',
+          title: 'Admin · Viento Norte',
+          description: 'Internal panel: leads, bookings, diagnostics, and catalog.',
         },
       },
     },
@@ -409,9 +409,9 @@ export default {
       },
       packagesSection: {
         badge: 'How you hire',
-        title: 'Three formats + app if you need it',
+        title: 'Three formats + modules that install',
         description:
-          'Pick diagnostic, prototype, or team process. If you need an app in production, use the strip below.',
+          'Interfaces, Design Systems, and research/AI data. Pick diagnostic, prototype, or process. You keep the data and the code.',
         deliverablesLabel: 'Includes',
         cta: 'Start',
         ctaForm: 'Write',
@@ -712,10 +712,10 @@ export default {
 
     // Hero
     hero: {
-      label: 'Design Ops for regulated products',
+      label: 'UXtech · custom modules',
       headlineLead: 'Design that',
       headlineFocus: 'cuts the noise.',
-      valueProp: 'UX Lead · Design Ops for regulated products — fintech and mobility.',
+      valueProp: 'We turn complexity into decision capacity. Software that installs. Client owns the data.',
       specialties: ['Compliance', 'Premium UX', 'Fintech', 'Mobility'],
       unifiedBanner: {
         groupLabel: 'What do you need?',
@@ -1171,7 +1171,7 @@ export default {
         sending: 'Sending…',
         editMessage: 'You can edit the message before sending',
         privacyNote:
-          'Your data goes to Google Forms (Viento Norte). You get an email copy; we receive it at contacto@vientonorte.cl — no marketing.',
+          'Your data goes to the Viento Norte Worker and Google Forms. We keep the lead to reply — no marketing.',
         success: 'Done! I\'ll reply within 24 hours.',
       },
       social: {
@@ -1430,7 +1430,7 @@ export default {
       consulting: 'Consulting',
       grafo: 'Graph',
       autosuggest: 'Autosuggest Funds',
-      admin: 'Photo admin',
+      admin: 'Admin',
       notFound: 'Not found',
     },
 
@@ -1445,7 +1445,7 @@ export default {
       contact: {
         title: 'Contact form',
         body:
-          'If you submit the form or assistant, your name, email, and message are sent over HTTPS to Google Forms (Viento Norte account). Google may email you a copy of your response and notify us at contacto@vientonorte.cl (forwarded to gaete.gaona@gmail.com). We do not store that data in site databases or use it for marketing. Legal basis: explicit consent (Chile Data Protection Law 21.719).',
+          'If you submit the form, assistant, or an agent tool, your name, email, and message are sent over HTTPS to the Viento Norte Cloudflare Worker and, in parallel, to Google Forms. We keep the lead in the internal panel to reply. We do not use it for marketing or sell it. Legal basis: explicit consent (Chile Data Protection Law 21.719).',
       },
       retention: {
         title: 'Retention',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -99,8 +99,8 @@ export default {
             'Patrón UX en SURA Inversiones: búsqueda predictiva de fondos con progressive disclosure y WCAG 2.2 AA — evidencia de producto, no case study.',
         },
         admin: {
-          title: 'Admin fotos',
-          description: 'Editor privado de imágenes del portafolio.',
+          title: 'Admin · Viento Norte',
+          description: 'Panel interno: leads, agenda, diagnósticos y catálogo.',
         },
       },
     },
@@ -409,9 +409,9 @@ export default {
       },
       packagesSection: {
         badge: 'Cómo se contrata',
-        title: 'Tres formatos + app si la necesitas',
+        title: 'Tres formatos + módulos que se instalan',
         description:
-          'Elige diagnóstico, prototipo o proceso de equipo. Si necesitas una app en producción, usa la franja de abajo.',
+          'Interfaces, Design Systems y research/AI data. Elige diagnóstico, prototipo o proceso. El cliente queda dueño del dato y del código.',
         deliverablesLabel: 'Incluye',
         cta: 'Empezar',
         ctaForm: 'Escribir',
@@ -712,10 +712,10 @@ export default {
 
     // Hero
     hero: {
-      label: 'Design Ops en productos regulados',
+      label: 'UXtech · módulos a medida',
       headlineLead: 'Diseño que',
       headlineFocus: 'reduce el ruido.',
-      valueProp: 'UX Lead · Design Ops en productos regulados — fintech y mobility.',
+      valueProp: 'Transformamos complejidad en capacidad de decisión. Software que se instala. Cliente dueño del dato.',
       specialties: ['Cumplimiento', 'Experiencias premium', 'Fintech', 'Mobility'],
       unifiedBanner: {
         groupLabel: '¿Qué necesitas?',
@@ -1413,7 +1413,7 @@ export default {
       consulting: 'Consultoría',
       grafo: 'Grafo',
       autosuggest: 'Autosuggest Fondos',
-      admin: 'Admin fotos',
+      admin: 'Admin',
       notFound: 'No encontrado',
     },
 
@@ -1428,7 +1428,7 @@ export default {
       contact: {
         title: 'Formulario de contacto',
         body:
-          'Si envías el formulario o el asistente, tu nombre, email y mensaje se transmiten por HTTPS a Google Forms (cuenta Viento Norte). Google puede enviarte copia de tu respuesta y notificarnos en contacto@vientonorte.cl (reenvío a gaete.gaona@gmail.com). No almacenamos esos datos en bases de datos del sitio ni los usamos para marketing. Base legal: consentimiento explícito (Ley 21.719).',
+          'Si envías el formulario, el asistente o una tool de agente, tu nombre, email y mensaje se transmiten por HTTPS al Worker de Viento Norte (Cloudflare) y, en paralelo, a Google Forms. Conservamos el lead en el panel interno para responder. No los usamos para marketing ni los vendemos. Base legal: consentimiento explícito (Ley 21.719).',
       },
       retention: {
         title: 'Conservación',

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -27,6 +27,9 @@ export const ROUTES = {
    */
   consultingFunnel: "/",
 
+  /** Panel interno. No está en nav. Gate passkey. */
+  admin: "/admin",
+
   /** Deep link a un módulo del tour SEM. */
   consultingModule: (moduleId: string) =>
     `/consultoria/modulos/${encodeURIComponent(moduleId)}`,
@@ -88,6 +91,11 @@ export function isConsultingPath(pathname: string): boolean {
   return (
     isConsultingFunnelPath(pathname) || isConsultingOfferPath(pathname)
   );
+}
+
+export function isAdminPath(pathname: string): boolean {
+  const path = normalizePathname(pathname);
+  return path === ROUTES.admin || path.startsWith(`${ROUTES.admin}/`);
 }
 
 export function isProcessPath(pathname: string): boolean {

--- a/src/lib/vn-booking.ts
+++ b/src/lib/vn-booking.ts
@@ -1,0 +1,46 @@
+import { ADMIN_API_BASE } from "./admin-config";
+import { readContactSession } from "./contact-draft-storage";
+import { trackEvent } from "./analytics";
+
+export type BookingIntent = "kickoff" | "radar-free" | "consulting";
+
+/**
+ * Registra la intención de agenda en el Worker (best-effort).
+ * Si no hay nombre/email de sesión, no inventa identidad — solo analytics.
+ */
+export async function recordBookingIntent(params: {
+  origin: string;
+  intent?: BookingIntent;
+  notes?: string;
+}): Promise<void> {
+  const session = readContactSession();
+  const name = session?.name.trim() ?? "";
+  const email = session?.email.trim() ?? "";
+
+  trackEvent("book_call", {
+    category: "conversion",
+    origin: params.origin,
+    intent: params.intent ?? "kickoff",
+    has_identity: Boolean(name && email),
+  });
+
+  if (name.length < 2 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return;
+  }
+
+  try {
+    await fetch(`${ADMIN_API_BASE}/api/booking`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({
+        name,
+        email,
+        notes: params.notes ?? "",
+        intent: params.intent ?? "kickoff",
+        origin: params.origin,
+      }),
+    });
+  } catch {
+    /* Worker no desplegado o red — el Calendar igual abre */
+  }
+}

--- a/src/pages/AdminHub.tsx
+++ b/src/pages/AdminHub.tsx
@@ -1,0 +1,567 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { CalendarDays, Database, ImageIcon, LogOut, RefreshCw, Search } from "lucide-react";
+import { SEOHead } from "../components/atoms/SEOHead";
+import { PageShell } from "../components/layout/PageShell";
+import { useLanguage } from "../lib/LanguageContext";
+import { useTranslation } from "../lib/i18n";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { Badge } from "../components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/ui/tabs";
+import { ADMIN_GITHUB_USER } from "../lib/admin-config";
+import { ROUTES } from "../lib/routes";
+import {
+  adminLogout,
+  getAdminOverview,
+  getAdminSession,
+  listAdminCatalog,
+  listAdminCollection,
+  passkeyLoginBegin,
+  passkeyLoginFinish,
+  patchAdminRecord,
+  startGithubLogin,
+  type AdminCollection,
+  type AdminOverview,
+  type AdminRecord,
+} from "../lib/admin-api";
+import { isPasskeySupported, loginWithPasskey } from "../lib/admin-passkey";
+
+const STATUSES: Record<AdminCollection, string[]> = {
+  leads: ["nuevo", "contactado", "cerrado"],
+  bookings: ["pendiente", "confirmado", "cancelado", "hecho"],
+  diagnosticos: ["nuevo", "en_revision", "respondido", "cerrado"],
+};
+
+function personName(value: AdminRecord["name"]) {
+  if (!value) return "—";
+  if (typeof value === "string") return value;
+  return value.es || value.en || "—";
+}
+
+function formatWhen(value?: string) {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleString("es-CL", { dateStyle: "short", timeStyle: "short" });
+}
+
+function statusVariant(status?: string): "default" | "secondary" | "outline" | "destructive" {
+  if (status === "cerrado" || status === "cancelado") return "outline";
+  if (status === "nuevo" || status === "pendiente") return "default";
+  return "secondary";
+}
+
+export default function AdminHub() {
+  const { language } = useLanguage();
+  const t = useTranslation(language);
+  const [session, setSession] = useState<{ ok: boolean; user?: string } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState("overview");
+  const [overview, setOverview] = useState<AdminOverview | null>(null);
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [rows, setRows] = useState<AdminRecord[]>([]);
+  const [catalog, setCatalog] = useState<AdminRecord[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refreshSession = useCallback(async () => {
+    try {
+      const data = await getAdminSession();
+      setSession(data);
+      return data.ok;
+    } catch {
+      setSession({ ok: false });
+      return false;
+    }
+  }, []);
+
+  const loadOverview = useCallback(async () => {
+    const data = await getAdminOverview();
+    setOverview(data);
+  }, []);
+
+  const loadCollection = useCallback(async (collection: AdminCollection) => {
+    const items = await listAdminCollection(collection, {
+      q: query || undefined,
+      status: statusFilter === "all" ? undefined : statusFilter,
+    });
+    setRows(items);
+  }, [query, statusFilter]);
+
+  const loadCatalog = useCallback(async (kind: "services" | "cases") => {
+    const items = await listAdminCatalog(kind);
+    setCatalog(items);
+  }, []);
+
+  const refreshTab = useCallback(
+    async (next = tab) => {
+      setError(null);
+      try {
+        if (next === "overview") await loadOverview();
+        else if (next === "leads" || next === "bookings" || next === "diagnosticos") {
+          await loadCollection(next);
+        } else if (next === "services" || next === "cases") {
+          await loadCatalog(next);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Error cargando datos");
+      }
+    },
+    [loadCatalog, loadCollection, loadOverview, tab]
+  );
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const ok = await refreshSession();
+      if (ok) {
+        try {
+          await loadOverview();
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "Error cargando overview");
+        }
+      }
+      setLoading(false);
+    })();
+  }, [loadOverview, refreshSession]);
+
+  useEffect(() => {
+    if (!session?.ok) return;
+    if (tab === "overview") return;
+    void refreshTab(tab);
+  }, [query, refreshTab, session?.ok, statusFilter, tab]);
+
+  const handleGithub = () => startGithubLogin(ROUTES.admin);
+
+  const handlePasskeyLogin = async () => {
+    setError(null);
+    try {
+      const options = await passkeyLoginBegin();
+      const body = await loginWithPasskey(options);
+      await passkeyLoginFinish(body);
+      const ok = await refreshSession();
+      if (ok) await loadOverview();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error con passkey");
+    }
+  };
+
+  const handleLogout = async () => {
+    await adminLogout();
+    setSession({ ok: false });
+    setOverview(null);
+    setRows([]);
+  };
+
+  const handleStatus = async (collection: AdminCollection, id: string, status: string) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const updated = await patchAdminRecord(collection, id, { status });
+      setRows((prev) => prev.map((row) => (row.id === id ? updated : row)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo actualizar");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const collectionTab = tab === "leads" || tab === "bookings" || tab === "diagnosticos" ? tab : null;
+
+  const filteredHint = useMemo(() => {
+    if (!collectionTab) return null;
+    return `${rows.length} registro${rows.length === 1 ? "" : "s"}`;
+  }, [collectionTab, rows.length]);
+
+  if (loading) {
+    return (
+      <PageShell crumbs={[]} showToolbar={false}>
+        <SEOHead title="VN" description="" noIndex />
+        <div className="container max-w-md mx-auto px-4 py-24 text-center text-muted-foreground">
+          …
+        </div>
+      </PageShell>
+    );
+  }
+
+  if (!session?.ok) {
+    return (
+      <PageShell crumbs={[]} showToolbar={false}>
+        <SEOHead title="VN" description="" noIndex />
+        <div className="container max-w-md mx-auto px-4 py-24 space-y-6">
+          <h1 className="text-xl font-semibold tracking-tight">Entrar</h1>
+          <p className="text-sm text-muted-foreground">Acceso con passkey.</p>
+          {error ? (
+            <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+          {isPasskeySupported() ? (
+            <Button className="min-h-[44px] w-full" onClick={() => void handlePasskeyLogin()}>
+              Continuar con passkey
+            </Button>
+          ) : (
+            <p className="text-sm text-muted-foreground">Este dispositivo no soporta passkey.</p>
+          )}
+          <details className="text-sm text-muted-foreground">
+            <summary className="cursor-pointer select-none">Primera vez</summary>
+            <p className="mt-2 mb-3">
+              Solo @{ADMIN_GITHUB_USER}. Después registra la passkey y no vuelvas a usar GitHub aquí.
+            </p>
+            <Button variant="outline" className="min-h-[44px]" onClick={handleGithub}>
+              GitHub (bootstrap)
+            </Button>
+          </details>
+        </div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell crumbs={[{ label: t.breadcrumbs.admin, current: true }]} showLogoText={false}>
+      <SEOHead title="VN" description="" noIndex />
+      <div className="container max-w-6xl mx-auto px-4 py-8 md:py-12 space-y-8">
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-2">
+            <p className="font-mono text-xs uppercase tracking-widest text-primary">Interno</p>
+            <h1 className="text-3xl font-bold">Bases</h1>
+            <p className="text-muted-foreground max-w-2xl">
+              Solo sesión @{ADMIN_GITHUB_USER}.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline" className="min-h-[44px]">
+              <Link to={ROUTES.adminPhotos}>
+                <ImageIcon className="mr-2 h-4 w-4" aria-hidden />
+                Fotos
+              </Link>
+            </Button>
+            <Button variant="ghost" className="min-h-[44px]" onClick={() => void handleLogout()}>
+              <LogOut className="mr-2 h-4 w-4" aria-hidden />
+              Salir {session.user ? `(@${session.user})` : ""}
+            </Button>
+          </div>
+        </header>
+
+        {error ? (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        <Tabs value={tab} onValueChange={setTab}>
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <TabsList className="flex flex-wrap h-auto">
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="leads">Leads</TabsTrigger>
+                <TabsTrigger value="bookings">Agenda</TabsTrigger>
+                <TabsTrigger value="diagnosticos">Diagnósticos</TabsTrigger>
+                <TabsTrigger value="services">Servicios</TabsTrigger>
+                <TabsTrigger value="cases">Casos</TabsTrigger>
+              </TabsList>
+              <Button
+                type="button"
+                variant="outline"
+                className="min-h-[44px]"
+                onClick={() => void refreshTab()}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" aria-hidden />
+                Actualizar
+              </Button>
+            </div>
+
+            <TabsContent value="overview" className="space-y-6">
+              <div className="grid gap-4 sm:grid-cols-3">
+                <Metric title="Leads hoy / semana" today={overview?.today.leads} week={overview?.week.leads} total={overview?.totals.leads} />
+                <Metric title="Agenda hoy / semana" today={overview?.today.bookings} week={overview?.week.bookings} total={overview?.totals.bookings} />
+                <Metric title="Diagnósticos hoy / semana" today={overview?.today.diagnosticos} week={overview?.week.diagnosticos} total={overview?.totals.diagnosticos} />
+              </div>
+              <RecentList title="Últimos leads" items={overview?.recent.leads ?? []} />
+              <RecentList title="Últimas reservas" items={overview?.recent.bookings ?? []} />
+            </TabsContent>
+
+            {(["leads", "bookings", "diagnosticos"] as const).map((collection) => (
+              <TabsContent key={collection} value={collection} className="space-y-4">
+                <div className="flex flex-col gap-3 md:flex-row">
+                  <div className="relative flex-1">
+                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+                    <Input
+                      className="min-h-[44px] pl-9"
+                      placeholder="Buscar nombre, email, mensaje…"
+                      value={tab === collection ? query : ""}
+                      onChange={(e) => setQuery(e.target.value)}
+                    />
+                  </div>
+                  <Select
+                    value={tab === collection ? statusFilter : "all"}
+                    onValueChange={setStatusFilter}
+                  >
+                    <SelectTrigger className="min-h-[44px] w-full md:w-48">
+                      <SelectValue placeholder="Estado" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Todos</SelectItem>
+                      {STATUSES[collection].map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {status}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <p className="text-sm text-muted-foreground">{filteredHint}</p>
+                <RecordsTable
+                  collection={collection}
+                  rows={tab === collection ? rows : []}
+                  busyId={busyId}
+                  onStatus={handleStatus}
+                />
+              </TabsContent>
+            ))}
+
+            <TabsContent value="services">
+              <CatalogTable rows={tab === "services" ? catalog : []} kind="services" />
+            </TabsContent>
+            <TabsContent value="cases">
+              <CatalogTable rows={tab === "cases" ? catalog : []} kind="cases" />
+            </TabsContent>
+        </Tabs>
+      </div>
+    </PageShell>
+  );
+}
+
+function Metric({
+  title,
+  today,
+  week,
+  total,
+}: {
+  title: string;
+  today?: number;
+  week?: number;
+  total?: number;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-3xl font-semibold tabular-nums">
+          {today ?? "—"} <span className="text-base text-muted-foreground">/ {week ?? "—"}</span>
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">Total histórico: {total ?? "—"}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentList({ title, items }: { title: string; items: AdminRecord[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Sin registros todavía.</p>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <li key={item.id} className="flex flex-col gap-1 border-b border-border/60 pb-3 last:border-0 last:pb-0">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium">{personName(item.name) === "—" ? item.id : personName(item.name)}</span>
+                  <Badge variant={statusVariant(item.status)}>{item.status || "—"}</Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">{item.email}</p>
+                <p className="text-xs text-muted-foreground">{formatWhen(item.createdAt)}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecordsTable({
+  collection,
+  rows,
+  busyId,
+  onStatus,
+}: {
+  collection: AdminCollection;
+  rows: AdminRecord[];
+  busyId: string | null;
+  onStatus: (collection: AdminCollection, id: string, status: string) => void;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Cuándo</TableHead>
+            <TableHead>Nombre</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Detalle</TableHead>
+            <TableHead>Estado</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={5} className="text-muted-foreground">
+                Sin registros.
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell className="whitespace-nowrap text-xs">{formatWhen(row.createdAt)}</TableCell>
+                <TableCell className="font-medium">{personName(row.name)}</TableCell>
+                <TableCell>
+                  {row.email ? (
+                    <a className="underline-offset-2 hover:underline" href={`mailto:${row.email}`}>
+                      {row.email}
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </TableCell>
+                <TableCell className="max-w-[28rem] text-sm text-muted-foreground">
+                  <DetailCell row={row} collection={collection} />
+                </TableCell>
+                <TableCell>
+                  <Select
+                    value={row.status || STATUSES[collection][0]}
+                    disabled={busyId === row.id}
+                    onValueChange={(value) => onStatus(collection, row.id, value)}
+                  >
+                    <SelectTrigger className="min-h-[40px] w-[11rem]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUSES[collection].map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {status}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function DetailCell({ row, collection }: { row: AdminRecord; collection: AdminCollection }) {
+  if (collection === "bookings") {
+    return (
+      <div className="space-y-1">
+        <p>{row.intent || row.notes || "—"}</p>
+        {row.calendarUrl ? (
+          <a
+            href={String(row.calendarUrl)}
+            className="inline-flex items-center gap-1 text-primary"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <CalendarDays className="h-3.5 w-3.5" aria-hidden />
+            Calendar
+          </a>
+        ) : null}
+      </div>
+    );
+  }
+  if (collection === "diagnosticos") {
+    return (
+      <div className="space-y-1">
+        <p>{row.friction || "—"}</p>
+        {row.company ? <p>Empresa: {String(row.company)}</p> : null}
+      </div>
+    );
+  }
+  return <p className="line-clamp-3">{row.message || row.intent || "—"}</p>;
+}
+
+function CatalogTable({ rows, kind }: { rows: AdminRecord[]; kind: "services" | "cases" }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>{kind === "services" ? "Nombre" : "Caso"}</TableHead>
+            <TableHead>Estado</TableHead>
+            <TableHead>Nota</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={4} className="text-muted-foreground">
+                Catálogo vacío o API no disponible.
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((row) => {
+              const name =
+                typeof row.name === "object" && row.name
+                  ? String((row.name as { es?: string }).es || row.id)
+                  : String(row.name || row.title || row.id);
+              const title =
+                typeof row.title === "object" && row.title
+                  ? String((row.title as { es?: string }).es || "")
+                  : "";
+              const active = row.active !== false && row.published !== false;
+              return (
+                <TableRow key={row.id}>
+                  <TableCell className="font-mono text-xs">{row.id}</TableCell>
+                  <TableCell className="font-medium">{name || title}</TableCell>
+                  <TableCell>
+                    <Badge variant={active ? "default" : "outline"}>
+                      {active ? "activo" : "oculto"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {kind === "services" ? (
+                      <span className="inline-flex items-center gap-1">
+                        <Database className="h-3.5 w-3.5" aria-hidden />
+                        {String(row.kind || "servicio")}
+                      </span>
+                    ) : (
+                      String(row.company || "")
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/pages/AdminPhotos.tsx
+++ b/src/pages/AdminPhotos.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { KeyRound, LogOut, RefreshCw, ShieldCheck, Upload } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Database, KeyRound, LogOut, RefreshCw, ShieldCheck, Upload } from "lucide-react";
 import { SEOHead } from "../components/atoms/SEOHead";
 import { PageShell } from "../components/layout/PageShell";
 import { useLanguage } from "../lib/LanguageContext";
@@ -11,6 +12,7 @@ import { Badge } from "../components/ui/badge";
 import { ResponsiveImage } from "../components/atoms/ResponsiveImage";
 import { IMAGE_CATEGORIES, IMAGE_REGISTRY } from "../data/image-registry";
 import { ADMIN_GITHUB_USER } from "../lib/admin-config";
+import { ROUTES } from "../lib/routes";
 import {
   adminLogout,
   getAdminSession,
@@ -174,6 +176,12 @@ export default function AdminPhotos() {
             Edita las imágenes contenidas en <code className="text-sm">public/images/</code> y{" "}
             <code className="text-sm">profile-photo.jpg</code>. Solo @{ADMIN_GITHUB_USER} en GitHub.
           </p>
+          <Button asChild variant="outline" className="min-h-[44px] w-fit">
+            <Link to={ROUTES.admin}>
+              <Database className="mr-2 h-4 w-4" aria-hidden />
+              Ver leads y bases
+            </Link>
+          </Button>
         </header>
 
         {error && (

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,3 +1,9 @@
+# Worker Viento Norte — contacto, APIs, MCP, admin
+
+Relay de contacto **y** capa de negocio del kick-off: catálogo, leads, agenda, diagnósticos, MCP y panel.
+
+Contrato: [`docs/API-KICKOFF.md`](../docs/API-KICKOFF.md).
+
 # Contact relay — mi-portafolio
 
 Reenvía el formulario de contacto a tu Gmail **sin publicar** `gaete.gaona@gmail.com` en el sitio.

--- a/worker/src/api/admin-data.js
+++ b/worker/src/api/admin-data.js
@@ -1,0 +1,129 @@
+import { json } from '../lib/cors.js';
+import { getCases, getServices } from '../data/catalog.js';
+import { requireAdmin } from '../lib/require-admin.js';
+import { countSince, listRecords, updateRecord } from '../lib/store.js';
+
+const COLLECTIONS = new Set(['leads', 'bookings', 'diagnosticos']);
+const STATUSES = {
+  leads: new Set(['nuevo', 'contactado', 'cerrado']),
+  bookings: new Set(['pendiente', 'confirmado', 'cancelado', 'hecho']),
+  diagnosticos: new Set(['nuevo', 'en_revision', 'respondido', 'cerrado']),
+};
+
+function dayStart(ms = Date.now()) {
+  const d = new Date(ms);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+export async function handleOverview(request, env, cors) {
+  const gate = await requireAdmin(request, env, cors);
+  if (gate.error) return gate.error;
+
+  const [leads, bookings, diagnosticos] = await Promise.all([
+    listRecords(env, 'leads'),
+    listRecords(env, 'bookings'),
+    listRecords(env, 'diagnosticos'),
+  ]);
+
+  const today = dayStart();
+  const week = today - 6 * 24 * 60 * 60 * 1000;
+
+  return json(
+    {
+      ok: true,
+      overview: {
+        today: {
+          leads: countSince(leads, today),
+          bookings: countSince(bookings, today),
+          diagnosticos: countSince(diagnosticos, today),
+        },
+        week: {
+          leads: countSince(leads, week),
+          bookings: countSince(bookings, week),
+          diagnosticos: countSince(diagnosticos, week),
+        },
+        totals: {
+          leads: leads.length,
+          bookings: bookings.length,
+          diagnosticos: diagnosticos.length,
+          services: getServices({ includeInactive: true }).length,
+          cases: getCases({ includeUnpublished: true }).length,
+        },
+        recent: {
+          leads: leads.slice(0, 5),
+          bookings: bookings.slice(0, 5),
+          diagnosticos: diagnosticos.slice(0, 5),
+        },
+      },
+    },
+    200,
+    cors
+  );
+}
+
+export async function handleListCollection(request, env, cors, collection) {
+  const gate = await requireAdmin(request, env, cors);
+  if (gate.error) return gate.error;
+  if (!COLLECTIONS.has(collection)) {
+    return json({ ok: false, error: 'Colección desconocida' }, 404, cors);
+  }
+
+  const url = new URL(request.url);
+  const q = (url.searchParams.get('q') || '').trim().toLowerCase();
+  const status = (url.searchParams.get('status') || '').trim();
+  const items = await listRecords(env, collection);
+
+  const filtered = items.filter((item) => {
+    if (status && item.status !== status) return false;
+    if (!q) return true;
+    return JSON.stringify(item).toLowerCase().includes(q);
+  });
+
+  return json({ ok: true, items: filtered, total: filtered.length }, 200, cors);
+}
+
+export async function handlePatchCollection(request, env, cors, collection, id) {
+  const gate = await requireAdmin(request, env, cors);
+  if (gate.error) return gate.error;
+  if (!COLLECTIONS.has(collection)) {
+    return json({ ok: false, error: 'Colección desconocida' }, 404, cors);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ ok: false, error: 'JSON inválido' }, 400, cors);
+  }
+
+  const patch = {};
+  if (typeof body.status === 'string') {
+    if (!STATUSES[collection].has(body.status)) {
+      return json({ ok: false, error: 'Estado inválido' }, 400, cors);
+    }
+    patch.status = body.status;
+  }
+  if (typeof body.notes === 'string') {
+    patch.notes = body.notes.trim().slice(0, 2000);
+  }
+  if (Object.keys(patch).length === 0) {
+    return json({ ok: false, error: 'Nada que actualizar' }, 400, cors);
+  }
+
+  const updated = await updateRecord(env, collection, id, patch);
+  if (!updated) return json({ ok: false, error: 'No encontrado' }, 404, cors);
+  return json({ ok: true, item: updated }, 200, cors);
+}
+
+export async function handleAdminCatalog(request, env, cors, kind) {
+  const gate = await requireAdmin(request, env, cors);
+  if (gate.error) return gate.error;
+  if (kind === 'services') {
+    return json({ ok: true, items: getServices({ includeInactive: true }) }, 200, cors);
+  }
+  if (kind === 'cases') {
+    return json({ ok: true, items: getCases({ includeUnpublished: true }) }, 200, cors);
+  }
+  return json({ ok: false, error: 'Catálogo desconocido' }, 404, cors);
+}

--- a/worker/src/api/public.js
+++ b/worker/src/api/public.js
@@ -1,0 +1,196 @@
+import { json } from '../lib/cors.js';
+import { getCases, getCompany, getServices } from '../data/catalog.js';
+import { newId, nowIso, prependRecord } from '../lib/store.js';
+
+const MAX_NAME = 120;
+const MAX_EMAIL = 254;
+const MAX_MESSAGE = 4000;
+const MAX_TEXT = 2000;
+
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length <= MAX_EMAIL;
+}
+
+function calendarUrl(env) {
+  return (
+    env.CALENDAR_BOOKING_URL ||
+    env.A11Y_FREE_SCHEDULE_URL ||
+    'https://vientonorte.io/#/contacto'
+  );
+}
+
+export function handleHealth(env, cors) {
+  return json(
+    {
+      ok: true,
+      service: 'vientonorte-api',
+      time: nowIso(),
+      kv: Boolean(env.ADMIN_KV),
+    },
+    200,
+    cors
+  );
+}
+
+export function handleGetServices(cors) {
+  return json({ ok: true, services: getServices() }, 200, cors);
+}
+
+export function handleGetCases(cors) {
+  return json({ ok: true, cases: getCases() }, 200, cors);
+}
+
+export function handleGetCompany(cors) {
+  return json({ ok: true, company: getCompany() }, 200, cors);
+}
+
+export async function persistLead(env, fields) {
+  const record = {
+    id: newId('lead'),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    status: 'nuevo',
+    name: fields.name,
+    email: fields.email,
+    message: fields.message,
+    intent: fields.intent || '',
+    source: fields.source || 'form',
+    language: fields.language || 'es',
+    channel: fields.channel || 'api',
+  };
+  await prependRecord(env, 'leads', record);
+  return record;
+}
+
+export async function handleCreateLead(request, env, cors, { persistOnly = false } = {}) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ ok: false, error: 'JSON inválido' }, 400, cors);
+  }
+
+  if (body?._gotcha) return json({ ok: true }, 200, cors);
+
+  const name = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const message = typeof body.message === 'string' ? body.message.trim().slice(0, MAX_MESSAGE) : '';
+  const intent = typeof body.intent === 'string' ? body.intent.trim().slice(0, 80) : '';
+  const source = typeof body.source === 'string' ? body.source.trim().slice(0, 40) : 'api';
+  const language = body.language === 'en' ? 'en' : 'es';
+
+  if (name.length < 2) return json({ ok: false, error: 'Nombre inválido' }, 400, cors);
+  if (!isValidEmail(email)) return json({ ok: false, error: 'Email inválido' }, 400, cors);
+  if (message.length < 10) return json({ ok: false, error: 'Mensaje demasiado corto' }, 400, cors);
+  if (body.consent !== true && !persistOnly) {
+    return json({ ok: false, error: 'Se requiere consentimiento de contacto' }, 400, cors);
+  }
+
+  const record = await persistLead(env, {
+    name,
+    email,
+    message,
+    intent,
+    source,
+    language,
+    channel: 'leads',
+  });
+
+  return json({ ok: true, lead: { id: record.id, status: record.status } }, 201, cors);
+}
+
+export async function handleCreateBooking(request, env, cors) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ ok: false, error: 'JSON inválido' }, 400, cors);
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const notes = typeof body.notes === 'string' ? body.notes.trim().slice(0, MAX_TEXT) : '';
+  const intent = typeof body.intent === 'string' ? body.intent.trim().slice(0, 80) : 'kickoff';
+
+  if (name.length < 2) return json({ ok: false, error: 'Nombre inválido' }, 400, cors);
+  if (!isValidEmail(email)) return json({ ok: false, error: 'Email inválido' }, 400, cors);
+
+  const url = calendarUrl(env);
+  const record = {
+    id: newId('book'),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    status: 'pendiente',
+    name,
+    email,
+    notes,
+    intent,
+    calendarUrl: url,
+  };
+  await prependRecord(env, 'bookings', record);
+
+  return json(
+    {
+      ok: true,
+      booking: { id: record.id, status: record.status, calendarUrl: url, minutes: 30 },
+    },
+    201,
+    cors
+  );
+}
+
+export async function handleCreateDiagnostico(request, env, cors) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ ok: false, error: 'JSON inválido' }, 400, cors);
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const company = typeof body.company === 'string' ? body.company.trim().slice(0, MAX_NAME) : '';
+  const url = typeof body.url === 'string' ? body.url.trim().slice(0, 400) : '';
+  const friction = typeof body.friction === 'string' ? body.friction.trim().slice(0, MAX_TEXT) : '';
+
+  if (name.length < 2) return json({ ok: false, error: 'Nombre inválido' }, 400, cors);
+  if (!isValidEmail(email)) return json({ ok: false, error: 'Email inválido' }, 400, cors);
+  if (friction.length < 10) {
+    return json({ ok: false, error: 'Describe la fricción (mín. 10 caracteres)' }, 400, cors);
+  }
+
+  const summary = {
+    es: `Diagnóstico recibido. Eje sugerido: ${suggestAxis(friction)}. Próximo paso: call de 30 min para cerrar alcance (Radar / Marco / Ops).`,
+    en: `Diagnostic received. Suggested axis: ${suggestAxis(friction)}. Next step: 30-min call to lock scope (Radar / Marco / Ops).`,
+  };
+
+  const record = {
+    id: newId('dx'),
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    status: 'nuevo',
+    name,
+    email,
+    company,
+    url,
+    friction,
+    response: summary,
+  };
+  await prependRecord(env, 'diagnosticos', record);
+
+  return json(
+    {
+      ok: true,
+      diagnostico: { id: record.id, status: record.status, response: summary },
+    },
+    201,
+    cors
+  );
+}
+
+function suggestAxis(text) {
+  const t = text.toLowerCase();
+  if (/token|design system|componente|wcag|a11y|handoff/.test(t)) return 'design-systems';
+  if (/dato|analytics|ia|ai|research|métrica|metric/.test(t)) return 'research-ai';
+  return 'interfaces';
+}

--- a/worker/src/contact.js
+++ b/worker/src/contact.js
@@ -1,4 +1,5 @@
 import { json } from './lib/cors.js';
+import { persistLead } from './api/public.js';
 import { buildAdminEmail, buildVisitorConfirmation } from './lib/email-templates.js';
 
 const MAX_NAME = 120;
@@ -131,10 +132,10 @@ export async function handleContact(request, env, cors) {
 
   const inbox = env.CONTACT_INBOX || DEFAULT_INBOX;
   const fromEmail = env.CONTACT_FROM || 'contacto@vientonorte.cl';
-  const fromName = env.CONTACT_FROM_NAME || 'Rodrigo Gaete · Portfolio';
+  const fromName = env.CONTACT_FROM_NAME || 'Viento Norte';
   const subject = safeIntent
-    ? `Portfolio · ${safeIntent} · ${safeName}`
-    : `Portfolio · mensaje de ${safeName}`;
+    ? `VN · ${safeIntent} · ${safeName}`
+    : `VN · mensaje de ${safeName}`;
 
   const { text, html } = buildAdminEmail({
     safeName,
@@ -144,6 +145,21 @@ export async function handleContact(request, env, cors) {
     source: safeSource,
     subject,
   });
+
+  let stored = null;
+  try {
+    stored = await persistLead(env, {
+      name: safeName,
+      email: safeEmail,
+      message: safeMessage,
+      intent: safeIntent,
+      source: safeSource,
+      language: safeLanguage,
+      channel: 'contact',
+    });
+  } catch (err) {
+    console.warn('[contact] persist lead failed:', err?.message || err);
+  }
 
   const sent = await sendContactEmail(env, {
     inbox,
@@ -157,17 +173,19 @@ export async function handleContact(request, env, cors) {
     html,
   });
 
-  if (!sent.ok) {
+  if (!sent.ok && !stored) {
     return json({ ok: false, error: 'No se pudo enviar el mensaje.' }, 502, cors);
   }
 
-  await sendVisitorConfirmation(env, {
-    safeName,
-    safeEmail,
-    fromEmail,
-    fromName,
-    language: safeLanguage,
-  });
+  if (sent.ok) {
+    await sendVisitorConfirmation(env, {
+      safeName,
+      safeEmail,
+      fromEmail,
+      fromName,
+      language: safeLanguage,
+    });
+  }
 
-  return json({ ok: true }, 200, cors);
+  return json({ ok: true, leadId: stored?.id || null, emailed: Boolean(sent.ok) }, 200, cors);
 }

--- a/worker/src/data/catalog.js
+++ b/worker/src/data/catalog.js
@@ -1,0 +1,211 @@
+/** Catálogo público de Viento Norte — fuente del GET /api/services|cases|company. */
+
+export const COMPANY = {
+  name: 'Viento Norte',
+  tagline: 'Transformamos complejidad en capacidad de decisión.',
+  kind: 'Consultora UXtech',
+  url: 'https://vientonorte.io',
+  email: 'contacto@vientonorte.io',
+  bookingMinutes: 30,
+  axes: [
+    {
+      id: 'interfaces',
+      es: 'Interfaces y productos digitales (front office, e-comm, dashboards, sistemas internos)',
+      en: 'Interfaces and digital products (front office, e-comm, dashboards, internal systems)',
+    },
+    {
+      id: 'design-systems',
+      es: 'Design Systems y Design Ops (tokens, componentes, WCAG, handoff real)',
+      en: 'Design Systems and Design Ops (tokens, components, WCAG, real handoff)',
+    },
+    {
+      id: 'research-ai',
+      es: 'Investigación + analytics + AI data aplicados a decisiones de negocio',
+      en: 'Research + analytics + AI data applied to business decisions',
+    },
+  ],
+  differentiators: [
+    {
+      id: 'installable',
+      es: 'Software que se instala (no solo prototipos)',
+      en: 'Software that installs (not only prototypes)',
+    },
+    {
+      id: 'data-owner',
+      es: 'Cliente dueño del dato y del código',
+      en: 'Client owns the data and the code',
+    },
+    {
+      id: 'n2n',
+      es: 'Enfoque N2N: de la fricción detectada a capacidad de decisión operativa',
+      en: 'N2N: from detected friction to operational decision capacity',
+    },
+  ],
+};
+
+export const SERVICES = [
+  {
+    id: 'radar',
+    kind: 'package',
+    active: true,
+    order: 1,
+    name: { es: 'Diagnóstico', en: 'Diagnostic' },
+    packLabel: { es: 'Radar', en: 'Radar' },
+    duration: { es: '5–7 días hábiles', en: '5–7 business days' },
+    tagline: {
+      es: 'Diagnóstico express: usabilidad, accesibilidad y plan de mejoras.',
+      en: 'Express diagnostic: usability, accessibility, and improvement plan.',
+    },
+  },
+  {
+    id: 'marco',
+    kind: 'package',
+    active: true,
+    order: 2,
+    featured: true,
+    name: { es: 'Prototipo', en: 'Prototype' },
+    packLabel: { es: 'Marco', en: 'Marco' },
+    duration: { es: '3–4 semanas', en: '3–4 weeks' },
+    tagline: {
+      es: 'Pantallas listas para construir. Incluye diagnóstico y 3 sesiones.',
+      en: 'Screens ready to build. Includes diagnostic and 3 sessions.',
+    },
+  },
+  {
+    id: 'ops',
+    kind: 'package',
+    active: true,
+    order: 3,
+    name: { es: 'Proceso de equipo', en: 'Team process' },
+    packLabel: { es: 'Ops', en: 'Ops' },
+    duration: { es: '4–6 semanas', en: '4–6 weeks' },
+    tagline: {
+      es: 'Ordenar cómo diseña y entrega tu equipo.',
+      en: 'Organize how your team designs and delivers.',
+    },
+  },
+  {
+    id: 'dashboard',
+    kind: 'module',
+    active: true,
+    order: 10,
+    name: { es: 'Dashboard', en: 'Dashboard' },
+    packLabel: { es: 'Módulo', en: 'Module' },
+    tagline: {
+      es: 'Operación y KPIs en un aliento, instalado en tu perímetro.',
+      en: 'Ops and KPIs in one breath, installed in your perimeter.',
+    },
+  },
+  {
+    id: 'riesgo',
+    kind: 'module',
+    active: true,
+    order: 11,
+    name: { es: 'Riesgo', en: 'Risk' },
+    packLabel: { es: 'Módulo', en: 'Module' },
+    tagline: {
+      es: 'Alertas y control de riesgo sin ceder el dato.',
+      en: 'Risk alerts and control without giving up the data.',
+    },
+  },
+  {
+    id: 'inventario',
+    kind: 'module',
+    active: true,
+    order: 12,
+    name: { es: 'Inventario', en: 'Inventory' },
+    packLabel: { es: 'Módulo', en: 'Module' },
+    tagline: {
+      es: 'Stock y movimiento con ownership de tablas.',
+      en: 'Stock and movement with table ownership.',
+    },
+  },
+  {
+    id: 'pedidos',
+    kind: 'module',
+    active: true,
+    order: 13,
+    name: { es: 'Pedidos', en: 'Orders' },
+    packLabel: { es: 'Módulo', en: 'Module' },
+    tagline: {
+      es: 'Front office de pedidos, instalable.',
+      en: 'Installable order front office.',
+    },
+  },
+  {
+    id: 'clientes',
+    kind: 'module',
+    active: true,
+    order: 14,
+    name: { es: 'Clientes', en: 'Customers' },
+    packLabel: { es: 'Módulo', en: 'Module' },
+    tagline: {
+      es: 'Base comercial y fidelización, dueño del dato.',
+      en: 'Commercial base and loyalty — you own the data.',
+    },
+  },
+  {
+    id: 'reportes',
+    kind: 'module',
+    active: true,
+    order: 15,
+    name: { es: 'Reportes', en: 'Reports' },
+    packLabel: { es: 'Módulo', en: 'Module' },
+    tagline: {
+      es: 'Reportes exportables, sin arriendo de analítica.',
+      en: 'Exportable reports, no analytics rent.',
+    },
+  },
+];
+
+export const CASES = [
+  {
+    id: 'sura-ux-enterprise',
+    published: true,
+    company: 'SURA Investments',
+    title: { es: 'UX enterprise Wealth', en: 'Wealth enterprise UX' },
+    url: 'https://vientonorte.io/#/proyecto/sura-ux-enterprise',
+  },
+  {
+    id: 'transvip-app-premium',
+    published: true,
+    company: 'Transvip',
+    title: { es: 'App premium de reserva', en: 'Premium booking app' },
+    url: 'https://vientonorte.io/#/proyecto/transvip-app-premium',
+  },
+  {
+    id: 'karri-design-sprint',
+    published: true,
+    company: 'Karri',
+    title: { es: 'Design Sprint y delivery', en: 'Design Sprint and delivery' },
+    url: 'https://vientonorte.io/#/proyecto/karri-design-sprint',
+  },
+  {
+    id: 'edu21',
+    published: true,
+    company: 'Edu21',
+    title: { es: 'Producto educativo', en: 'Education product' },
+    url: 'https://vientonorte.io/#/proyectos',
+  },
+  {
+    id: 'xcms',
+    published: true,
+    company: 'Viento Norte',
+    title: { es: 'X|CMS · módulos a medida', en: 'X|CMS · custom modules' },
+    url: 'https://vientonorte.io/#/demo/x-cms',
+  },
+];
+
+export function getCompany() {
+  return COMPANY;
+}
+
+export function getServices({ includeInactive = false } = {}) {
+  return SERVICES.filter((item) => includeInactive || item.active).sort(
+    (a, b) => a.order - b.order
+  );
+}
+
+export function getCases({ includeUnpublished = false } = {}) {
+  return CASES.filter((item) => includeUnpublished || item.published);
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -16,6 +16,22 @@ import {
   handlePatchImage,
   handleDeleteImage,
 } from './admin/images.js';
+import {
+  handleCreateBooking,
+  handleCreateDiagnostico,
+  handleCreateLead,
+  handleGetCases,
+  handleGetCompany,
+  handleGetServices,
+  handleHealth,
+} from './api/public.js';
+import {
+  handleAdminCatalog,
+  handleListCollection,
+  handleOverview,
+  handlePatchCollection,
+} from './api/admin-data.js';
+import { handleMcp } from './mcp/server.js';
 
 export default {
   async fetch(request, env) {
@@ -30,9 +46,37 @@ export default {
       return new Response(null, { status: 204, headers: cors });
     }
 
-    // ── Contact (existente) ──
+    // ── Health + catálogo público ──
+    if (path === '/api/health' && request.method === 'GET') {
+      return handleHealth(env, cors);
+    }
+    if (path === '/api/services' && request.method === 'GET') {
+      return handleGetServices(cors);
+    }
+    if (path === '/api/cases' && request.method === 'GET') {
+      return handleGetCases(cors);
+    }
+    if (path === '/api/company' && request.method === 'GET') {
+      return handleGetCompany(cors);
+    }
+
+    // ── Escritura pública ──
     if (path === '/api/contact' && request.method === 'POST') {
       return handleContact(request, env, cors);
+    }
+    if (path === '/api/leads' && request.method === 'POST') {
+      return handleCreateLead(request, env, cors);
+    }
+    if (path === '/api/booking' && request.method === 'POST') {
+      return handleCreateBooking(request, env, cors);
+    }
+    if (path === '/api/diagnostico' && request.method === 'POST') {
+      return handleCreateDiagnostico(request, env, cors);
+    }
+
+    // ── MCP (JSON-RPC) ──
+    if (path === '/mcp' || path === '/api/mcp') {
+      return handleMcp(request, env, cors);
     }
 
     // ── Manifest público ──
@@ -71,6 +115,35 @@ export default {
     }
     if (path === '/api/admin/auth/logout' && request.method === 'POST') {
       return json({ ok: true }, 200, { ...cors, 'Set-Cookie': clearSessionCookie() });
+    }
+
+    // ── Admin data browser ──
+    if (path === '/api/admin/overview' && request.method === 'GET') {
+      return handleOverview(request, env, cors);
+    }
+    if (path === '/api/admin/services' && request.method === 'GET') {
+      return handleAdminCatalog(request, env, cors, 'services');
+    }
+    if (path === '/api/admin/cases' && request.method === 'GET') {
+      return handleAdminCatalog(request, env, cors, 'cases');
+    }
+
+    const collectionMatch = path.match(/^\/api\/admin\/(leads|bookings|diagnosticos)$/);
+    if (collectionMatch && request.method === 'GET') {
+      return handleListCollection(request, env, cors, collectionMatch[1]);
+    }
+
+    const collectionItemMatch = path.match(
+      /^\/api\/admin\/(leads|bookings|diagnosticos)\/([^/]+)$/
+    );
+    if (collectionItemMatch && request.method === 'PATCH') {
+      return handlePatchCollection(
+        request,
+        env,
+        cors,
+        collectionItemMatch[1],
+        decodeURIComponent(collectionItemMatch[2])
+      );
     }
 
     // ── Imágenes admin ──

--- a/worker/src/lib/cors.js
+++ b/worker/src/lib/cors.js
@@ -1,15 +1,19 @@
-export function corsHeaders(origin) {
-  return {
+export function corsHeaders(origin, { credentials = true } = {}) {
+  const headers = {
     'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-VN-API-KEY',
     'Access-Control-Max-Age': '86400',
   };
+  if (credentials && origin !== '*') {
+    headers['Access-Control-Allow-Credentials'] = 'true';
+  }
+  return headers;
 }
 
 export function isAllowedOrigin(request, env) {
   const origin = request.headers.get('Origin') || '';
+  if (!origin) return '*';
   const allowed = (env.ALLOWED_ORIGIN || '')
     .split(',')
     .map((s) => s.trim())

--- a/worker/src/lib/email-templates.js
+++ b/worker/src/lib/email-templates.js
@@ -20,7 +20,7 @@ export function escapeHtml(str) {
 
 export function buildAdminEmail({ safeName, safeEmail, safeMessage, intent, source, subject }) {
   const text = [
-    'Nuevo mensaje desde el portafolio',
+    'Nuevo mensaje desde vientonorte.io',
     '',
     `Nombre: ${safeName}`,
     `Email: ${safeEmail}`,
@@ -46,7 +46,7 @@ export function buildAdminEmail({ safeName, safeEmail, safeMessage, intent, sour
     </tr>
     <tr>
       <td style="padding:28px 24px">
-        <p style="margin:0 0 8px;font-size:11px;letter-spacing:0.12em;text-transform:uppercase;color:#888">Viento Norte · Portfolio</p>
+        <p style="margin:0 0 8px;font-size:11px;letter-spacing:0.12em;text-transform:uppercase;color:#888">Viento Norte · vientonorte.io</p>
         <h1 style="margin:0 0 20px;font-size:20px;font-weight:600;line-height:1.3">${escapeHtml(subject)}</h1>
         <table role="presentation" width="100%" style="margin-bottom:20px;font-size:14px">
           <tr><td style="padding:6px 0;color:#666;width:100px">Nombre</td><td style="padding:6px 0;font-weight:500">${escapeHtml(safeName)}</td></tr>
@@ -78,24 +78,26 @@ export function buildVisitorConfirmation({ safeName, publicFromEmail, language =
     ? [
         `Hi ${safeName},`,
         '',
-        'We received your inquiry through the portfolio. I will reply within 24 business hours.',
+        'We received your message from vientonorte.io. Viento Norte will reply within 24 business hours.',
         '',
         'Your email is used only to respond to this contact — we do not share it with third parties.',
         '',
         `If you did not send this request, ignore this email or write to ${publicFromEmail}.`,
         '',
-        '— Rodrigo Gaete · UX Lead',
+        '— Viento Norte',
+        'vientonorte.io',
       ].join('\n')
     : [
         `Hola ${safeName},`,
         '',
-        'Recibimos tu consulta desde el portafolio. Te responderé en menos de 24 horas hábiles.',
+        'Recibimos tu consulta desde vientonorte.io. Viento Norte te responde en menos de 24 horas hábiles.',
         '',
         'Tu email se usa solo para responder este contacto — no lo compartimos con terceros.',
         '',
         `Si no enviaste esta solicitud, ignora este correo o escribe a ${publicFromEmail}.`,
         '',
-        '— Rodrigo Gaete · UX Lead',
+        '— Viento Norte',
+        'vientonorte.io',
       ].join('\n');
 
   const footer = isEn ? PRIVACY_FOOTER_EN : PRIVACY_FOOTER_ES;
@@ -113,8 +115,8 @@ export function buildVisitorConfirmation({ safeName, publicFromEmail, language =
         <p style="margin:0 0 12px;font-size:15px;line-height:1.5">${isEn ? 'Hi' : 'Hola'} <strong>${escapeHtml(safeName)}</strong>,</p>
         <p style="margin:0 0 12px;font-size:14px;line-height:1.6;color:#333">
           ${isEn
-            ? 'We received your inquiry through the portfolio. I will reply within <strong>24 business hours</strong>.'
-            : 'Recibimos tu consulta desde el portafolio. Te responderé en <strong>menos de 24 horas hábiles</strong>.'}
+            ? 'We received your message from <strong>vientonorte.io</strong>. Viento Norte will reply within <strong>24 business hours</strong>.'
+            : 'Recibimos tu consulta desde <strong>vientonorte.io</strong>. Viento Norte te responde en <strong>menos de 24 horas hábiles</strong>.'}
         </p>
         <p style="margin:0;font-size:13px;line-height:1.5;color:#666">
           ${isEn

--- a/worker/src/lib/require-admin.js
+++ b/worker/src/lib/require-admin.js
@@ -1,0 +1,10 @@
+import { json } from './cors.js';
+import { readSession } from './session.js';
+
+export async function requireAdmin(request, env, cors) {
+  const user = await readSession(request, env);
+  if (!user) {
+    return { user: null, error: json({ ok: false, error: 'Unauthorized' }, 401, cors) };
+  }
+  return { user, error: null };
+}

--- a/worker/src/lib/store.js
+++ b/worker/src/lib/store.js
@@ -1,0 +1,64 @@
+const KEYS = {
+  leads: 'vn:leads',
+  bookings: 'vn:bookings',
+  diagnosticos: 'vn:diagnosticos',
+};
+
+const MAX_RECORDS = 2000;
+
+export function newId(prefix) {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+function assertCollection(collection) {
+  if (!KEYS[collection]) {
+    throw new Error(`Colección desconocida: ${collection}`);
+  }
+}
+
+export async function listRecords(env, collection) {
+  assertCollection(collection);
+  if (!env.ADMIN_KV) return [];
+  const raw = await env.ADMIN_KV.get(KEYS[collection]);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function prependRecord(env, collection, record) {
+  assertCollection(collection);
+  const items = await listRecords(env, collection);
+  items.unshift(record);
+  const next = items.slice(0, MAX_RECORDS);
+  if (env.ADMIN_KV) {
+    await env.ADMIN_KV.put(KEYS[collection], JSON.stringify(next));
+  }
+  return record;
+}
+
+export async function updateRecord(env, collection, id, patch) {
+  assertCollection(collection);
+  const items = await listRecords(env, collection);
+  const idx = items.findIndex((item) => item.id === id);
+  if (idx < 0) return null;
+  items[idx] = { ...items[idx], ...patch, updatedAt: nowIso() };
+  if (env.ADMIN_KV) {
+    await env.ADMIN_KV.put(KEYS[collection], JSON.stringify(items));
+  }
+  return items[idx];
+}
+
+export function countSince(items, sinceMs) {
+  return items.filter((item) => {
+    const ts = Date.parse(item.createdAt || '');
+    return Number.isFinite(ts) && ts >= sinceMs;
+  }).length;
+}

--- a/worker/src/mcp/server.js
+++ b/worker/src/mcp/server.js
@@ -1,0 +1,255 @@
+import { json } from '../lib/cors.js';
+import { getCases, getCompany, getServices } from '../data/catalog.js';
+import { newId, nowIso, prependRecord } from '../lib/store.js';
+
+const PROTOCOL = '2024-11-05';
+const SERVER_INFO = { name: 'vientonorte', version: '1.0.0' };
+
+const READ_TOOLS = new Set(['list_services', 'get_cases', 'get_company_info']);
+const WRITE_TOOLS = new Set(['submit_lead', 'book_call', 'request_diagnostico']);
+
+function tool(name, description, properties, required = []) {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      properties,
+      required,
+      additionalProperties: false,
+    },
+  };
+}
+
+function toolsList() {
+  return [
+    tool('list_services', 'Lista paquetes (Radar/Marco/Ops) y módulos a medida de Viento Norte.', {
+      kind: { type: 'string', enum: ['all', 'package', 'module'], description: 'Filtro opcional' },
+    }),
+    tool('get_cases', 'Casos publicados de Viento Norte (SURA, Transvip, Karri, X|CMS).', {}),
+    tool('get_company_info', 'Propuesta de valor, ejes, contacto y diferenciadores.', {}),
+    tool(
+      'submit_lead',
+      'Captura un lead de contacto. Requiere API key.',
+      {
+        name: { type: 'string' },
+        email: { type: 'string' },
+        message: { type: 'string' },
+        intent: { type: 'string' },
+      },
+      ['name', 'email', 'message']
+    ),
+    tool(
+      'book_call',
+      'Registra una solicitud de agenda de 30 min y devuelve la URL de Calendar. Requiere API key.',
+      {
+        name: { type: 'string' },
+        email: { type: 'string' },
+        notes: { type: 'string' },
+        intent: { type: 'string' },
+      },
+      ['name', 'email']
+    ),
+    tool(
+      'request_diagnostico',
+      'Solicita un diagnóstico rápido a partir de una fricción. Requiere API key.',
+      {
+        name: { type: 'string' },
+        email: { type: 'string' },
+        company: { type: 'string' },
+        url: { type: 'string' },
+        friction: { type: 'string' },
+      },
+      ['name', 'email', 'friction']
+    ),
+  ];
+}
+
+function hasApiKey(request, env) {
+  const expected = env.VN_API_KEY;
+  if (!expected) return false;
+  const header = request.headers.get('X-VN-API-KEY') || '';
+  const auth = request.headers.get('Authorization') || '';
+  const bearer = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  return header === expected || bearer === expected;
+}
+
+function rpcResult(id, result) {
+  return { jsonrpc: '2.0', id: id ?? null, result };
+}
+
+function rpcError(id, code, message) {
+  return { jsonrpc: '2.0', id: id ?? null, error: { code, message } };
+}
+
+function textResult(payload) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(email || ''));
+}
+
+async function callTool(name, args, env) {
+  const a = args && typeof args === 'object' ? args : {};
+
+  if (name === 'list_services') {
+    const kind = a.kind || 'all';
+    const services = getServices().filter((s) => kind === 'all' || s.kind === kind);
+    return textResult({ services });
+  }
+  if (name === 'get_cases') return textResult({ cases: getCases() });
+  if (name === 'get_company_info') return textResult({ company: getCompany() });
+
+  if (name === 'submit_lead') {
+    if (!a.name || String(a.name).trim().length < 2) throw new Error('name inválido');
+    if (!isValidEmail(a.email)) throw new Error('email inválido');
+    if (!a.message || String(a.message).trim().length < 10) throw new Error('message demasiado corto');
+    const record = {
+      id: newId('lead'),
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+      status: 'nuevo',
+      name: String(a.name).trim().slice(0, 120),
+      email: String(a.email).trim().toLowerCase(),
+      message: String(a.message).trim().slice(0, 4000),
+      intent: String(a.intent || 'mcp').slice(0, 80),
+      source: 'mcp',
+      language: 'es',
+      channel: 'mcp',
+    };
+    await prependRecord(env, 'leads', record);
+    return textResult({ ok: true, id: record.id });
+  }
+
+  if (name === 'book_call') {
+    if (!a.name || String(a.name).trim().length < 2) throw new Error('name inválido');
+    if (!isValidEmail(a.email)) throw new Error('email inválido');
+    const calendarUrl =
+      env.CALENDAR_BOOKING_URL || env.A11Y_FREE_SCHEDULE_URL || 'https://vientonorte.io/#/contacto';
+    const record = {
+      id: newId('book'),
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+      status: 'pendiente',
+      name: String(a.name).trim().slice(0, 120),
+      email: String(a.email).trim().toLowerCase(),
+      notes: String(a.notes || '').trim().slice(0, 2000),
+      intent: String(a.intent || 'kickoff').slice(0, 80),
+      calendarUrl,
+    };
+    await prependRecord(env, 'bookings', record);
+    return textResult({ ok: true, id: record.id, calendarUrl, minutes: 30 });
+  }
+
+  if (name === 'request_diagnostico') {
+    if (!a.name || String(a.name).trim().length < 2) throw new Error('name inválido');
+    if (!isValidEmail(a.email)) throw new Error('email inválido');
+    if (!a.friction || String(a.friction).trim().length < 10) throw new Error('friction demasiado corta');
+    const record = {
+      id: newId('dx'),
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+      status: 'nuevo',
+      name: String(a.name).trim().slice(0, 120),
+      email: String(a.email).trim().toLowerCase(),
+      company: String(a.company || '').trim().slice(0, 120),
+      url: String(a.url || '').trim().slice(0, 400),
+      friction: String(a.friction).trim().slice(0, 2000),
+      response: {
+        es: 'Diagnóstico recibido. Próximo paso: call de 30 min para cerrar Radar / Marco / Ops.',
+        en: 'Diagnostic received. Next step: 30-min call to lock Radar / Marco / Ops.',
+      },
+    };
+    await prependRecord(env, 'diagnosticos', record);
+    return textResult({ ok: true, id: record.id, response: record.response });
+  }
+
+  throw new Error(`Tool desconocida: ${name}`);
+}
+
+async function handleRpc(message, request, env) {
+  if (!message || message.jsonrpc !== '2.0') {
+    return rpcError(null, -32600, 'Invalid Request');
+  }
+
+  const { id, method, params } = message;
+
+  if (method === 'initialize') {
+    return rpcResult(id, {
+      protocolVersion: PROTOCOL,
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: SERVER_INFO,
+    });
+  }
+
+  if (method === 'notifications/initialized' || method === 'initialized') {
+    return null;
+  }
+
+  if (method === 'ping') {
+    return rpcResult(id, {});
+  }
+
+  if (method === 'tools/list') {
+    return rpcResult(id, { tools: toolsList() });
+  }
+
+  if (method === 'tools/call') {
+    const name = params?.name;
+    if (!name) return rpcError(id, -32602, 'name requerido');
+    if (WRITE_TOOLS.has(name) && !hasApiKey(request, env)) {
+      return rpcError(id, -32001, 'API key requerida para tools de escritura (X-VN-API-KEY)');
+    }
+    if (!READ_TOOLS.has(name) && !WRITE_TOOLS.has(name)) {
+      return rpcError(id, -32601, `Tool no encontrada: ${name}`);
+    }
+    try {
+      const result = await callTool(name, params?.arguments || {}, env);
+      return rpcResult(id, result);
+    } catch (err) {
+      return rpcError(id, -32000, err.message || 'Tool failed');
+    }
+  }
+
+  return rpcError(id, -32601, `Method not found: ${method}`);
+}
+
+export async function handleMcp(request, env, cors) {
+  if (request.method === 'GET') {
+    return json(
+      {
+        ok: true,
+        name: SERVER_INFO.name,
+        version: SERVER_INFO.version,
+        protocol: PROTOCOL,
+        transport: 'json-rpc',
+        tools: toolsList().map((t) => t.name),
+      },
+      200,
+      cors
+    );
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json(rpcError(null, -32700, 'Parse error'), 400, cors);
+  }
+
+  if (Array.isArray(body)) {
+    const results = [];
+    for (const msg of body) {
+      const out = await handleRpc(msg, request, env);
+      if (out) results.push(out);
+    }
+    return json(results, 200, cors);
+  }
+
+  const out = await handleRpc(body, request, env);
+  if (!out) return new Response(null, { status: 204, headers: cors });
+  return json(out, 200, cors);
+}

--- a/worker/wrangler.contact.toml
+++ b/worker/wrangler.contact.toml
@@ -14,7 +14,7 @@ routes = [
 [vars]
 ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173"
 CONTACT_FROM = "contacto@vientonorte.io"
-CONTACT_FROM_NAME = "Rodrigo Gaete · Portfolio"
+CONTACT_FROM_NAME = "Viento Norte"
 CONTACT_INBOX = "gaete.gaona@gmail.com"
 
 [[send_email]]

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -9,18 +9,20 @@ routes = [
 ]
 
 [vars]
-ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173"
+ALLOWED_ORIGIN = "https://vientonorte.io,https://www.vientonorte.io,https://vientonorte.github.io,http://localhost:3000,http://localhost:5173,http://localhost:4173,http://127.0.0.1:5173"
 CONTACT_FROM = "contacto@vientonorte.io"
-CONTACT_FROM_NAME = "Rodrigo Gaete · Portfolio"
+CONTACT_FROM_NAME = "Viento Norte"
 # Inbox privado — override con secret si prefieres: wrangler secret put CONTACT_INBOX
 CONTACT_INBOX = "gaete.gaona@gmail.com"
 ADMIN_GITHUB_USER = "vientonorte"
 STATIC_IMAGE_BASE = "https://vientonorte.io/mi-portafolio"
 WEBAUTHN_RP_ID = "vientonorte.io"
+# Agenda pública de 30 min (override: wrangler secret / var)
+CALENDAR_BOOKING_URL = ""
 # R2_PUBLIC_BASE = "https://pub-xxxx.r2.dev"  # tras habilitar acceso público al bucket
 
 # Secrets (wrangler secret put):
-#   CONTACT_INBOX, SESSION_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET
+#   CONTACT_INBOX, SESSION_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, VN_API_KEY
 
 [[send_email]]
 name = "EMAIL"


### PR DESCRIPTION
## Qué
- `#/admin` no está en la nav. Sin sesión: gate de **passkey** (GitHub solo en «Primera vez»).
- Chrome público (header/dock) oculto en admin. `noindex` + robots.
- Mail de confirmación: «desde vientonorte.io», voz Viento Norte (no portafolio).
- APIs + MCP + persistencia de leads/booking. Journey de agenda documentado.

## Seguridad por diseño
- Datos solo vía Worker con cookie HttpOnly / sesión @vientonorte.
- El HTML no lista leads hasta haber sesión.
- Passkey como camino diario; GitHub es bootstrap.

## GTM
Código dataLayer listo. Falta `VITE_GTM_ID` (no hay contenedor). Receta: `docs/GTM-KICKOFF.md`.

## Deploy Worker
Tras merge: `cd worker && npx wrangler deploy` (no solo contact.toml) + `wrangler secret put VN_API_KEY`.