### PR TITLE
docs(gtm): contenedor GTM-PM5LBQRP + smoke de bundle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,8 @@ jobs:
           VITE_VIDEO_CALL_URL: ${{ secrets.VITE_VIDEO_CALL_URL }}
 
       - name: Artifact smoke (domain root)
+        env:
+          VITE_GTM_ID: ${{ secrets.VITE_GTM_ID }}
         run: |
           set -euo pipefail
           test -f dist/index.html
@@ -100,6 +102,12 @@ jobs:
           fi
           JS=$(find dist/assets -name '*.js' | wc -l | tr -d ' ')
           test "$JS" -ge 1
+          if [ -n "${VITE_GTM_ID:-}" ]; then
+            grep -R -q -- "$VITE_GTM_ID" dist/assets || {
+              echo "VITE_GTM_ID set but ID missing from bundle" >&2
+              exit 1
+            }
+          fi
 
       - name: SPA fallback + legacy /mi-portafolio redirect
         run: |

--- a/docs/CHECKLIST-CANALES-PAID.md
+++ b/docs/CHECKLIST-CANALES-PAID.md
@@ -1,12 +1,13 @@
 # Checklist · habilitar canales (share → Ads / IG)
 
-**Decider:** Rö · **Actualizado:** 2026-08-13  
-**Loop D→E→F: PARKED** hasta que Rö diga *activar campañas*. No GTM, no Ads, no IG Ads, no spend.  
-**Regla:** no gastar en Ads/IG hasta la sección **E** y **F** en verde **y** el Decider reactive este loop.  
+**Decider:** Rö · **Actualizado:** 2026-08-15  
+**Loop D:** en curso (DS instrumentación · contenedor `GTM-PM5LBQRP` · secret `VITE_GTM_ID`).  
+**Loop E→F: PARKED** hasta que Rö diga *activar campañas*. No Ads, no IG Ads, no spend.  
+**Regla:** no gastar en Ads/IG hasta la sección **E** y **F** en verde **y** el Decider reactive ese loop.  
 **Final URL de paid y de bio:** `https://vientonorte.io/s/consultoria`  
 **No usar** `/#/auditoria` ni `#/admin` en anuncios.
 
-Evidencia live 13 ago: `/s/consultoria` **200** · OG home `og-home-1200.png` **1200×630** · GTM en HTML **0** · PR #172/#174/#180 **merged** `b3301ca`. Residual humano (parked con el loop): LinkedIn Post Inspector / Meta Debugger scrape.
+Evidencia 15 ago: `/s/consultoria` **200** · OG `og-home-1200.png` **1200×630** · secret `VITE_GTM_ID` · **no** `VITE_GA_MEASUREMENT_ID` · #181 merged `1602ed6`. Residual humano: GTM Preview + tags GA4 en el contenedor · LinkedIn/Meta scrape (A).
 
 ---
 
@@ -61,11 +62,11 @@ Misma cuenta Google que GSC / Calendar / Forms.
 
 Código ya emite `generate_lead`, `book_call`, `submit_contact_form`, `page_view`. Falta el contenedor.
 
-- [ ] Crear contenedor GTM Web **Viento Norte / vientonorte.io** → anotar `GTM-XXXX`
-- [ ] `gh secret set VITE_GTM_ID -R vientonorte/mi-portafolio -b 'GTM-XXXX'`
-- [ ] Opcional: `gh secret set VITE_GA_MEASUREMENT_ID` (`G-XXXX`)
-- [ ] Redeploy Pages
-- [ ] View-source `vientonorte.io` contiene `gtm.js?id=GTM-`
+- [x] Crear contenedor GTM Web **Viento Norte / vientonorte.io** → `GTM-PM5LBQRP`
+- [x] `gh secret set VITE_GTM_ID` (15 ago)
+- [ ] `VITE_GA_MEASUREMENT_ID` — **no** (apuesta A: GA4 = tag en GTM)
+- [ ] Redeploy Pages con el secret (run dispatch 15 ago)
+- [ ] Bundle live contiene `GTM-PM5LBQRP` (no view-source estático: `initGTM` es JS)
 - [ ] GTM Preview: click agenda o form → evento `generate_lead` o `book_call`
 - [ ] Tag GA4 Event (o Ads conversion) escuchando esos custom events
 - [ ] Receta: `docs/GTM-KICKOFF.md`

--- a/docs/CHECKLIST-CANALES-PAID.md
+++ b/docs/CHECKLIST-CANALES-PAID.md
@@ -65,8 +65,8 @@ Código ya emite `generate_lead`, `book_call`, `submit_contact_form`, `page_view
 - [x] Crear contenedor GTM Web **Viento Norte / vientonorte.io** → `GTM-PM5LBQRP`
 - [x] `gh secret set VITE_GTM_ID` (15 ago)
 - [ ] `VITE_GA_MEASUREMENT_ID` — **no** (apuesta A: GA4 = tag en GTM)
-- [ ] Redeploy Pages con el secret (run dispatch 15 ago)
-- [ ] Bundle live contiene `GTM-PM5LBQRP` (no view-source estático: `initGTM` es JS)
+- [x] Redeploy Pages con el secret ([run 31908951330](https://github.com/vientonorte/mi-portafolio/actions/runs/31908951330) success)
+- [x] Bundle live contiene `GTM-PM5LBQRP` (`/assets/index-DklCOEAE.js` · no view-source estático: `initGTM` es JS)
 - [ ] GTM Preview: click agenda o form → evento `generate_lead` o `book_call`
 - [ ] Tag GA4 Event (o Ads conversion) escuchando esos custom events
 - [ ] Receta: `docs/GTM-KICKOFF.md`

--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -1,23 +1,23 @@
 # GTM kick-off · wire de conversión
 
 **Estado código:** dataLayer + `initGTM` listos.  
-**Estado prod:** sin `VITE_GTM_ID` en GitHub Secrets → el HTML live **no** carga `gtm.js`.
+**Contenedor:** `GTM-PM5LBQRP` (Web · Viento Norte / vientonorte.io).  
+**Secret:** `VITE_GTM_ID` seteado 2026-08-15. **No** `VITE_GA_MEASUREMENT_ID` (apuesta A: GA4 = tag dentro de GTM).  
+**Anti-patrón:** no pegar el snippet oficial en `index.html`. El build inyecta vía `AnalyticsProvider` → `initGTM`.
 
-No hay `GTM-XXXX` en el vault. El contenedor se crea una vez en tagmanager.google.com (cuenta Viento Norte).
+El ID es público (sale en el bundle). El valor vive en GitHub Secrets para no hardcodear.
 
-## 1. Crear contenedor (humano, 2 min)
+## 1. Contenedor (hecho)
 
-1. [Google Tag Manager](https://tagmanager.google.com/) → cuenta **Viento Norte** → contenedor **vientonorte.io** (Web).
-2. Copiar el ID `GTM-XXXXXXX`.
-3. En el repo:
+1. [Google Tag Manager](https://tagmanager.google.com/) → cuenta **Viento Norte** → contenedor **vientonorte.io** (Web) → `GTM-PM5LBQRP`.
+2. Repo:
 
 ```bash
-gh secret set VITE_GTM_ID -R vientonorte/mi-portafolio -b 'GTM-XXXXXXX'
-# opcional, mismo contenedor + GA4:
-# gh secret set VITE_GA_MEASUREMENT_ID -R vientonorte/mi-portafolio -b 'G-XXXXXXXX'
+gh secret set VITE_GTM_ID -R vientonorte/mi-portafolio -b 'GTM-PM5LBQRP'
+# no setear VITE_GA_MEASUREMENT_ID salvo apuesta B (doble snippet)
 ```
 
-4. Redeploy Pages (`workflow_dispatch` Deploy to GitHub Pages). El build ya pasa `VITE_GTM_ID` a Vite.
+3. Redeploy Pages (`workflow_dispatch` Deploy to GitHub Pages). Vite recibe `VITE_GTM_ID`.
 
 ## 2. Tags de conversión (mismo contenedor)
 

--- a/src/vn-core/analytics/gtm.ts
+++ b/src/vn-core/analytics/gtm.ts
@@ -71,6 +71,7 @@ export function initGTM(gtmId: string): void {
     const noscript = document.createElement('noscript');
     const iframe = document.createElement('iframe');
     iframe.src = `https://www.googletagmanager.com/ns.html?id=${gtmId}`;
+    iframe.title = 'Google Tag Manager';
     iframe.height = '0';
     iframe.width = '0';
     iframe.style.display = 'none';


### PR DESCRIPTION
## Por qué
Decider entregó el snippet de `GTM-PM5LBQRP`. Apuesta A del DS instrumentación: secret + `initGTM`, no pegar el snippet en `index.html`.

## Qué
- Receta y checklist D actualizados (`GTM-PM5LBQRP`, E/F siguen $0)
- Smoke de deploy: si hay `VITE_GTM_ID`, el ID tiene que estar en el bundle

## Ya en GitHub
- Secret `VITE_GTM_ID` seteado
- Redeploy manual: https://github.com/vientonorte/mi-portafolio/actions/runs/31908951330