### PR TITLE
feat(admin): ficha operable de agenda y lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-13] — Agenda: registro + mail automáticos
+
+### Changed
+- Click **Agendar** siempre escribe en KV (`bookings`) y avisa a `contacto` inbox.
+- Sync de cita Google (eventId, slot, sitio, tel) sin exigir sesión previa.
+
+---
+
 ## [2026-08-13] — Landing: Calendar único + contacto por mail
 
 ### Changed

--- a/docs/BOOKING-JOURNEY.md
+++ b/docs/BOOKING-JOURNEY.md
@@ -11,7 +11,7 @@ Descubrir → Decidir → Agendar → Confirmar → Follow-up
 |------|-------|------------|--------|------|
 | 1. Descubrir | Visitante | Hero / modalidades / `#contacto` | `page_view` | path HashRouter |
 | 2. Decidir 30 min | Visitante | CTA «Abrir agenda» o form | `generate_lead` (`channel=google_calendar` o `contact_form`) | origin, package |
-| 3. Agendar | Visitante | Google Appointment Schedule | `book_call` | origin; si hay nombre+email de sesión → `POST /api/booking` |
+| 3. Agendar | Visitante | Google Appointment Schedule | `book_call` + **siempre** `POST /api/booking` | click queda en `#/admin` Agenda; mail a `CONTACT_INBOX`. Identidad si hay sesión o sync Calendar |
 | 4a. Confirmar Calendar | Google | Mail de Calendar al visitante | (fuera de VN) | slot |
 | 4b. Confirmar web | Worker | Mail VN si usó el form | `submit_contact_form` | lead en KV |
 | 5. Follow-up | VN | `#/admin` Bookings / Leads | PATCH estado | nuevo → contactado |

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -56,6 +56,11 @@ export interface AdminRecord {
   name?: string | { es?: string; en?: string };
   title?: string | { es?: string; en?: string };
   email?: string;
+  phone?: string;
+  website?: string;
+  startAt?: string;
+  origin?: string;
+  eventId?: string;
   message?: string;
   intent?: string;
   source?: string;

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -57,9 +57,16 @@ export function openA11yFreeScheduleOrFallback(fallback: () => void): boolean {
   return false;
 }
 
-/** CTA único de agendamiento (Google Appointment). */
+/** CTA único de agendamiento (Google Appointment) + registro Worker. */
 export function openCalendarBooking(): boolean {
   if (!A11Y_FREE_SCHEDULE_URL) return false;
+  void import("./vn-booking").then(({ recordBookingIntent }) =>
+    recordBookingIntent({
+      origin: "calendar-cta",
+      intent: "radar-free",
+      notes: "Click Agendar · Google Appointment",
+    })
+  );
   window.open(A11Y_FREE_SCHEDULE_URL, "_blank", "noopener,noreferrer");
   return true;
 }

--- a/src/lib/vn-booking.ts
+++ b/src/lib/vn-booking.ts
@@ -5,8 +5,8 @@ import { trackEvent } from "./analytics";
 export type BookingIntent = "kickoff" | "radar-free" | "consulting";
 
 /**
- * Registra la intención de agenda en el Worker (best-effort).
- * Si no hay nombre/email de sesión, no inventa identidad — solo analytics.
+ * Siempre registra el click de agenda en el Worker y dispara mail a VN.
+ * Si hay sesión, adjunta nombre/email. Si no, queda status abierto.
  */
 export async function recordBookingIntent(params: {
   origin: string;
@@ -24,17 +24,13 @@ export async function recordBookingIntent(params: {
     has_identity: Boolean(name && email),
   });
 
-  if (name.length < 2 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    return;
-  }
-
   try {
     await fetch(`${ADMIN_API_BASE}/api/booking`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
       body: JSON.stringify({
-        name,
-        email,
+        name: name.length >= 2 ? name : "Agenda abierta",
+        email: /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : "",
         notes: params.notes ?? "",
         intent: params.intent ?? "kickoff",
         origin: params.origin,

--- a/src/pages/AdminHub.tsx
+++ b/src/pages/AdminHub.tsx
@@ -432,6 +432,15 @@ function RecentList({ title, items }: { title: string; items: AdminRecord[] }) {
                   <Badge variant={statusVariant(item.status)}>{item.status || "—"}</Badge>
                 </div>
                 <p className="text-sm text-muted-foreground">{item.email}</p>
+                {item.startAt ? (
+                  <p className="text-sm">Cita: {formatWhen(item.startAt)}</p>
+                ) : null}
+                {item.website ? (
+                  <p className="text-xs break-all text-muted-foreground">{item.website}</p>
+                ) : null}
+                {item.phone ? (
+                  <p className="text-xs text-muted-foreground">Tel {item.phone}</p>
+                ) : null}
                 <p className="text-xs text-muted-foreground">{formatWhen(item.createdAt)}</p>
               </li>
             ))}
@@ -519,8 +528,34 @@ function RecordsTable({
 function DetailCell({ row, collection }: { row: AdminRecord; collection: AdminCollection }) {
   if (collection === "bookings") {
     return (
-      <div className="space-y-1">
-        <p>{row.intent || row.notes || "—"}</p>
+      <div className="space-y-1 text-foreground">
+        {row.startAt ? <p className="font-medium">Slot: {formatWhen(row.startAt)}</p> : null}
+        {row.phone ? (
+          <p>
+            Tel:{" "}
+            <a className="underline-offset-2 hover:underline" href={`tel:${row.phone}`}>
+              {row.phone}
+            </a>
+          </p>
+        ) : null}
+        {row.website ? (
+          <p className="break-all">
+            Sitio:{" "}
+            <a
+              className="text-primary underline-offset-2 hover:underline"
+              href={row.website}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {row.website}
+            </a>
+          </p>
+        ) : null}
+        {row.notes ? <p className="whitespace-pre-wrap text-muted-foreground">{row.notes}</p> : null}
+        <p className="text-xs text-muted-foreground">
+          {row.intent || "agenda"} {row.origin ? `· ${row.origin}` : ""}
+        </p>
+        <p className="text-xs">Siguiente: informe WCAG del sitio → walkthrough en la cita.</p>
         {row.calendarUrl ? (
           <a
             href={String(row.calendarUrl)}
@@ -529,7 +564,7 @@ function DetailCell({ row, collection }: { row: AdminRecord; collection: AdminCo
             rel="noreferrer"
           >
             <CalendarDays className="h-3.5 w-3.5" aria-hidden />
-            Calendar
+            Abrir Calendar / Meet
           </a>
         ) : null}
       </div>
@@ -543,7 +578,21 @@ function DetailCell({ row, collection }: { row: AdminRecord; collection: AdminCo
       </div>
     );
   }
-  return <p className="line-clamp-3">{row.message || row.intent || "—"}</p>;
+  return (
+    <div className="space-y-1">
+      {row.startAt ? <p className="font-medium">Cita: {formatWhen(row.startAt)}</p> : null}
+      {row.phone ? <p>Tel: {row.phone}</p> : null}
+      {row.website ? (
+        <p className="break-all">
+          Sitio:{" "}
+          <a href={row.website} className="text-primary" target="_blank" rel="noreferrer">
+            {row.website}
+          </a>
+        </p>
+      ) : null}
+      <p className="line-clamp-4 whitespace-pre-wrap">{row.message || row.intent || "—"}</p>
+    </div>
+  );
 }
 
 function CatalogTable({ rows, kind }: { rows: AdminRecord[]; kind: "services" | "cases" }) {

--- a/worker/src/api/public.js
+++ b/worker/src/api/public.js
@@ -1,6 +1,7 @@
 import { json } from '../lib/cors.js';
 import { getCases, getCompany, getServices } from '../data/catalog.js';
-import { newId, nowIso, prependRecord } from '../lib/store.js';
+import { listRecords, newId, nowIso, prependRecord } from '../lib/store.js';
+import { notifyInbox, notifyVisitor } from '../lib/notify.js';
 
 const MAX_NAME = 120;
 const MAX_EMAIL = 254;
@@ -107,32 +108,105 @@ export async function handleCreateBooking(request, env, cors) {
     return json({ ok: false, error: 'JSON inválido' }, 400, cors);
   }
 
-  const name = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
-  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const nameRaw = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME) : '';
+  const emailRaw = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
   const notes = typeof body.notes === 'string' ? body.notes.trim().slice(0, MAX_TEXT) : '';
   const intent = typeof body.intent === 'string' ? body.intent.trim().slice(0, 80) : 'kickoff';
+  const origin = typeof body.origin === 'string' ? body.origin.trim().slice(0, 80) : '';
+  const phone = typeof body.phone === 'string' ? body.phone.trim().slice(0, 40) : '';
+  const website = typeof body.website === 'string' ? body.website.trim().slice(0, 400) : '';
+  const startAt = typeof body.startAt === 'string' ? body.startAt.trim().slice(0, 40) : '';
+  const eventId = typeof body.eventId === 'string' ? body.eventId.trim().slice(0, 120) : '';
+  const htmlLink = typeof body.htmlLink === 'string' ? body.htmlLink.trim().slice(0, 500) : '';
 
-  if (name.length < 2) return json({ ok: false, error: 'Nombre inválido' }, 400, cors);
-  if (!isValidEmail(email)) return json({ ok: false, error: 'Email inválido' }, 400, cors);
-
+  const name = nameRaw.length >= 2 ? nameRaw : 'Agenda abierta';
+  const email = isValidEmail(emailRaw) ? emailRaw : '';
   const url = calendarUrl(env);
+
+  if (eventId) {
+    const existing = await listRecords(env, 'bookings');
+    const dup = existing.find((item) => item.eventId === eventId);
+    if (dup) {
+      return json({ ok: true, booking: dup, deduped: true }, 200, cors);
+    }
+  }
+
   const record = {
     id: newId('book'),
     createdAt: nowIso(),
     updatedAt: nowIso(),
-    status: 'pendiente',
+    status: email ? 'pendiente' : 'abierto',
     name,
     email,
+    phone,
+    website,
     notes,
     intent,
-    calendarUrl: url,
+    origin,
+    startAt,
+    eventId,
+    calendarUrl: htmlLink || url,
   };
   await prependRecord(env, 'bookings', record);
+
+  const subject = email
+    ? `VN · agenda · ${name}${startAt ? ` · ${startAt}` : ''}`
+    : `VN · alguien abrió la agenda${origin ? ` · ${origin}` : ''}`;
+  const text = [
+    'Registro automático de agenda · vientonorte.io',
+    '',
+    `Nombre: ${name}`,
+    `Email: ${email || '(aún no)'}`,
+    phone ? `Tel: ${phone}` : null,
+    website ? `Sitio: ${website}` : null,
+    startAt ? `Slot: ${startAt}` : null,
+    origin ? `Origen: ${origin}` : null,
+    intent ? `Intent: ${intent}` : null,
+    notes ? `Notas: ${notes}` : null,
+    htmlLink || url,
+    '',
+    `Admin: https://vientonorte.io/#/admin`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const mailed = await notifyInbox(env, {
+    subject,
+    text,
+    replyTo: email || undefined,
+    replyName: name,
+  });
+
+  if (email) {
+    await notifyVisitor(env, {
+      to: email,
+      name,
+      subject: 'Tu cita con Viento Norte está registrada',
+      text: [
+        `Hola ${name},`,
+        '',
+        'Quedó registrada tu agenda con Viento Norte.',
+        startAt ? `Horario: ${startAt}` : 'Te confirmamos el horario en Google Calendar.',
+        website ? `Sitio a revisar: ${website}` : null,
+        '',
+        'En la cita recorremos el informe WCAG del flujo que nos pasaste.',
+        htmlLink || url,
+        '',
+        '— Viento Norte · vientonorte.io',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      html: `<p>Hola ${name},</p><p>Quedó registrada tu agenda con Viento Norte.</p>${
+        startAt ? `<p>Horario: ${startAt}</p>` : ''
+      }<p><a href="${htmlLink || url}">Abrir Calendar</a></p><p>— Viento Norte</p>`,
+    });
+  }
 
   return json(
     {
       ok: true,
-      booking: { id: record.id, status: record.status, calendarUrl: url, minutes: 30 },
+      booking: { id: record.id, status: record.status, calendarUrl: record.calendarUrl },
+      emailed: mailed.ok,
     },
     201,
     cors

--- a/worker/src/api/public.js
+++ b/worker/src/api/public.js
@@ -1,6 +1,6 @@
 import { json } from '../lib/cors.js';
 import { getCases, getCompany, getServices } from '../data/catalog.js';
-import { listRecords, newId, nowIso, prependRecord } from '../lib/store.js';
+import { listRecords, newId, nowIso, prependRecord, updateRecord } from '../lib/store.js';
 import { notifyInbox, notifyVisitor } from '../lib/notify.js';
 
 const MAX_NAME = 120;
@@ -61,6 +61,54 @@ export async function persistLead(env, fields) {
   };
   await prependRecord(env, 'leads', record);
   return record;
+}
+
+async function upsertLeadFromBooking(env, booking) {
+  const email = typeof booking.email === 'string' ? booking.email.trim().toLowerCase() : '';
+  if (!isValidEmail(email)) return null;
+  const leads = await listRecords(env, 'leads');
+  const existing = leads.find(
+    (item) =>
+      item.email === email &&
+      (item.eventId === booking.eventId || item.source === 'calendar')
+  );
+  const message = [
+    booking.startAt ? `Cita: ${booking.startAt}` : null,
+    booking.phone ? `Tel: ${booking.phone}` : null,
+    booking.website ? `Sitio a revisar: ${booking.website}` : null,
+    booking.notes || null,
+    'Siguiente: informe WCAG de un flujo → walkthrough en la cita.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+  if (existing) {
+    return updateRecord(env, 'leads', existing.id, {
+      name: booking.name || existing.name,
+      phone: booking.phone || existing.phone,
+      website: booking.website || existing.website,
+      startAt: booking.startAt || existing.startAt,
+      eventId: booking.eventId || existing.eventId,
+      message,
+      updatedAt: nowIso(),
+    });
+  }
+  return persistLead(env, {
+    name: booking.name || email,
+    email,
+    message,
+    intent: booking.intent || 'radar-free',
+    source: 'calendar',
+    language: 'es',
+    channel: 'calendar',
+  }).then(async (lead) => {
+    await updateRecord(env, 'leads', lead.id, {
+      phone: booking.phone || '',
+      website: booking.website || '',
+      startAt: booking.startAt || '',
+      eventId: booking.eventId || '',
+    });
+    return lead;
+  });
 }
 
 export async function handleCreateLead(request, env, cors, { persistOnly = false } = {}) {
@@ -127,7 +175,19 @@ export async function handleCreateBooking(request, env, cors) {
     const existing = await listRecords(env, 'bookings');
     const dup = existing.find((item) => item.eventId === eventId);
     if (dup) {
-      return json({ ok: true, booking: dup, deduped: true }, 200, cors);
+      const merged = {
+        phone: phone || dup.phone || '',
+        website: website || dup.website || '',
+        startAt: startAt || dup.startAt || '',
+        notes: notes || dup.notes || '',
+        name: nameRaw.length >= 2 ? name : dup.name,
+        email: email || dup.email || '',
+        calendarUrl: htmlLink || dup.calendarUrl || url,
+        updatedAt: nowIso(),
+      };
+      const updated = await updateRecord(env, 'bookings', dup.id, merged);
+      await upsertLeadFromBooking(env, { ...dup, ...merged, intent, origin });
+      return json({ ok: true, booking: updated, deduped: true }, 200, cors);
     }
   }
 
@@ -148,6 +208,7 @@ export async function handleCreateBooking(request, env, cors) {
     calendarUrl: htmlLink || url,
   };
   await prependRecord(env, 'bookings', record);
+  await upsertLeadFromBooking(env, record);
 
   const subject = email
     ? `VN · agenda · ${name}${startAt ? ` · ${startAt}` : ''}`

--- a/worker/src/lib/notify.js
+++ b/worker/src/lib/notify.js
@@ -1,0 +1,70 @@
+/** Aviso inbox VN (FormSubmit → Cloudflare Email). */
+
+export async function notifyInbox(env, { subject, text, html, replyTo, replyName }) {
+  const inbox = env.CONTACT_INBOX || 'gaete.gaona@gmail.com';
+  const fromEmail = env.CONTACT_FROM || 'contacto@vientonorte.io';
+  const fromName = env.CONTACT_FROM_NAME || 'Viento Norte';
+
+  try {
+    const response = await fetch(`https://formsubmit.co/ajax/${encodeURIComponent(inbox)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Referer: 'https://vientonorte.io/',
+        Origin: 'https://vientonorte.io',
+      },
+      body: JSON.stringify({
+        name: replyName || fromName,
+        email: replyTo || fromEmail,
+        message: text,
+        _subject: subject,
+        _replyto: replyTo || fromEmail,
+        _template: 'table',
+      }),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (data.success === 'true' || data.success === true) {
+      return { ok: true, channel: 'formsubmit' };
+    }
+  } catch (err) {
+    console.warn('[notify] formsubmit failed:', err?.message || err);
+  }
+
+  if (env.EMAIL) {
+    try {
+      await env.EMAIL.send({
+        to: inbox,
+        from: { email: fromEmail, name: fromName },
+        replyTo: replyTo ? { email: replyTo, name: replyName || replyTo } : undefined,
+        subject,
+        text,
+        html: html || `<pre>${text}</pre>`,
+      });
+      return { ok: true, channel: 'cloudflare' };
+    } catch (err) {
+      console.warn('[notify] cloudflare email failed:', err?.message || err);
+    }
+  }
+  return { ok: false };
+}
+
+export async function notifyVisitor(env, { to, name, subject, text, html }) {
+  if (!to || !env.EMAIL) return { ok: false };
+  const fromEmail = env.CONTACT_FROM || 'contacto@vientonorte.io';
+  const fromName = env.CONTACT_FROM_NAME || 'Viento Norte';
+  try {
+    await env.EMAIL.send({
+      to,
+      from: { email: fromEmail, name: fromName },
+      replyTo: { email: fromEmail, name: fromName },
+      subject,
+      text,
+      html,
+    });
+    return { ok: true, channel: 'cloudflare' };
+  } catch (err) {
+    console.warn('[notify] visitor email failed:', err?.message || err);
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
## Por qué
Overview mostraba dos filas PRUEBA con mail y nada más. No se gestiona un lead así.

## Qué
- Agenda/Lead: slot, teléfono, sitio, notas, Calendar/Meet, siguiente paso (informe WCAG).
- Booking con email → también entra en **Leads**.
- Dedup Calendar actualiza la ficha (no otra fila vacía).

Worker ya live. La cita PRUEBA quedó enriquecida (tel, sitio, 17 ago 09:40).