### PR TITLE
docs(gtm): anotar G-G7JXJKGCDV (solo tag GTM)

### DIFF
--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -2,8 +2,9 @@
 
 **Estado código:** dataLayer + `initGTM` listos.  
 **Contenedor:** `GTM-PM5LBQRP` (Web · Viento Norte / vientonorte.io).  
-**Secret:** `VITE_GTM_ID` seteado 2026-08-15. **No** `VITE_GA_MEASUREMENT_ID` (apuesta A: GA4 = tag dentro de GTM).  
-**Anti-patrón:** no pegar el snippet oficial en `index.html`. El build inyecta vía `AnalyticsProvider` → `initGTM`.
+**GA4:** `G-G7JXJKGCDV` — solo como **Etiqueta de Google** dentro de GTM.  
+**Secret:** `VITE_GTM_ID` seteado 2026-08-15. **No** `VITE_GA_MEASUREMENT_ID` (apuesta A: no segundo snippet gtag).  
+**Anti-patrón:** no pegar el snippet GTM ni el de `gtag.js` en `index.html`.
 
 El ID es público (sale en el bundle). El valor vive en GitHub Secrets para no hardcodear.
 
@@ -14,7 +15,8 @@ El ID es público (sale en el bundle). El valor vive en GitHub Secrets para no h
 
 ```bash
 gh secret set VITE_GTM_ID -R vientonorte/mi-portafolio -b 'GTM-PM5LBQRP'
-# no setear VITE_GA_MEASUREMENT_ID salvo apuesta B (doble snippet)
+# no setear VITE_GA_MEASUREMENT_ID (= G-G7JXJKGCDV). Eso carga gtag.js
+# en paralelo a GTM y duplica page_view.
 ```
 
 3. Redeploy Pages (`workflow_dispatch` Deploy to GitHub Pages). Vite recibe `VITE_GTM_ID`.


### PR DESCRIPTION
Apuesta A: el ID GA4 va en Etiqueta de Google del contenedor GTM-PM5LBQRP.
No snippet gtag en index.html. No secret VITE_GA_MEASUREMENT_ID.