### PR TITLE
feat(consultoria): Calendar único + mail con motivo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-13] — Landing: Calendar único + contacto por mail
+
+### Changed
+- Hero y sticky: **un** CTA de Google Calendar.
+- Alcance (packs) y contacto: mail con motivo (diagnóstico / prototipo / proceso / ayuda / simple).
+- Fuera del landing: onboarding, N2N, edu y demos (viven en `/proceso`, `/proyectos`, `/#/consultoria`).
+
 ## [2026-08-13] — Admin fotos: nombre + aplicación web
 
 ### Added

--- a/scripts/qa-routes.mjs
+++ b/scripts/qa-routes.mjs
@@ -52,10 +52,7 @@ const PROJECT_IDS = [
 const SECTION_CHECKS = [
   { path: '/', sectionId: 'inicio', label: 'Home embudo #inicio' },
   { path: '/', sectionId: 'modalidades', label: 'Home embudo #modalidades' },
-  { path: '/', sectionId: 'consultoria-onboarding', label: 'Home embudo #onboarding' },
-  { path: '/', sectionId: 'metodo-n2n', label: 'Home embudo #metodo-n2n' },
-  { path: '/', sectionId: 'partner-educacion', label: 'Home embudo #partner-educacion' },
-  { path: '/', sectionId: 'consultoria-demo', label: 'Home embudo #consultoria-demo' },
+  { path: '/', sectionId: 'mas-del-sitio', label: 'Home embudo #mas-del-sitio' },
   { path: '/', sectionId: 'contacto', label: 'Home embudo #contacto' },
   { path: '/design-system', sectionId: 'figma-export', label: 'Design System #figma-export' },
 ];

--- a/src/__tests__/lib/nav-config.test.ts
+++ b/src/__tests__/lib/nav-config.test.ts
@@ -102,12 +102,9 @@ describe("getDockNavAction", () => {
     });
   });
 
-  it("funnel (home): liquid center scrolls to kickoff; inicio/contacto anchors", () => {
-    expect(getDockNavAction("consultoria", "funnel")).toEqual({
-      kind: "anchor",
-      target: "#consultoria-onboarding",
-      homeRoute: "/",
-    });
+  it("funnel (home): liquid center is Calendar or #contacto; inicio/contacto anchors", () => {
+    const center = getDockNavAction("consultoria", "funnel");
+    expect(center.kind === "external" || center.target === "#contacto").toBe(true);
     expect(getDockNavAction("inicio", "funnel")).toEqual({
       kind: "anchor",
       target: "#inicio",
@@ -128,14 +125,11 @@ describe("getDockNavItems", () => {
     expect(ids[1]).toBe(DOCK_CENTER_ID);
   });
 
-  it("funnel dock keeps 3 slots with kickoff action on center", () => {
+  it("funnel dock keeps 3 slots with Calendar or contact on center", () => {
     const items = getDockNavItems("funnel", labels, "Proceso");
     expect(items.map((i) => i.id)).toEqual(["inicio", "consultoria", "contacto"]);
-    expect(items[1]!.action).toEqual({
-      kind: "anchor",
-      target: "#consultoria-onboarding",
-      homeRoute: "/",
-    });
+    const center = items[1]!.action;
+    expect(center.kind === "external" || center.target === "#contacto").toBe(true);
   });
 });
 

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -3,46 +3,30 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
-import { useNavigate } from "react-router-dom";
 import { trackEvent } from "../../lib/analytics";
-import {
-  freeRadarHasSchedule,
-  openFreeRadarEntry,
-} from "../../lib/free-radar-entry";
-import { cn } from "../../lib/utils";
-import type { ConsultingPackageId } from "../../data/vientonorte-consulting";
+import { openCalendarBooking } from "../../lib/site-contact";
 import { scrollToSection } from "../../lib/scroll-to-section";
 
 interface ConsultoriaLandingHeroProps {
-  onStartOnboarding?: (
-    packageId?: ConsultingPackageId,
-    options?: { c1Goal?: boolean; appGoal?: boolean }
-  ) => void;
   onExploreEvidence?: () => void;
 }
 
 /**
- * Hero consultoría — mínimo conversion:
- * Empezar · Ver opciones · link free sutil.
- * Sin grilla de 4 ofertas (duplicaba #modalidades).
- *
- * Decider 2026-08-03 (DS Map · no re-Map):
- * - Empezar → onboarding en la **misma superficie** (home o SEM), nunca “saltar” a SEM desde home.
- * - SEM `/#/consultoria` es solo **entrada paid**; home SEO convierte in-place.
- * - Rechazado: “¿tour módulos fullscreen convierte más que embudo home?”
+ * Hero FO: un solo CTA = Google Calendar.
+ * Alcance y mail viven más abajo; método/casos en páginas interiores.
  */
 export function ConsultoriaLandingHero({
-  onStartOnboarding,
   onExploreEvidence,
 }: ConsultoriaLandingHeroProps) {
-  const navigate = useNavigate();
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.landing;
   const es = language === "es";
 
-  const startPrimary = () => {
-    trackEvent("consultoria_hero_cta", { action: "primary_onboarding" });
-    onStartOnboarding?.();
+  const bookCalendar = () => {
+    trackEvent("consultoria_hero_cta", { action: "calendar_booking" });
+    if (!openCalendarBooking()) {
+      scrollToSection("contacto");
+    }
   };
 
   const seeOptions = () => {
@@ -52,16 +36,6 @@ export function ConsultoriaLandingHero({
       return;
     }
     scrollToSection("modalidades");
-  };
-
-  const freeRadar = () => {
-    trackEvent("consultoria_hero_cta", {
-      action: "free_radar_entry",
-      has_schedule: freeRadarHasSchedule(),
-    });
-    openFreeRadarEntry(navigate, language, "consultoria-hero", {
-      mode: freeRadarHasSchedule() ? "schedule" : "auto",
-    });
   };
 
   return (
@@ -91,41 +65,23 @@ export function ConsultoriaLandingHero({
             {t.description}
           </p>
 
-          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+          <div className="flex flex-col items-center justify-center gap-3">
             <Button
               size="lg"
               className="funnel-cta-primary min-h-[48px] bg-brand-gradient px-8 font-semibold hover:opacity-90 focus-visible:ring-offset-2"
-              onClick={startPrimary}
+              onClick={bookCalendar}
             >
               {t.ctaPrimary}
               <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
             </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              className="funnel-cta-ghost min-h-[48px] border-primary/30 bg-background/80 font-semibold hover:border-primary/50"
-              onClick={seeOptions}
-            >
-              {t.ctaSecondary}
-            </Button>
-          </div>
-
-          <p className="text-sm text-muted-foreground">
             <button
               type="button"
-              onClick={freeRadar}
-              className={cn(
-                "funnel-link underline-offset-4 hover:text-foreground hover:underline",
-                "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-                freeRadarHasSchedule() &&
-                  "font-medium text-primary underline decoration-primary/40"
-              )}
+              onClick={seeOptions}
+              className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
             >
-              {freeRadarHasSchedule()
-                ? t.ctaFreeLinkSchedule ?? t.ctaFreeLink
-                : t.ctaFreeLink}
+              {t.ctaSecondary}
             </button>
-          </p>
+          </div>
 
           <ul
             className="flex flex-wrap items-center justify-center gap-2"

--- a/src/components/organisms/ConsultoriaPackages.tsx
+++ b/src/components/organisms/ConsultoriaPackages.tsx
@@ -1,5 +1,4 @@
-import { ArrowRight, Clock, Gift, Package, Smartphone, Star } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { ArrowRight, Clock, Package, Smartphone, Star } from "lucide-react";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { Badge } from "../ui/badge";
@@ -12,10 +11,6 @@ import {
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { trackEvent } from "../../lib/analytics";
-import {
-  freeRadarHasSchedule,
-  openFreeRadarEntry,
-} from "../../lib/free-radar-entry";
 import { cn } from "../../lib/utils";
 
 export type PackageSelectOptions = { appGoal?: boolean };
@@ -28,7 +23,6 @@ interface ConsultoriaPackagesProps {
 }
 
 export function ConsultoriaPackages({ onSelectPackage }: ConsultoriaPackagesProps) {
-  const navigate = useNavigate();
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.packagesSection;
   const rec = useTranslation(language).consultoria.recommended;
@@ -40,17 +34,6 @@ export function ConsultoriaPackages({ onSelectPackage }: ConsultoriaPackagesProp
     });
     onSelectPackage?.(id, options);
   };
-
-  const freeRadar = (mode: "auto" | "schedule" | "message" = "auto") => {
-    trackEvent("consultoria_free_radar", {
-      source: "packages_strip",
-      mode,
-      has_schedule: freeRadarHasSchedule(),
-    });
-    openFreeRadarEntry(navigate, language, "consultoria-packages", { mode });
-  };
-
-  const scheduleReady = freeRadarHasSchedule();
 
   return (
     <PageSection
@@ -148,60 +131,7 @@ export function ConsultoriaPackages({ onSelectPackage }: ConsultoriaPackagesProp
         ))}
       </ul>
 
-      {/* Entrada gratis Radar — copy público (SEM es interno, no en UI) */}
-      <Card className="mt-5 border-2 border-primary/35 bg-primary/5 shadow-none">
-        <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex gap-3 min-w-0">
-            <span
-              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-brand-gradient text-white"
-              aria-hidden
-            >
-              <Gift className="h-5 w-5" />
-            </span>
-            <div className="min-w-0 space-y-1">
-              <Badge
-                variant="outline"
-                className="border-primary/30 font-normal normal-case tracking-normal"
-              >
-                {t.freeStripBadge}
-              </Badge>
-              <p className="text-base font-semibold tracking-tight">
-                {t.freeStripTitle}
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {t.freeStripBody}
-              </p>
-            </div>
-          </div>
-          <div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto">
-            <Button
-              className="funnel-cta-primary w-full min-h-[44px] bg-brand-gradient font-semibold hover:opacity-90"
-              onClick={() => freeRadar(scheduleReady ? "schedule" : "auto")}
-            >
-              {scheduleReady ? t.freeStripCtaSchedule : t.freeStripCta}
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-            </Button>
-            {scheduleReady ? (
-              <Button
-                variant="outline"
-                className="w-full min-h-[40px]"
-                onClick={() => freeRadar("message")}
-              >
-                {t.freeStripCtaMessage}
-              </Button>
-            ) : null}
-            <Button
-              variant="ghost"
-              className="w-full min-h-[40px] text-muted-foreground"
-              onClick={() => select("radar")}
-            >
-              {t.freeStripSecondary}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* App punta a punta — un interlocutor, no “red” en vitrina */}
+      {/* Herramientas: escribe, no agenda (Calendar es único en el hero) */}
       <Card className="mt-3 border border-primary/20 bg-surface-matte-elevated shadow-none">
         <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex gap-3 min-w-0">

--- a/src/components/organisms/Contact.tsx
+++ b/src/components/organisms/Contact.tsx
@@ -14,7 +14,10 @@ import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { ContactAssistant } from "./ContactAssistant";
 import { SITE_CONTACT, getContactMailtoUrl } from "../../lib/site-contact";
-import { FreeA11yScheduleCta } from "../molecules/FreeA11yScheduleCta";
+import {
+  consultingMotiveMessage,
+  type ContactMotive,
+} from "../../lib/consulting-contact-motive";
 import { submitContactMessage } from "../../lib/submit-contact";
 import { analytics } from "../../lib/analytics";
 import { useLanguage } from "../../lib/LanguageContext";
@@ -64,7 +67,10 @@ export function Contact({
 
   const sessionSnapshot = readContactSession();
   const [activeTab, setActiveTab] = useState<ContactTab>(() =>
-    effectiveDraft ? "assistant" : (sessionSnapshot?.activeTab ?? "assistant")
+    isConsulting ? "form" : effectiveDraft ? "assistant" : (sessionSnapshot?.activeTab ?? "assistant")
+  );
+  const [motive, setMotive] = useState<ContactMotive>(
+    () => (effectiveDraft?.packageId as ContactMotive) || "simple"
   );
   const [sharedIdentity, setSharedIdentity] = useState<ContactSharedIdentity>(() => ({
     name: sessionSnapshot?.name ?? "",
@@ -138,7 +144,7 @@ export function Contact({
         message: sharedMessage,
         _gotcha: gotcha,
         source: "form",
-        intent: effectiveDraft?.intent,
+        intent: effectiveDraft?.intent ?? motive,
         conversationTitle: effectiveDraft?.conversationTitle,
         consent: sharedIdentity.consent,
         language,
@@ -230,13 +236,33 @@ export function Contact({
           </Badge>
         </div>
 
-        {/* Agenda Google free a11y — visible en contacto (no solo toast post-envío) */}
-        <div className="mx-auto mb-8 max-w-3xl">
-          <FreeA11yScheduleCta
-            origin={isConsulting ? "consultoria-contact" : "contact"}
-            layout="card"
-          />
-        </div>
+        {isConsulting ? (
+          <div className="mx-auto mb-8 flex max-w-3xl flex-wrap justify-center gap-2">
+            {(
+              [
+                ["radar", language === "es" ? "Diagnóstico" : "Diagnostic"],
+                ["marco", language === "es" ? "Prototipo" : "Prototype"],
+                ["ops", language === "es" ? "Proceso" : "Process"],
+                ["help", language === "es" ? "Necesito ayuda" : "I need help"],
+                ["simple", language === "es" ? "Contacto simple" : "Simple note"],
+              ] as const
+            ).map(([id, label]) => (
+              <Button
+                key={id}
+                type="button"
+                size="sm"
+                variant={motive === id ? "default" : "outline"}
+                onClick={() => {
+                  setMotive(id);
+                  setSharedMessage(consultingMotiveMessage(id, language));
+                  setActiveTab("form");
+                }}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+        ) : null}
 
         <div className="grid lg:grid-cols-3 gap-6 md:gap-8">
           <div className="space-y-4 md:space-y-6">

--- a/src/lib/consulting-contact-motive.ts
+++ b/src/lib/consulting-contact-motive.ts
@@ -1,0 +1,33 @@
+import type { ConsultingPackageId } from "../data/vientonorte-consulting";
+
+export type ContactMotive = ConsultingPackageId | "help" | "simple";
+
+const MOTIVE_COPY: Record<ContactMotive, { es: string; en: string }> = {
+  radar: {
+    es: "Motivo: Diagnóstico (heurístico a medida).\n\n",
+    en: "Reason: Diagnostic (custom heuristic).\n\n",
+  },
+  marco: {
+    es: "Motivo: Prototipo / pantallas listas para construir.\n\n",
+    en: "Reason: Prototype / screens ready to build.\n\n",
+  },
+  ops: {
+    es: "Motivo: Proceso de equipo / Design Ops.\n\n",
+    en: "Reason: Team process / Design Ops.\n\n",
+  },
+  help: {
+    es: "Motivo: necesito ayuda para elegir alcance.\n\n",
+    en: "Reason: I need help choosing scope.\n\n",
+  },
+  simple: {
+    es: "Motivo: contacto simple.\n\n",
+    en: "Reason: simple contact.\n\n",
+  },
+};
+
+export function consultingMotiveMessage(
+  motive: ContactMotive,
+  language: "es" | "en"
+): string {
+  return MOTIVE_COPY[motive][language];
+}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -239,7 +239,7 @@ export default {
       recommended: 'Recommended',
       back: 'Back',
       next: 'Continue',
-      stickyCta: 'Start',
+      stickyCta: 'Book a slot',
       entry: {
         selectedPackage: 'Selected format:',
         changePackage: 'Change',
@@ -253,8 +253,8 @@ export default {
           'Diagnostic, prototype, team process, or working app.',
         transparencyLine:
           'Free Diagnostic entry: WCAG 2.2 AA review of one critical flow. If it fits, let’s talk full Diagnostic (5–7 days).',
-        ctaPrimary: 'Start',
-        ctaSecondary: 'See options',
+        ctaPrimary: 'Book on Google Calendar',
+        ctaSecondary: 'See scopes',
         /** Lead magnet — regulated-product job language, not WCAG jargon in the link */
         ctaFreeLink: 'Free review of one critical flow',
         ctaFreeLinkSchedule: 'Book 30 free minutes on Google Calendar',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -239,7 +239,7 @@ export default {
       recommended: 'Recomendada',
       back: 'Atrás',
       next: 'Continuar',
-      stickyCta: 'Empezar',
+      stickyCta: 'Agendar',
       entry: {
         selectedPackage: 'Modalidad elegida:',
         changePackage: 'Cambiar',
@@ -253,8 +253,8 @@ export default {
           'Diagnóstico, prototipo, proceso de equipo o app funcional.',
         transparencyLine:
           'Entrada gratis a Diagnóstico: revisión WCAG 2.2 AA de un flujo crítico. Si aplica, conversemos el Diagnóstico completo (5–7 días).',
-        ctaPrimary: 'Empezar',
-        ctaSecondary: 'Ver opciones',
+        ctaPrimary: 'Agendar en Google Calendar',
+        ctaSecondary: 'Ver alcances',
         /** Free a11y — con agenda: copy de Calendar; sin agenda: mensaje */
         ctaFreeLink: 'Revisión gratis de un flujo crítico',
         ctaFreeLinkSchedule: 'Reservar 30 min gratis en Google Calendar',

--- a/src/lib/nav-config.ts
+++ b/src/lib/nav-config.ts
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import type { NavigateFunction } from "react-router-dom";
 import { ROUTES, isConsultingOfferPath, isProcessPath } from "./routes";
+import { A11Y_FREE_SCHEDULE_URL } from "./site-contact";
 import { VIENTO_NORTE_LINKS } from "./viento-norte-links";
 import { navigateToPageSection } from "./navigate-to-section";
 import { scrollToSection } from "./scroll-to-section";
@@ -168,11 +169,14 @@ export function getDockNavAction(id: DockNavItemId, variant: DockVariant): NavAc
     }
     return { kind: "contact", target: ROUTES.contact };
   }
-  // Embudo (home): liquid CTA = kickoff — no SEM tour
+  // Embudo (home): liquid CTA = Calendar (único agendamiento)
   if (id === "consultoria" && variant === "funnel") {
+    if (A11Y_FREE_SCHEDULE_URL) {
+      return { kind: "external", target: A11Y_FREE_SCHEDULE_URL };
+    }
     return {
       kind: "anchor",
-      target: `#${CONSULTORIA_FUNNEL_KICKOFF_ID}`,
+      target: "#contacto",
       homeRoute: ROUTES.home,
     };
   }

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -57,6 +57,13 @@ export function openA11yFreeScheduleOrFallback(fallback: () => void): boolean {
   return false;
 }
 
+/** CTA único de agendamiento (Google Appointment). */
+export function openCalendarBooking(): boolean {
+  if (!A11Y_FREE_SCHEDULE_URL) return false;
+  window.open(A11Y_FREE_SCHEDULE_URL, "_blank", "noopener,noreferrer");
+  return true;
+}
+
 /**
  * Relay Cloudflare Worker — POST formulario de contacto.
  * Canónico: contact.vientonorte.io · fallback workers.dev si DNS aún no propagó.

--- a/src/pages/ConsultoriaVientoNorte.tsx
+++ b/src/pages/ConsultoriaVientoNorte.tsx
@@ -1,24 +1,18 @@
 import { useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { SEOHead } from "../components/atoms/SEOHead";
 import { PageShell } from "../components/layout/PageShell";
 import { ConsultoriaLandingHero } from "../components/organisms/ConsultoriaLandingHero";
-import { ConsultoriaN2NMethod } from "../components/organisms/ConsultoriaN2NMethod";
 import { ConsultoriaPackages } from "../components/organisms/ConsultoriaPackages";
-import { ConsultoriaEducationPartner } from "../components/organisms/ConsultoriaEducationPartner";
-import { ConsultoriaDemoShowcase } from "../components/organisms/ConsultoriaDemoShowcase";
-import { ConsultoriaOnboarding } from "../components/organisms/ConsultoriaOnboarding";
 import { Contact } from "../components/organisms/Contact";
 import { ProcessNavigation } from "../components/molecules/ProcessNavigation";
 import { StickyCTA } from "../components/molecules/StickyCTA";
-import {
-  PARTNER_EDU_CONTACT_GOAL,
-  type ConsultingPackageId,
-} from "../data/vientonorte-consulting";
-import { APP_ONBOARDING_GOAL, C1_ONBOARDING_GOAL } from "../data/n2n-method";
+import { type ConsultingPackageId } from "../data/vientonorte-consulting";
+import { openCalendarBooking } from "../lib/site-contact";
+import { consultingMotiveMessage } from "../lib/consulting-contact-motive";
 import { useLanguage } from "../lib/LanguageContext";
 import { useTranslation } from "../lib/i18n";
-import { CONSULTORIA_FUNNEL_KICKOFF_ID } from "../lib/nav-config";
+import { type ContactDraft } from "../lib/contact-draft";
 import { ROUTES } from "../lib/routes";
 import { canonicalFromPath } from "../lib/seo";
 import { withHomeCrumb } from "../lib/breadcrumb-helpers";
@@ -32,11 +26,7 @@ import type { ProcessNavSection } from "../hooks/useProcessSectionSpy";
 
 type ConsultoriaLocationState = SectionScrollState & {
   recommendedPackage?: ConsultingPackageId;
-  c1Goal?: boolean;
-  appGoal?: boolean;
 };
-
-type EntryGoalKind = "c1" | "education" | "app" | null;
 
 export default function ConsultoriaVientoNorte() {
   const navigate = useNavigate();
@@ -49,114 +39,46 @@ export default function ConsultoriaVientoNorte() {
   const [selectedPackage, setSelectedPackage] = useState<
     ConsultingPackageId | undefined
   >(() => entryState?.recommendedPackage);
-  const [packageLocked, setPackageLocked] = useState(
-    () => Boolean(entryState?.recommendedPackage)
-  );
-  const [goalKind, setGoalKind] = useState<EntryGoalKind>(() => {
-    if (entryState?.appGoal) return "app";
-    if (entryState?.c1Goal) return "c1";
-    return null;
-  });
-  const [entryNonce, setEntryNonce] = useState(0);
-
-  const locationState = location.state as ConsultoriaLocationState | null;
-  const recommendedPackage =
-    selectedPackage ?? locationState?.recommendedPackage;
-
-  const initialGoal =
-    goalKind === "c1"
-      ? C1_ONBOARDING_GOAL[language]
-      : goalKind === "education"
-        ? PARTNER_EDU_CONTACT_GOAL[language]
-        : goalKind === "app"
-          ? APP_ONBOARDING_GOAL[language]
-          : undefined;
-
-  const initialIndustry =
-    goalKind === "education"
-      ? language === "es"
-        ? "Educación"
-        : "Education"
-      : undefined;
 
   useEffect(() => {
     const state = location.state as ConsultoriaLocationState | null;
     const scrollTo =
       state?.scrollTo ?? consumePendingSectionScroll(location.pathname);
-
-    // One-shot scroll entry; package is seeded via useState from location.state
     if (!scrollTo) return;
-
     runPendingSectionScroll(scrollTo);
     navigate(location.pathname, {
       replace: true,
-      state: {
-        ...(state?.recommendedPackage
-          ? { recommendedPackage: state.recommendedPackage }
-          : {}),
-        ...(state?.c1Goal ? { c1Goal: true } : {}),
-        ...(state?.appGoal ? { appGoal: true } : {}),
-      },
+      state: state?.recommendedPackage
+        ? { recommendedPackage: state.recommendedPackage }
+        : {},
     });
   }, [location.pathname, location.state, navigate]);
 
-  /**
-   * Entra al onboarding sin pasos de más:
-   * - packageId → salta welcome + re-elección de modalidad
-   * - c1Goal / appGoal / education → goal e industria prearmados
-   */
-  const scrollToOnboarding = (
-    packageId?: ConsultingPackageId,
-    options?: { c1Goal?: boolean; education?: boolean; appGoal?: boolean }
-  ) => {
-    if (packageId) {
-      setSelectedPackage(packageId);
-      setPackageLocked(true);
-    } else {
-      setPackageLocked(false);
-    }
-
-    if (options?.education) setGoalKind("education");
-    else if (options?.appGoal) setGoalKind("app");
-    else if (options?.c1Goal) setGoalKind("c1");
-    else if (packageId) setGoalKind(null);
-    // sticky sin package: limpia goal forzado
-    else setGoalKind(null);
-
-    setEntryNonce((n) => n + 1);
-
-    requestAnimationFrame(() => {
-      scrollToSection(CONSULTORIA_FUNNEL_KICKOFF_ID);
-    });
+  const goContactWithPackage = (packageId?: ConsultingPackageId) => {
+    if (packageId) setSelectedPackage(packageId);
+    requestAnimationFrame(() => scrollToSection("contacto"));
   };
 
-  /** Hero secondary CTA → modalidades (Radar · Marco · Ops). */
-  const scrollToModalidades = () => {
-    scrollToSection("modalidades");
-  };
+  const contactDraft = useMemo<ContactDraft>(
+    () => ({
+      message: selectedPackage
+        ? consultingMotiveMessage(selectedPackage, language)
+        : "",
+      source: "cta",
+      intent: "consulting",
+      packageId: selectedPackage,
+    }),
+    [language, selectedPackage]
+  );
 
   const funnelNav = t.consultoria.landing.nav;
 
-  /** Embudo: ofertas → kickoff → método → prueba → contacto. */
   const funnelSections: ProcessNavSection[] = useMemo(
     () => [
       { id: "modalidades", label: funnelNav.packages, number: "01" },
-      {
-        id: CONSULTORIA_FUNNEL_KICKOFF_ID,
-        label: funnelNav.start,
-        number: "02",
-      },
-      { id: "metodo-n2n", label: funnelNav.n2n, number: "03" },
-      { id: "consultoria-demo", label: funnelNav.evidence, number: "04" },
-      { id: "contacto", label: funnelNav.contact, number: "05" },
+      { id: "contacto", label: funnelNav.contact, number: "02" },
     ],
-    [
-      funnelNav.contact,
-      funnelNav.evidence,
-      funnelNav.n2n,
-      funnelNav.packages,
-      funnelNav.start,
-    ]
+    [funnelNav.contact, funnelNav.packages]
   );
 
   const isHomeSurface =
@@ -213,50 +135,47 @@ export default function ConsultoriaVientoNorte() {
           Sin calculadora ni árbol (duplicaban la decisión del hero).
         */}
         <ConsultoriaLandingHero
-          onStartOnboarding={(packageId, options) =>
-            scrollToOnboarding(packageId, options)
-          }
-          onExploreEvidence={scrollToModalidades}
+          onExploreEvidence={() => scrollToSection("modalidades")}
         />
 
         <ConsultoriaPackages
-          onSelectPackage={(id, options) =>
-            scrollToOnboarding(id, { appGoal: options?.appGoal })
-          }
+          onSelectPackage={(id) => goContactWithPackage(id)}
         />
 
-        <div
-          id={CONSULTORIA_FUNNEL_KICKOFF_ID}
-          className="scroll-mt-[calc(var(--header-height)+0.75rem)]"
+        <section
+          id="mas-del-sitio"
+          className="container mx-auto max-w-2xl px-4 py-8 text-center"
         >
-          <ConsultoriaOnboarding
-            key={`onboarding-${entryNonce}-${recommendedPackage ?? "none"}-${goalKind ?? "x"}`}
-            initialPackageId={recommendedPackage}
-            initialGoal={initialGoal}
-            initialIndustry={initialIndustry}
-            packageLocked={packageLocked && Boolean(recommendedPackage)}
-          />
-        </div>
+          <p className="mb-3 text-sm text-muted-foreground">
+            {language === "es"
+              ? "Método, casos y oferta completa están en páginas interiores."
+              : "Method, cases, and the full offer live on interior pages."}
+          </p>
+          <div className="flex flex-wrap justify-center gap-3 text-sm">
+            <Link className="underline-offset-4 hover:underline" to={ROUTES.process}>
+              {language === "es" ? "Proceso" : "Process"}
+            </Link>
+            <Link className="underline-offset-4 hover:underline" to={ROUTES.projects}>
+              {language === "es" ? "Proyectos" : "Projects"}
+            </Link>
+            <Link className="underline-offset-4 hover:underline" to={ROUTES.consulting}>
+              {language === "es" ? "Oferta / tour" : "Offer / tour"}
+            </Link>
+          </div>
+        </section>
 
-        <ConsultoriaN2NMethod
-          onStartOnboarding={() => scrollToOnboarding("marco")}
+        <Contact
+          key={selectedPackage ?? "none"}
+          surface="consulting"
+          contactDraft={contactDraft}
         />
-
-        <ConsultoriaEducationPartner
-          onStartOnboarding={() =>
-            scrollToOnboarding("marco", { education: true })
-          }
-        />
-
-        <ConsultoriaDemoShowcase />
-
-        {/* Cierre embudo: Contact en modo consultoría (intent fijo, sin laboral/freelance) */}
-        <Contact surface="consulting" />
 
         <StickyCTA
           label={t.consultoria.stickyCta}
           ariaLabel={t.consultoria.stickyCta}
-          onClick={() => scrollToOnboarding()}
+          onClick={() => {
+            if (!openCalendarBooking()) scrollToSection("contacto");
+          }}
           showAfterScroll={480}
         />
       </div>


### PR DESCRIPTION
## Storyboard
1. **CTA único** hero + sticky + dock centro → Google Appointment.
2. **Alcance / bot / form** → mail con motivo (pack elegido, ayuda o contacto simple).
3. **Ruido** (método, casos, tour, onboarding) → páginas interiores ya usadas: \`/proceso\`, \`/proyectos\`, \`/#/consultoria\`.

## No
Ads, GTM, merge de PRs previos (173/174/176).