### PR TITLE
feat(admin): fotos con nombre y aplicación (share, schema, favicon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-13] — Admin fotos: nombre + aplicación web
+
+### Added
+- `#/admin/fotos`: subir foto con **nombre** y **aplicación** (share home/consultoría, schema, favicon, logo, Apple/PWA, FAQ, galería).
+- `POST /api/admin/images` crea slot cableado o `custom.*` en KV/R2.
+
+---
+
 ## [2026-08-13] — Kick-off consultora: landing + APIs + MCP + admin BD
 
 ### Added

--- a/docs/CMS-ADMIN-CAPABILIDADES.md
+++ b/docs/CMS-ADMIN-CAPABILIDADES.md
@@ -19,7 +19,7 @@ Vamos excelente: el CMS ya es el tablero de las mismas BDs que alimentan landing
 | Agenda | tab Agenda | `GET/PATCH /api/admin/bookings` | Ver slot + link Calendar, cambiar estado |
 | Diagnósticos | tab Diagnósticos | `GET/PATCH /api/admin/diagnosticos` | Ver fricción + respuesta, estado |
 | Servicios / casos | tabs | `GET /api/admin/services` · `/cases` | Catálogo **solo lectura** (Radar/Marco/Ops + módulos) |
-| Fotos / OG | `#/admin/fotos` | `GET/POST/PATCH /api/admin/images` · `POST .../publish` | Subir a **R2**. `branding/*` abre **PR automático** a `public/images/` (Pages). Botón «Publicar PR» para el resto |
+| Fotos / OG | `#/admin/fotos` | `GET/POST /api/admin/images` · `POST .../:id` · PATCH label/rol/alt · publish | Subir **con nombre + aplicación** (share home/consultoría, schema, favicon, logo, Apple, FAQ, galería). Roles cableados abren PR a Pages. |
 | Público | web + agentes | `/api/health` `/services` `/cases` `/company` `/contact` `/leads` `/booking` `/diagnostico` | Captura y catálogo |
 | Agentes | MCP | `list_services` `get_cases` `get_company_info` `submit_lead` `book_call` `request_diagnostico` | Misma BD |
 

--- a/src/data/image-registry.ts
+++ b/src/data/image-registry.ts
@@ -7,6 +7,7 @@ export interface ImageRegistryEntry {
   path: string;
   defaultUrl: string;
   alt: string;
+  role?: string;
 }
 
 function entry(
@@ -23,7 +24,13 @@ function entry(
 /** Catálogo editable — fotos en public/images/ y profile-photo.jpg */
 export const IMAGE_REGISTRY: ImageRegistryEntry[] = [
   entry("branding.profilePhoto", "Branding", "Foto de perfil", "profile-photo.jpg", portfolioImages.branding.profilePhoto, "Rodrigo Gaete, UX Lead"),
-  entry("branding.ogPortfolio", "Branding", "OG / PWA", "branding/og-portfolio.png", portfolioImages.branding.ogPortfolio, "Viento Norte · UXtech · módulos a medida"),
+  entry("branding.ogHome", "Branding", "Share redes · home", "branding/og-home-1200.png", portfolioImages.branding.ogHome, "Viento Norte — share home"),
+  entry("branding.ogConsultoria", "Branding", "Share redes · consultoría", "branding/og-consultoria-1200.png", portfolioImages.branding.ogConsultoria, "Viento Norte — share consultoría"),
+  entry("branding.ogPortfolio", "Branding", "OG / PWA (legacy)", "branding/og-portfolio.png", portfolioImages.branding.ogPortfolio, "Viento Norte · UXtech · módulos a medida"),
+  entry("branding.isologo", "Branding", "Logo / isologo", "branding/isologo-512.png", portfolioImages.branding.isologo, "Isologo Viento Norte"),
+  entry("branding.favicon", "Branding", "Favicon", "favicon.ico", portfolioImages.branding.favicon, "Favicon Viento Norte"),
+  entry("branding.schemaLogo", "Branding", "Schema.org logo", "icon-512x512.png", portfolioImages.branding.schemaLogo, "Logo schema Viento Norte"),
+  entry("branding.appleTouch", "Branding", "Apple / PWA", "icon-192x192.png", portfolioImages.branding.appleTouch, "Apple touch Viento Norte"),
   entry("sura.riaOnboarding", "SURA", "RIA onboarding", "sura/ria-onboarding.png", portfolioImages.sura.riaOnboarding, "Onboarding RIA SURA US"),
   entry("sura.webPrototype", "SURA", "Prototipo web RIA", "sura/web-prototype.png", portfolioImages.sura.webPrototype, "Prototipo web SURA — plataforma inversiones / RIA"),
   entry("sura.componentPipeline", "SURA", "Pipeline componentes", "sura/component-pipeline.png", portfolioImages.sura.componentPipeline, "Pipeline MVP — Explorar, Refinar, Documentar, Implementar"),

--- a/src/data/image-roles.ts
+++ b/src/data/image-roles.ts
@@ -1,0 +1,72 @@
+/** Aplicaciones web que una foto puede alimentar. Una casa por rol. */
+
+export type ImageWebRole =
+  | "share_home"
+  | "share_consultoria"
+  | "schema"
+  | "favicon"
+  | "logo"
+  | "apple"
+  | "faq"
+  | "gallery";
+
+export interface ImageRoleDef {
+  id: ImageWebRole;
+  label: string;
+  hint: string;
+  /** Slot de catálogo; vacío = subida libre (R2, sin Pages). */
+  slotId?: string;
+}
+
+export const IMAGE_WEB_ROLES: ImageRoleDef[] = [
+  {
+    id: "share_home",
+    label: "Share redes · home",
+    hint: "LinkedIn / Meta / WhatsApp al pegar vientonorte.io. PNG 1200×630.",
+    slotId: "branding.ogHome",
+  },
+  {
+    id: "share_consultoria",
+    label: "Share redes · consultoría",
+    hint: "Card al pegar /s/consultoria. PNG 1200×630.",
+    slotId: "branding.ogConsultoria",
+  },
+  {
+    id: "schema",
+    label: "Schema.org (logo)",
+    hint: "JSON-LD Organization.logo. Cuadrado ≥512.",
+    slotId: "branding.schemaLogo",
+  },
+  {
+    id: "favicon",
+    label: "Favicon",
+    hint: "Pestaña del navegador. ICO o PNG 32–48.",
+    slotId: "branding.favicon",
+  },
+  {
+    id: "logo",
+    label: "Logo / isologo",
+    hint: "Marca en toolbar. PNG cuadrado, fondo limpio.",
+    slotId: "branding.isologo",
+  },
+  {
+    id: "apple",
+    label: "Apple / PWA",
+    hint: "icon-192. Cuadrado.",
+    slotId: "branding.appleTouch",
+  },
+  {
+    id: "faq",
+    label: "FAQ / ayuda",
+    hint: "Ilustración de ayuda. No reescribe HTML solo.",
+  },
+  {
+    id: "gallery",
+    label: "Galería (sin cable)",
+    hint: "Queda en R2 + CMS. No cambia favicon ni share.",
+  },
+];
+
+export function roleDef(id: string | undefined): ImageRoleDef | undefined {
+  return IMAGE_WEB_ROLES.find((r) => r.id === id);
+}

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -8,6 +8,8 @@ export interface AdminImageRecord {
   path: string;
   category: string;
   label: string;
+  role?: string;
+  custom?: boolean;
   overridden: boolean;
   updatedAt?: string;
   prUrl?: string;
@@ -112,6 +114,18 @@ export async function listAdminImages(): Promise<AdminImageRecord[]> {
   return data.images;
 }
 
+export async function createAdminImage(
+  file: File,
+  fields: { label: string; role: string; alt?: string }
+): Promise<ImagePublishResult> {
+  const form = new FormData();
+  form.append("file", file);
+  form.append("label", fields.label);
+  form.append("role", fields.role);
+  if (fields.alt) form.append("alt", fields.alt);
+  return adminFetch<ImagePublishResult>(ADMIN_ROUTES.images, { method: "POST", body: form });
+}
+
 export async function uploadAdminImage(id: string, file: File, alt?: string): Promise<ImagePublishResult> {
   const form = new FormData();
   form.append("file", file);
@@ -130,10 +144,14 @@ export async function publishAdminImage(id: string): Promise<ImagePublishResult>
   );
 }
 
-export async function updateAdminImageMeta(id: string, alt: string): Promise<AdminImageRecord> {
+export async function updateAdminImageMeta(
+  id: string,
+  patch: string | { alt?: string; label?: string; role?: string }
+): Promise<AdminImageRecord> {
+  const body = typeof patch === "string" ? { alt: patch } : patch;
   const data = await adminFetch<{ image: AdminImageRecord }>(
     `${ADMIN_ROUTES.images}/${encodeURIComponent(id)}`,
-    { method: "PATCH", body: JSON.stringify({ alt }) }
+    { method: "PATCH", body: JSON.stringify(body) }
   );
   return data.image;
 }
@@ -215,6 +233,7 @@ export function registryToAdminPreview(entry: ImageRegistryEntry): AdminImageRec
     path: entry.path,
     category: entry.category,
     label: entry.label,
+    role: entry.role,
     overridden: false,
   };
 }

--- a/src/lib/portfolio-image-urls.ts
+++ b/src/lib/portfolio-image-urls.ts
@@ -101,7 +101,13 @@ export const portfolioImages = {
   },
   branding: {
     ogPortfolio: img("branding/og-portfolio.png"),
+    ogHome: img("branding/og-home-1200.png"),
+    ogConsultoria: img("branding/og-consultoria-1200.png"),
+    isologo: img("branding/isologo-512.png"),
     profilePhoto: `${base}profile-photo.jpg?v=20260703b`,
+    favicon: `${base}favicon.ico`,
+    schemaLogo: `${base}icon-512x512.png`,
+    appleTouch: `${base}icon-192x192.png`,
   },
   /** Monogramas para marcas sin wordmark oficial en el repo */
   brands: {

--- a/src/pages/AdminPhotos.tsx
+++ b/src/pages/AdminPhotos.tsx
@@ -11,6 +11,7 @@ import { Input } from "../components/ui/input";
 import { Badge } from "../components/ui/badge";
 import { ResponsiveImage } from "../components/atoms/ResponsiveImage";
 import { IMAGE_CATEGORIES, IMAGE_REGISTRY } from "../data/image-registry";
+import { IMAGE_WEB_ROLES, roleDef } from "../data/image-roles";
 import { ADMIN_GITHUB_USER } from "../lib/admin-config";
 import { ROUTES } from "../lib/routes";
 import {
@@ -24,6 +25,7 @@ import {
   revertAdminImage,
   startGithubLogin,
   publishAdminImage,
+  createAdminImage,
   uploadAdminImage,
   updateAdminImageMeta,
   registryToAdminPreview,
@@ -40,6 +42,9 @@ export default function AdminPhotos() {
   const [error, setError] = useState<string | null>(null);
   const [category, setCategory] = useState<string>("all");
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [newRole, setNewRole] = useState<string>("gallery");
+  const [newFile, setNewFile] = useState<File | null>(null);
 
   const refreshSession = useCallback(async () => {
     try {
@@ -116,6 +121,33 @@ export default function AdminPhotos() {
     setImages(IMAGE_REGISTRY.map(registryToAdminPreview));
   };
 
+  const handleCreate = async () => {
+    if (!newFile || !newName.trim()) {
+      setError("Nombre y archivo son obligatorios.");
+      return;
+    }
+    setBusyId("create");
+    setError(null);
+    try {
+      const result = await createAdminImage(newFile, {
+        label: newName.trim(),
+        role: newRole,
+        alt: newName.trim(),
+      });
+      await refreshImages(true);
+      setNewName("");
+      setNewFile(null);
+      setNewRole("gallery");
+      if (result.publishError) {
+        setError(`Subida OK. PR no abierto: ${result.publishError}`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error subiendo imagen");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   const handleUpload = async (id: string, file: File) => {
     setBusyId(id);
     setError(null);
@@ -175,10 +207,10 @@ export default function AdminPhotos() {
       <div className="container max-w-6xl mx-auto px-4 py-8 md:py-12 space-y-8">
         <header className="space-y-2">
           <p className="font-mono text-xs uppercase tracking-widest text-primary">Admin privado</p>
-          <h1 className="text-3xl font-bold">Fotos del portafolio</h1>
+          <h1 className="text-3xl font-bold">Fotos del sitio</h1>
           <p className="text-muted-foreground max-w-2xl">
-            Sube a R2. Las de <code className="text-sm">branding/</code> (OG) abren un PR a{" "}
-            <code className="text-sm">public/images/</code> para que Pages las sirva a LinkedIn/Meta.
+            Subí una foto, dale un nombre y elegí si alimenta share, schema, favicon, logo o FAQ.
+            Las de aplicación web abren PR a Pages (crawlers). Galería queda en R2.
           </p>
           <Button asChild variant="outline" className="min-h-[44px] w-fit">
             <Link to={ROUTES.admin}>
@@ -232,6 +264,66 @@ export default function AdminPhotos() {
           </div>
         )}
 
+        {session?.ok ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Subir foto</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="foto-nombre">
+                    Nombre
+                  </label>
+                  <Input
+                    id="foto-nombre"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    placeholder="Ej. Card LinkedIn agosto"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="foto-rol">
+                    Aplicación en la web
+                  </label>
+                  <select
+                    id="foto-rol"
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={newRole}
+                    onChange={(e) => setNewRole(e.target.value)}
+                  >
+                    {IMAGE_WEB_ROLES.map((role) => (
+                      <option key={role.id} value={role.id}>
+                        {role.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground">{roleDef(newRole)?.hint}</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-input px-3 py-2 text-sm">
+                  <Upload className="h-4 w-4" />
+                  {newFile ? newFile.name : "Elegir archivo"}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="sr-only"
+                    onChange={(e) => setNewFile(e.target.files?.[0] ?? null)}
+                  />
+                </label>
+                <Button
+                  type="button"
+                  disabled={busyId === "create" || !newFile || !newName.trim()}
+                  onClick={handleCreate}
+                >
+                  Subir
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+
         <div className="flex flex-wrap gap-2">
           <Button
             size="sm"
@@ -267,6 +359,9 @@ export default function AdminPhotos() {
                   <div>
                     <p className="font-medium text-sm">{image.label}</p>
                     <p className="text-xs text-muted-foreground font-mono">{image.path}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {roleDef(image.role)?.label || "Galería"}
+                    </p>
                   </div>
                   <div className="flex flex-col items-end gap-1">
                     {image.overridden && <Badge>Override</Badge>}
@@ -283,6 +378,36 @@ export default function AdminPhotos() {
                   </div>
                 </div>
 
+                <Input
+                  defaultValue={image.label}
+                  disabled={!session?.ok || busyId === image.id}
+                  onBlur={(e) => {
+                    if (session?.ok && e.target.value !== image.label) {
+                      void updateAdminImageMeta(image.id, { label: e.target.value }).then((updated) => {
+                        setImages((prev) => prev.map((img) => (img.id === image.id ? updated : img)));
+                      });
+                    }
+                  }}
+                  aria-label={`Nombre ${image.label}`}
+                />
+                <select
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 text-xs"
+                  disabled={!session?.ok || busyId === image.id}
+                  defaultValue={image.role || "gallery"}
+                  aria-label={`Aplicación ${image.label}`}
+                  onChange={(e) => {
+                    if (!session?.ok) return;
+                    void updateAdminImageMeta(image.id, { role: e.target.value }).then((updated) => {
+                      setImages((prev) => prev.map((img) => (img.id === image.id ? updated : img)));
+                    });
+                  }}
+                >
+                  {IMAGE_WEB_ROLES.map((role) => (
+                    <option key={role.id} value={role.id}>
+                      {role.label}
+                    </option>
+                  ))}
+                </select>
                 <Input
                   defaultValue={image.alt}
                   disabled={!session?.ok || busyId === image.id}

--- a/worker/src/admin/github-content.js
+++ b/worker/src/admin/github-content.js
@@ -10,15 +10,21 @@ function repoConfig(env) {
 
 export function shouldAutoPublish(entry) {
   const path = entry.path || '';
+  const role = entry.role || '';
   return (
     path.startsWith('branding/') ||
     path.startsWith('og-') ||
-    entry.id === 'branding.ogPortfolio'
+    path.startsWith('favicon') ||
+    path.startsWith('icon-') ||
+    entry.id === 'branding.ogPortfolio' ||
+    ['share_home', 'share_consultoria', 'schema', 'favicon', 'logo', 'apple'].includes(role)
   );
 }
 
 function repoPath(entry) {
+  if (entry.repoPath) return entry.repoPath;
   if (entry.path.startsWith('profile')) return `public/${entry.path}`;
+  if (/^(favicon\.|icon-)/.test(entry.path)) return `public/${entry.path}`;
   return `public/images/${entry.path}`;
 }
 

--- a/worker/src/admin/images.js
+++ b/worker/src/admin/images.js
@@ -1,6 +1,7 @@
 import { json } from '../lib/cors.js';
 import { readSession } from '../lib/session.js';
 import { IMAGE_REGISTRY, REGISTRY_BY_ID } from '../data/image-registry.js';
+import { IMAGE_WEB_ROLES, roleToEntry } from '../data/image-roles.js';
 import { publishImagePr, shouldAutoPublish } from './github-content.js';
 
 const MANIFEST_KEY = 'image:manifest';
@@ -24,16 +25,27 @@ function publicImageUrl(env, key) {
   return `${base.replace(/\/$/, '')}/${key}`;
 }
 
+function staticUrl(env, entry) {
+  const base = (env.STATIC_IMAGE_BASE || 'https://vientonorte.io/').replace(/\/$/, '');
+  if (entry.repoPath || /^(favicon\.|icon-)/.test(entry.path || '')) {
+    return `${base}/${entry.path}`;
+  }
+  if (entry.path?.startsWith('profile')) return `${base}/${entry.path}`;
+  return `${base}/images/${entry.path}`;
+}
+
 function buildImageRecord(entry, manifest, env) {
   const override = manifest[entry.id];
   const overridden = Boolean(override?.url);
   return {
     id: entry.id,
-    url: override?.url || `${(env.STATIC_IMAGE_BASE || 'https://vientonorte.io/mi-portafolio/').replace(/\/$/, '')}/${entry.path.startsWith('profile') ? '' : 'images/'}${entry.path}`,
+    url: override?.url || staticUrl(env, entry),
     alt: override?.alt || entry.alt,
-    path: entry.path,
-    category: entry.category,
-    label: entry.label,
+    path: override?.path || entry.path,
+    category: entry.category || override?.category || 'Subidas',
+    label: override?.label || entry.label,
+    role: override?.role || entry.role || 'gallery',
+    custom: Boolean(entry.custom || override?.custom),
     overridden,
     updatedAt: override?.updatedAt,
     prUrl: override?.prUrl,
@@ -51,25 +63,130 @@ export async function handleListImages(request, env, cors) {
   if (!user) return json({ ok: false, error: 'No autorizado' }, 401, cors);
 
   const manifest = await getManifest(env);
-  const images = IMAGE_REGISTRY.map((entry) => buildImageRecord(entry, manifest, env));
-  return json({ images }, 200, cors);
+  const seen = new Set();
+  const images = IMAGE_REGISTRY.map((entry) => {
+    seen.add(entry.id);
+    return buildImageRecord(entry, manifest, env);
+  });
+  for (const [id, rec] of Object.entries(manifest)) {
+    if (seen.has(id) || !rec || typeof rec !== 'object') continue;
+    if (!rec.custom && !id.startsWith('custom.')) continue;
+    images.push(
+      buildImageRecord(
+        {
+          id,
+          category: rec.category || 'Subidas',
+          label: rec.label || id,
+          path: rec.path || `uploads/${id}`,
+          alt: rec.alt || rec.label || id,
+          role: rec.role || 'gallery',
+          custom: true,
+        },
+        manifest,
+        env
+      )
+    );
+  }
+  return json({ images, roles: IMAGE_WEB_ROLES }, 200, cors);
+}
+
+function extFromType(contentType, filename) {
+  if (filename && /\.[a-z0-9]+$/i.test(filename)) {
+    return filename.split('.').pop().toLowerCase();
+  }
+  if (contentType.includes('jpeg')) return 'jpg';
+  if (contentType.includes('webp')) return 'webp';
+  if (contentType.includes('svg')) return 'svg';
+  if (contentType.includes('ico') || contentType.includes('icon')) return 'ico';
+  return 'png';
+}
+
+function slugName(name) {
+  return String(name || 'foto')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40) || 'foto';
+}
+
+function resolveEntry(imageId, manifest) {
+  if (REGISTRY_BY_ID[imageId]) return REGISTRY_BY_ID[imageId];
+  const rec = manifest[imageId];
+  if (rec && (rec.custom || imageId.startsWith('custom.'))) {
+    return {
+      id: imageId,
+      category: rec.category || 'Subidas',
+      label: rec.label || imageId,
+      path: rec.path,
+      alt: rec.alt,
+      role: rec.role || 'gallery',
+      custom: true,
+    };
+  }
+  return null;
+}
+
+export async function handleCreateImage(request, env, cors) {
+  const user = await readSession(request, env);
+  if (!user) return json({ ok: false, error: 'No autorizado' }, 401, cors);
+
+  const form = await request.formData();
+  const file = form.get('file');
+  const label = typeof form.get('label') === 'string' ? form.get('label').trim() : '';
+  const role = typeof form.get('role') === 'string' ? form.get('role').trim() : 'gallery';
+  const altField = form.get('alt');
+
+  if (!file || typeof file === 'string') {
+    return json({ ok: false, error: 'Archivo requerido' }, 400, cors);
+  }
+  if (!label) {
+    return json({ ok: false, error: 'Nombre requerido' }, 400, cors);
+  }
+
+  const mapped = roleToEntry(role, label);
+  if (mapped) {
+    return persistUpload(env, cors, user, mapped, file, altField, label, role);
+  }
+
+  const contentType = file.type || 'image/png';
+  const ext = extFromType(contentType, file.name);
+  const id = `custom.${Date.now()}`;
+  const entry = {
+    id,
+    category: 'Subidas',
+    label,
+    path: `uploads/${slugName(label)}-${Date.now()}.${ext}`,
+    alt: typeof altField === 'string' && altField.trim() ? altField.trim() : label,
+    role: role === 'faq' ? 'faq' : 'gallery',
+    custom: true,
+  };
+  return persistUpload(env, cors, user, entry, file, altField, label, entry.role);
 }
 
 export async function handleUploadImage(request, env, cors, imageId) {
   const user = await readSession(request, env);
   if (!user) return json({ ok: false, error: 'No autorizado' }, 401, cors);
 
-  const entry = REGISTRY_BY_ID[imageId];
+  const manifest = await getManifest(env);
+  const entry = resolveEntry(imageId, manifest);
   if (!entry) return json({ ok: false, error: 'Imagen no encontrada en catálogo' }, 404, cors);
 
   const form = await request.formData();
   const file = form.get('file');
   const altField = form.get('alt');
+  const label = typeof form.get('label') === 'string' ? form.get('label').trim() : entry.label;
+  const role = typeof form.get('role') === 'string' ? form.get('role').trim() : entry.role;
 
   if (!file || typeof file === 'string') {
     return json({ ok: false, error: 'Archivo requerido' }, 400, cors);
   }
 
+  return persistUpload(env, cors, user, { ...entry, label, role }, file, altField, label, role);
+}
+
+async function persistUpload(env, cors, user, entry, file, altField, label, role) {
   const contentType = file.type || 'image/png';
   if (!contentType.startsWith('image/')) {
     return json({ ok: false, error: 'Solo imágenes' }, 400, cors);
@@ -82,10 +199,14 @@ export async function handleUploadImage(request, env, cors, imageId) {
   });
 
   const manifest = await getManifest(env);
-  manifest[imageId] = {
+  manifest[entry.id] = {
     url: publicImageUrl(env, r2Key),
-    alt: typeof altField === 'string' && altField.trim() ? altField.trim() : entry.alt,
+    alt: typeof altField === 'string' && altField.trim() ? altField.trim() : entry.alt || label,
     path: entry.path,
+    label: label || entry.label,
+    role: role || entry.role || 'gallery',
+    custom: Boolean(entry.custom),
+    category: entry.category,
     updatedAt: new Date().toISOString(),
     updatedBy: user.login,
   };
@@ -95,8 +216,8 @@ export async function handleUploadImage(request, env, cors, imageId) {
   if (shouldAutoPublish(entry)) {
     try {
       publish = await publishImagePr(env, entry, bytes, user.login);
-      manifest[imageId].prUrl = publish.html_url;
-      manifest[imageId].prNumber = publish.number;
+      manifest[entry.id].prUrl = publish.html_url;
+      manifest[entry.id].prNumber = publish.number;
     } catch (err) {
       publishError = err.message || 'No se pudo abrir el PR';
       console.warn('[images] publish PR failed:', publishError);
@@ -112,7 +233,8 @@ export async function handlePublishImage(request, env, cors, imageId) {
   const user = await readSession(request, env);
   if (!user) return json({ ok: false, error: 'No autorizado' }, 401, cors);
 
-  const entry = REGISTRY_BY_ID[imageId];
+  const manifestPeek = await getManifest(env);
+  const entry = resolveEntry(imageId, manifestPeek);
   if (!entry) return json({ ok: false, error: 'Imagen no encontrada' }, 404, cors);
 
   const r2Key = `portfolio/${entry.path}`;
@@ -148,7 +270,8 @@ export async function handlePatchImage(request, env, cors, imageId) {
   const user = await readSession(request, env);
   if (!user) return json({ ok: false, error: 'No autorizado' }, 401, cors);
 
-  const entry = REGISTRY_BY_ID[imageId];
+  const manifest = await getManifest(env);
+  const entry = resolveEntry(imageId, manifest);
   if (!entry) return json({ ok: false, error: 'Imagen no encontrada' }, 404, cors);
 
   let body;
@@ -158,9 +281,10 @@ export async function handlePatchImage(request, env, cors, imageId) {
     return json({ ok: false, error: 'JSON inválido' }, 400, cors);
   }
 
-  const manifest = await getManifest(env);
-  const current = manifest[imageId] || { alt: entry.alt, path: entry.path };
+  const current = manifest[imageId] || { alt: entry.alt, path: entry.path, label: entry.label };
   if (typeof body.alt === 'string') current.alt = body.alt.trim();
+  if (typeof body.label === 'string' && body.label.trim()) current.label = body.label.trim();
+  if (typeof body.role === 'string' && body.role.trim()) current.role = body.role.trim();
   current.updatedAt = new Date().toISOString();
   current.updatedBy = user.login;
   manifest[imageId] = current;
@@ -173,10 +297,10 @@ export async function handleDeleteImage(request, env, cors, imageId) {
   const user = await readSession(request, env);
   if (!user) return json({ ok: false, error: 'No autorizado' }, 401, cors);
 
-  const entry = REGISTRY_BY_ID[imageId];
+  const manifest = await getManifest(env);
+  const entry = resolveEntry(imageId, manifest);
   if (!entry) return json({ ok: false, error: 'Imagen no encontrada' }, 404, cors);
 
-  const manifest = await getManifest(env);
   const override = manifest[imageId];
   if (override) {
     const r2Key = `portfolio/${entry.path}`;

--- a/worker/src/data/image-registry.js
+++ b/worker/src/data/image-registry.js
@@ -1,7 +1,13 @@
 /** Catálogo espejo de src/data/image-registry.ts */
 export const IMAGE_REGISTRY = [
-  { id: 'branding.profilePhoto', category: 'Branding', label: 'Foto de perfil', path: 'profile-photo.jpg', alt: 'Rodrigo Gaete — Lead UX Designer' },
-  { id: 'branding.ogPortfolio', category: 'Branding', label: 'OG / PWA', path: 'branding/og-portfolio.png', alt: 'Portfolio Rodrigo Gaete' },
+  { id: 'branding.profilePhoto', category: 'Branding', label: 'Foto de perfil', path: 'profile-photo.jpg', alt: 'Rodrigo Gaete — Lead UX Designer', role: 'gallery' },
+  { id: 'branding.ogHome', category: 'Branding', label: 'Share redes · home', path: 'branding/og-home-1200.png', alt: 'Viento Norte — share home', role: 'share_home' },
+  { id: 'branding.ogConsultoria', category: 'Branding', label: 'Share redes · consultoría', path: 'branding/og-consultoria-1200.png', alt: 'Viento Norte — share consultoría', role: 'share_consultoria' },
+  { id: 'branding.ogPortfolio', category: 'Branding', label: 'OG / PWA (legacy)', path: 'branding/og-portfolio.png', alt: 'Viento Norte share', role: 'share_home' },
+  { id: 'branding.isologo', category: 'Branding', label: 'Logo / isologo', path: 'branding/isologo-512.png', alt: 'Isologo Viento Norte', role: 'logo' },
+  { id: 'branding.favicon', category: 'Branding', label: 'Favicon', path: 'favicon.ico', repoPath: 'public/favicon.ico', alt: 'Favicon Viento Norte', role: 'favicon' },
+  { id: 'branding.schemaLogo', category: 'Branding', label: 'Schema.org logo', path: 'icon-512x512.png', repoPath: 'public/icon-512x512.png', alt: 'Logo schema Viento Norte', role: 'schema' },
+  { id: 'branding.appleTouch', category: 'Branding', label: 'Apple / PWA', path: 'icon-192x192.png', repoPath: 'public/icon-192x192.png', alt: 'Apple touch Viento Norte', role: 'apple' },
   { id: 'sura.riaOnboarding', category: 'SURA', label: 'RIA onboarding', path: 'sura/ria-onboarding.png', alt: 'Onboarding RIA SURA US' },
   { id: 'sura.webPrototype', category: 'SURA', label: 'Prototipo web', path: 'sura/web-prototype.png', alt: 'Prototipo web SURA' },
   { id: 'sura.benchmarkNavigation', category: 'SURA', label: 'Benchmark navegación', path: 'sura/benchmark-navigation.png', alt: 'Benchmark de navegación' },

--- a/worker/src/data/image-roles.js
+++ b/worker/src/data/image-roles.js
@@ -1,0 +1,87 @@
+/** Espejo de src/data/image-roles.ts */
+
+export const IMAGE_WEB_ROLES = [
+  {
+    id: 'share_home',
+    label: 'Share redes · home',
+    hint: 'LinkedIn / Meta al pegar vientonorte.io. 1200×630.',
+    slotId: 'branding.ogHome',
+    path: 'branding/og-home-1200.png',
+    category: 'Branding',
+    alt: 'Viento Norte — share home',
+  },
+  {
+    id: 'share_consultoria',
+    label: 'Share redes · consultoría',
+    hint: 'Card /s/consultoria. 1200×630.',
+    slotId: 'branding.ogConsultoria',
+    path: 'branding/og-consultoria-1200.png',
+    category: 'Branding',
+    alt: 'Viento Norte — share consultoría',
+  },
+  {
+    id: 'schema',
+    label: 'Schema.org (logo)',
+    hint: 'JSON-LD Organization.logo. Cuadrado ≥512.',
+    slotId: 'branding.schemaLogo',
+    path: 'icon-512x512.png',
+    repoPath: 'public/icon-512x512.png',
+    category: 'Branding',
+    alt: 'Viento Norte — logo schema',
+  },
+  {
+    id: 'favicon',
+    label: 'Favicon',
+    hint: 'Pestaña. ICO o PNG.',
+    slotId: 'branding.favicon',
+    path: 'favicon.ico',
+    repoPath: 'public/favicon.ico',
+    category: 'Branding',
+    alt: 'Favicon Viento Norte',
+  },
+  {
+    id: 'logo',
+    label: 'Logo / isologo',
+    hint: 'Toolbar. PNG cuadrado.',
+    slotId: 'branding.isologo',
+    path: 'branding/isologo-512.png',
+    category: 'Branding',
+    alt: 'Isologo Viento Norte',
+  },
+  {
+    id: 'apple',
+    label: 'Apple / PWA',
+    hint: 'icon-192.',
+    slotId: 'branding.appleTouch',
+    path: 'icon-192x192.png',
+    repoPath: 'public/icon-192x192.png',
+    category: 'Branding',
+    alt: 'Apple touch Viento Norte',
+  },
+  {
+    id: 'faq',
+    label: 'FAQ / ayuda',
+    hint: 'Sin cable HTML automático.',
+  },
+  {
+    id: 'gallery',
+    label: 'Galería (sin cable)',
+    hint: 'Solo R2 + CMS.',
+  },
+];
+
+export const ROLE_BY_ID = Object.fromEntries(IMAGE_WEB_ROLES.map((r) => [r.id, r]));
+
+export function roleToEntry(roleId, label) {
+  const role = ROLE_BY_ID[roleId];
+  if (!role?.slotId) return null;
+  return {
+    id: role.slotId,
+    category: role.category || 'Branding',
+    label: label || role.label,
+    path: role.path,
+    repoPath: role.repoPath,
+    alt: role.alt || label || role.label,
+    role: role.id,
+  };
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -13,6 +13,7 @@ import {
 import {
   handlePublicManifest,
   handleListImages,
+  handleCreateImage,
   handleUploadImage,
   handlePatchImage,
   handleDeleteImage,
@@ -166,6 +167,9 @@ export default {
     // ── Imágenes admin ──
     if (path === '/api/admin/images' && request.method === 'GET') {
       return handleListImages(request, env, cors);
+    }
+    if (path === '/api/admin/images' && request.method === 'POST') {
+      return handleCreateImage(request, env, cors);
     }
 
     const publishMatch = path.match(/^\/api\/admin\/images\/([^/]+)\/publish$/);


### PR DESCRIPTION
## Qué
En \`#/admin/fotos\` podés **subir cualquier foto**, ponerle **nombre** y elegir **aplicación en la web**:

- Share redes · home / consultoría (1200×630 → Pages)
- Schema.org logo
- Favicon
- Logo / isologo
- Apple / PWA
- FAQ / galería (R2, sin cable HTML)

## API
\`POST /api/admin/images\` (file + label + role). PATCH acepta label y role.

## Deploy
Worker hay que desplegar (\`wrangler deploy --keep-vars\`) para que el POST exista live. Pages al mergear el PR.