### PR TITLE
feat(booking): registro + mail automático al agendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-13] — Agenda: registro + mail automáticos
+
+### Changed
+- Click **Agendar** siempre escribe en KV (`bookings`) y avisa a `contacto` inbox.
+- Sync de cita Google (eventId, slot, sitio, tel) sin exigir sesión previa.
+
+---
+
 ## [2026-08-13] — Landing: Calendar único + contacto por mail
 
 ### Changed

--- a/docs/BOOKING-JOURNEY.md
+++ b/docs/BOOKING-JOURNEY.md
@@ -11,7 +11,7 @@ Descubrir → Decidir → Agendar → Confirmar → Follow-up
 |------|-------|------------|--------|------|
 | 1. Descubrir | Visitante | Hero / modalidades / `#contacto` | `page_view` | path HashRouter |
 | 2. Decidir 30 min | Visitante | CTA «Abrir agenda» o form | `generate_lead` (`channel=google_calendar` o `contact_form`) | origin, package |
-| 3. Agendar | Visitante | Google Appointment Schedule | `book_call` | origin; si hay nombre+email de sesión → `POST /api/booking` |
+| 3. Agendar | Visitante | Google Appointment Schedule | `book_call` + **siempre** `POST /api/booking` | click queda en `#/admin` Agenda; mail a `CONTACT_INBOX`. Identidad si hay sesión o sync Calendar |
 | 4a. Confirmar Calendar | Google | Mail de Calendar al visitante | (fuera de VN) | slot |
 | 4b. Confirmar web | Worker | Mail VN si usó el form | `submit_contact_form` | lead en KV |
 | 5. Follow-up | VN | `#/admin` Bookings / Leads | PATCH estado | nuevo → contactado |

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -57,9 +57,16 @@ export function openA11yFreeScheduleOrFallback(fallback: () => void): boolean {
   return false;
 }
 
-/** CTA único de agendamiento (Google Appointment). */
+/** CTA único de agendamiento (Google Appointment) + registro Worker. */
 export function openCalendarBooking(): boolean {
   if (!A11Y_FREE_SCHEDULE_URL) return false;
+  void import("./vn-booking").then(({ recordBookingIntent }) =>
+    recordBookingIntent({
+      origin: "calendar-cta",
+      intent: "radar-free",
+      notes: "Click Agendar · Google Appointment",
+    })
+  );
   window.open(A11Y_FREE_SCHEDULE_URL, "_blank", "noopener,noreferrer");
   return true;
 }

--- a/src/lib/vn-booking.ts
+++ b/src/lib/vn-booking.ts
@@ -5,8 +5,8 @@ import { trackEvent } from "./analytics";
 export type BookingIntent = "kickoff" | "radar-free" | "consulting";
 
 /**
- * Registra la intención de agenda en el Worker (best-effort).
- * Si no hay nombre/email de sesión, no inventa identidad — solo analytics.
+ * Siempre registra el click de agenda en el Worker y dispara mail a VN.
+ * Si hay sesión, adjunta nombre/email. Si no, queda status abierto.
  */
 export async function recordBookingIntent(params: {
   origin: string;
@@ -24,17 +24,13 @@ export async function recordBookingIntent(params: {
     has_identity: Boolean(name && email),
   });
 
-  if (name.length < 2 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    return;
-  }
-
   try {
     await fetch(`${ADMIN_API_BASE}/api/booking`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify({
-        name,
-        email,
+        name: name.length >= 2 ? name : "Agenda abierta",
+        email: /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : "",
         notes: params.notes ?? "",
         intent: params.intent ?? "kickoff",
         origin: params.origin,

--- a/worker/src/api/public.js
+++ b/worker/src/api/public.js
@@ -1,6 +1,7 @@
 import { json } from '../lib/cors.js';
 import { getCases, getCompany, getServices } from '../data/catalog.js';
-import { newId, nowIso, prependRecord } from '../lib/store.js';
+import { listRecords, newId, nowIso, prependRecord } from '../lib/store.js';
+import { notifyInbox, notifyVisitor } from '../lib/notify.js';
 
 const MAX_NAME = 120;
 const MAX_EMAIL = 254;
@@ -107,32 +108,105 @@ export async function handleCreateBooking(request, env, cors) {
     return json({ ok: false, error: 'JSON inválido' }, 400, cors);
   }
 
-  const name = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
-  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const nameRaw = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
+  const emailRaw = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
   const notes = typeof body.notes === 'string' ? body.notes.trim().slice(0, MAX_TEXT) : '';
   const intent = typeof body.intent === 'string' ? body.intent.trim().slice(0, 80) : 'kickoff';
+  const origin = typeof body.origin === 'string' ? body.origin.trim().slice(0, 80) : '';
+  const phone = typeof body.phone === 'string' ? body.phone.trim().slice(0, 40) : '';
+  const website = typeof body.website === 'string' ? body.website.trim().slice(0, 400) : '';
+  const startAt = typeof body.startAt === 'string' ? body.startAt.trim().slice(0, 40) : '';
+  const eventId = typeof body.eventId === 'string' ? body.eventId.trim().slice(0, 120) : '';
+  const htmlLink = typeof body.htmlLink === 'string' ? body.htmlLink.trim().slice(0, 500) : '';
 
-  if (name.length < 2) return json({ ok: false, error: 'Nombre inválido' }, 400, cors);
-  if (!isValidEmail(email)) return json({ ok: false, error: 'Email inválido' }, 400, cors);
-
+  const name = nameRaw.length >= 2 ? nameRaw : 'Agenda abierta';
+  const email = isValidEmail(emailRaw) ? emailRaw : '';
   const url = calendarUrl(env);
+
+  if (eventId) {
+    const existing = await listRecords(env, 'bookings');
+    const dup = existing.find((item) => item.eventId === eventId);
+    if (dup) {
+      return json({ ok: true, booking: dup, deduped: true }, 200, cors);
+    }
+  }
+
   const record = {
     id: newId('book'),
     createdAt: nowIso(),
     updatedAt: nowIso(),
-    status: 'pendiente',
+    status: email ? 'pendiente' : 'abierto',
     name,
     email,
+    phone,
+    website,
     notes,
     intent,
-    calendarUrl: url,
+    origin,
+    startAt,
+    eventId,
+    calendarUrl: htmlLink || url,
   };
   await prependRecord(env, 'bookings', record);
+
+  const subject = email
+    ? `VN · agenda · ${name}${startAt ? ` · ${startAt}` : ''}`
+    : `VN · alguien abrió la agenda${origin ? ` · ${origin}` : ''}`;
+  const text = [
+    'Registro automático de agenda · vientonorte.io',
+    '',
+    `Nombre: ${name}`,
+    `Email: ${email || '(aún no)'}`,
+    phone ? `Tel: ${phone}` : null,
+    website ? `Sitio: ${website}` : null,
+    startAt ? `Slot: ${startAt}` : null,
+    origin ? `Origen: ${origin}` : null,
+    intent ? `Intent: ${intent}` : null,
+    notes ? `Notas: ${notes}` : null,
+    htmlLink || url,
+    '',
+    `Admin: https://vientonorte.io/#/admin`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const mailed = await notifyInbox(env, {
+    subject,
+    text,
+    replyTo: email || undefined,
+    replyName: name,
+  });
+
+  if (email) {
+    await notifyVisitor(env, {
+      to: email,
+      name,
+      subject: 'Tu cita con Viento Norte está registrada',
+      text: [
+        `Hola ${name},`,
+        '',
+        'Quedó registrada tu agenda con Viento Norte.',
+        startAt ? `Horario: ${startAt}` : 'Te confirmamos el horario en Google Calendar.',
+        website ? `Sitio a revisar: ${website}` : null,
+        '',
+        'En la cita recorremos el informe WCAG del flujo que nos pasaste.',
+        htmlLink || url,
+        '',
+        '— Viento Norte · vientonorte.io',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      html: `<p>Hola ${name},</p><p>Quedó registrada tu agenda con Viento Norte.</p>${
+        startAt ? `<p>Horario: ${startAt}</p>` : ''
+      }<p><a href="${htmlLink || url}">Abrir Calendar</a></p><p>— Viento Norte</p>`,
+    });
+  }
 
   return json(
     {
       ok: true,
-      booking: { id: record.id, status: record.status, calendarUrl: url, minutes: 30 },
+      booking: { id: record.id, status: record.status, calendarUrl: record.calendarUrl },
+      emailed: mailed.ok,
     },
     201,
     cors

--- a/worker/src/lib/notify.js
+++ b/worker/src/lib/notify.js
@@ -1,0 +1,70 @@
+/** Aviso inbox VN (FormSubmit → Cloudflare Email). */
+
+export async function notifyInbox(env, { subject, text, html, replyTo, replyName }) {
+  const inbox = env.CONTACT_INBOX || 'gaete.gaona@gmail.com';
+  const fromEmail = env.CONTACT_FROM || 'contacto@vientonorte.io';
+  const fromName = env.CONTACT_FROM_NAME || 'Viento Norte';
+
+  try {
+    const response = await fetch(`https://formsubmit.co/ajax/${encodeURIComponent(inbox)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Referer: 'https://vientonorte.io/',
+        Origin: 'https://vientonorte.io',
+      },
+      body: JSON.stringify({
+        name: replyName || fromName,
+        email: replyTo || fromEmail,
+        message: text,
+        _subject: subject,
+        _replyto: replyTo || fromEmail,
+        _template: 'table',
+      }),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (data.success === 'true' || data.success === true) {
+      return { ok: true, channel: 'formsubmit' };
+    }
+  } catch (err) {
+    console.warn('[notify] formsubmit failed:', err?.message || err);
+  }
+
+  if (env.EMAIL) {
+    try {
+      await env.EMAIL.send({
+        to: inbox,
+        from: { email: fromEmail, name: fromName },
+        replyTo: replyTo ? { email: replyTo, name: replyName || replyTo } : undefined,
+        subject,
+        text,
+        html: html || `<pre>${text}</pre>`,
+      });
+      return { ok: true, channel: 'cloudflare' };
+    } catch (err) {
+      console.warn('[notify] cloudflare email failed:', err?.message || err);
+    }
+  }
+  return { ok: false };
+}
+
+export async function notifyVisitor(env, { to, name, subject, text, html }) {
+  if (!to || !env.EMAIL) return { ok: false };
+  const fromEmail = env.CONTACT_FROM || 'contacto@vientonorte.io';
+  const fromName = env.CONTACT_FROM_NAME || 'Viento Norte';
+  try {
+    await env.EMAIL.send({
+      to,
+      from: { email: fromEmail, name: fromName },
+      replyTo: { email: fromEmail, name: fromName },
+      subject,
+      text,
+      html,
+    });
+    return { ok: true, channel: 'cloudflare' };
+  } catch (err) {
+    console.warn('[notify] visitor email failed:', err?.message || err);
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
## Problema
La cita de Google no llegaba a \`#/admin\` ni a un mail VN. \`recordBookingIntent\` solo escribía si había nombre+email en sesión.

## Fix
- \`POST /api/booking\` acepta click sin identidad y **siempre** avisa inbox.
- Identidad (nombre, mail, tel, sitio, slot, eventId) cuando viene de Calendar sync.
- Dedup por \`eventId\`.
- CTA Agendar llama al API antes de abrir Google.

Worker ya está desplegado. La cita PRUEBA 17 ago quedó en KV.