### PR TITLE
feat(consultoria): SEM = funnel 3 packs + OB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-15] — SEM: `/#/consultoria` = funnel 3 packs + OB
+
+### Changed
+- Paid landing `/#/consultoria` usa el mismo funnel que home (Diagnóstico · Prototipo · Proceso), no el tour fullscreen.
+- **Empezar** en cada pack hace scroll a `#consultoria-onboarding` con `package_id`.
+- Calendar abre con `?pack=` (campo que Rö añade en Appointment).
+- Tour de módulos queda en `/#/consultoria/modulos/:id`.
+
+### Docs
+- `docs/BLUEPRINT-SEO-SEM.md` — checklist SEO/SEM y Decide de URLs.
+
 ## [2026-08-13] — Agenda: registro + mail automáticos
 
 ### Changed

--- a/docs/BLUEPRINT-SEO-SEM.md
+++ b/docs/BLUEPRINT-SEO-SEM.md
@@ -1,0 +1,47 @@
+# Blueprint SEO + SEM · Viento Norte
+
+**Decide 15 ago:** `/#/consultoria` se **queda** y es el funnel de conversión (3 packs + OB).  
+No deprecar. No pagar a `/`. Crawler: `/s/consultoria`.
+
+Vault (misma decisión): `Viento Norte/Resources/SEM/2026-08-15 BLUEPRINT SEO-SEM.md`
+
+## Superficies
+
+| Superficie | URL | Job |
+|------------|-----|-----|
+| Share / Ads crawler | `/s/consultoria` | OG 1200×630 |
+| Landing SEM | `/#/consultoria` | Packs + `#consultoria-onboarding` + Calendar |
+| Tour módulos | `/#/consultoria/modulos/:id` | Craft / deep link |
+| Home | `/` | Marca · mismo funnel · no final paid |
+| Admin / ops | `#/admin` · `/ops/` | Nunca en ads |
+
+## Checklist SEO
+
+`bash ~/.grok/skills/seo-vn/scripts/local-onboarding-smoke.sh http://127.0.0.1:5173`
+
+| # | Check |
+|---|--------|
+| S1 | Title/description SEM (`t.seo.pages.consultoria`) |
+| S2 | Canonical `#/consultoria` |
+| S3 | `/s/consultoria` 200 + og 1200×630 |
+| S4 | Free CTA ≠ `/#/auditoria` |
+| S5 | Crawler no lee Helmet — share solo `/s/` |
+
+## Checklist SEM
+
+`$0` hasta Decider *activar campañas*.
+
+| # | Check |
+|---|--------|
+| D1 | GTM `GTM-PM5LBQRP` + GA4 `G-G7JXJKGCDV` · `page_view` |
+| D2 | Tag evento `generate_lead` + `book_call` (GTM v3 · humano) |
+| D3 | Evento clave GA4 |
+| D4 | Filtro IP `casa-vn` Activo |
+| D5 | Campo `pack` en Calendar Appointment |
+| D6 | `?pack=radar\|marco\|ops` en SEM + Calendar URL |
+| D7 | Final URL `/s/consultoria` |
+| D8 | Copy ad = Diagnóstico / a11y · no “Radar” |
+
+## Receta GTM v3
+
+Ver `docs/GTM-KICKOFF.md` §2. Activador Custom Event = nombre del `dataLayer.event`.

--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -38,6 +38,18 @@ Variables de capa de datos: `lead_type`, `channel`, `origin`, `package_id`, `pag
 
 GA4: un tag **GA4 Event** por conversión, event name igual al custom event (o `generate_lead` → GA4 `generate_lead`).
 
+### v3 · receta UI (humano · no hay MCP GTM)
+
+1. Etiquetas → Nueva → **Google Analytics: evento de GA4**.
+2. ID de medición: `G-G7JXJKGCDV` (o “Etiqueta de Google” existente).
+3. Nombre del evento: `generate_lead`.
+4. Activador: **Evento personalizado** · nombre `generate_lead`.
+5. Repetir para `book_call`.
+6. Enviar → Publicar versión `v3 eventos lead`.
+7. GA4 → Admin → Eventos clave → marcar esos dos.
+
+`package_id` via dataLayer (`radar` | `marco` | `ops`).
+
 ## 3. QA
 
 ```text

--- a/docs/URL-CANON-VIENTONORTE.md
+++ b/docs/URL-CANON-VIENTONORTE.md
@@ -8,7 +8,7 @@
 | Superficie | Path | Live | Rol |
 |------------|------|------|-----|
 | **Home = embudo FO** | `/` | https://vientonorte.io/ | Conversión: packs, kickoff, Calendar free, contacto |
-| **Oferta SEM** | `/#/consultoria` | https://vientonorte.io/#/consultoria | Landing paid / story módulos (fullscreen) |
+| **Oferta SEM** | `/#/consultoria` | https://vientonorte.io/#/consultoria | Landing paid · 3 packs + OB |
 | Módulo SEM | `/#/consultoria/modulos/:id` | … | Deep link tour |
 | Proceso | `/#/proceso` | … | Macros método |
 | Demo X\|CMS | `/#/demo/x-cms` | … | Gate campaña |

--- a/public/s/consultoria/index.html
+++ b/public/s/consultoria/index.html
@@ -6,7 +6,7 @@
     <title>Consultoría UX · Viento Norte</title>
     <meta
       name="description"
-      content="Diagnóstico, prototipo o proceso de equipo. Entrada gratis de accesibilidad. Kickoff 30 min."
+      content="Diagnóstico 5–7 días, prototipo o proceso de equipo. Gratis: accesibilidad de un flujo. Kickoff 30 min."
     />
     <link rel="canonical" href="https://vientonorte.io/#/consultoria" />
     <meta property="og:type" content="website" />
@@ -14,7 +14,7 @@
     <meta property="og:title" content="Consultoría UX · Viento Norte" />
     <meta
       property="og:description"
-      content="Diagnóstico, prototipo o proceso. Software que se instala. Cliente dueño del dato."
+      content="Diagnóstico, prototipo o proceso. Software que se instala. Cliente dueño del dato. Kickoff 30 min."
     />
     <meta
       property="og:image"

--- a/scripts/qa-prototypes.mjs
+++ b/scripts/qa-prototypes.mjs
@@ -171,8 +171,8 @@ async function checkPageNeedles(page, { path, needles, label }) {
 }
 
 async function checkConsultoriaDemo(page, consultoria) {
-  // Demos viven en el tour SEM, no en el landing slim.
-  await visit(page, '/consultoria');
+  // Demos viven en el tour de módulos, no en el landing SEM slim.
+  await visit(page, '/consultoria/modulos/dashboard');
   const demo = page.locator('#consultoria-demo');
   if ((await demo.count()) === 0) {
     await visit(page, '/demo/x-cms');

--- a/scripts/qa-routes.mjs
+++ b/scripts/qa-routes.mjs
@@ -47,13 +47,17 @@ const PROJECT_IDS = [
   'framework',
 ];
 
-// Home FO = embudo (/). SEM tour = /consultoria (fullscreen, sin estas anclas).
+// Home FO + SEM paid = mismo funnel (packs + OB). Tour = /consultoria/modulos/:id
 // Legacy /consultoria/embudo redirige a / — las secciones se checan en home.
 const SECTION_CHECKS = [
   { path: '/', sectionId: 'inicio', label: 'Home embudo #inicio' },
   { path: '/', sectionId: 'modalidades', label: 'Home embudo #modalidades' },
+  { path: '/', sectionId: 'consultoria-onboarding', label: 'Home embudo #consultoria-onboarding' },
   { path: '/', sectionId: 'mas-del-sitio', label: 'Home embudo #mas-del-sitio' },
   { path: '/', sectionId: 'contacto', label: 'Home embudo #contacto' },
+  { path: '/consultoria', sectionId: 'modalidades', label: 'SEM #modalidades' },
+  { path: '/consultoria', sectionId: 'consultoria-onboarding', label: 'SEM #consultoria-onboarding' },
+  { path: '/consultoria', sectionId: 'contacto', label: 'SEM #contacto' },
   { path: '/design-system', sectionId: 'figma-export', label: 'Design System #figma-export' },
 ];
 
@@ -130,13 +134,17 @@ async function checkRoute(page, { path, label }) {
     await page.goto(hashUrl(path), { waitUntil: 'domcontentloaded', timeout: 45000 });
     // #main siempre en el shell; tour oferta es fixed (puede no “visible” a PW por height)
     await page.waitForSelector('#main', { state: 'attached', timeout: 25000 });
-    if (path === '/' || path === '/consultoria/embudo') {
+    if (
+      path === '/' ||
+      path === '/consultoria/embudo' ||
+      path === '/consultoria'
+    ) {
       await page.waitForSelector('[data-testid="consultoria-funnel"]', {
         state: 'attached',
         timeout: 20000,
       });
     }
-    if (path === '/consultoria' || path.startsWith('/consultoria/modulos/')) {
+    if (path.startsWith('/consultoria/modulos/')) {
       await page.waitForSelector('[data-testid="consultoria-offer"]', {
         state: 'attached',
         timeout: 20000,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,14 +48,13 @@ const OFFER_MODULE_IDS = new Set([
   'reportes',
 ]);
 
-/** Landing oferta = tour módulos (ex-POC). Deep link opcional por moduleId. */
+/** SEM paid = funnel 3 packs + OB. Tour de módulos solo en deep link. */
 function ConsultoriaOfferPage() {
   const { moduleId } = useParams<{ moduleId?: string }>();
-  const initial =
-    moduleId && OFFER_MODULE_IDS.has(moduleId)
-      ? (moduleId as PocModuleId)
-      : undefined;
-  return <PocProductOnboarding initialModuleId={initial} />;
+  if (moduleId && OFFER_MODULE_IDS.has(moduleId)) {
+    return <PocProductOnboarding initialModuleId={moduleId as PocModuleId} />;
+  }
+  return <Home />;
 }
 
 function LegacyCasesProcessRedirect() {

--- a/src/__tests__/lib/consulting-pack-url.test.ts
+++ b/src/__tests__/lib/consulting-pack-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  parsePackFromSearch,
+  withPackQuery,
+} from "../../lib/consulting-pack-url";
+
+describe("consulting-pack-url", () => {
+  it("parses radar | marco | ops from search", () => {
+    expect(parsePackFromSearch("?pack=radar")).toBe("radar");
+    expect(parsePackFromSearch("pack=marco")).toBe("marco");
+    expect(parsePackFromSearch("?pack=ops&utm_source=google")).toBe("ops");
+  });
+
+  it("ignores unknown pack", () => {
+    expect(parsePackFromSearch("?pack=auditoria")).toBeUndefined();
+    expect(parsePackFromSearch("")).toBeUndefined();
+  });
+
+  it("appends pack to Calendar URL", () => {
+    expect(
+      withPackQuery("https://calendar.app.google/abc", "radar")
+    ).toBe("https://calendar.app.google/abc?pack=radar");
+  });
+});

--- a/src/components/organisms/ConsultoriaOnboarding.tsx
+++ b/src/components/organisms/ConsultoriaOnboarding.tsx
@@ -1,407 +1,88 @@
-import { useMemo, useState } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "motion/react";
-import { ArrowLeft, ArrowRight, Check, Package } from "lucide-react";
-import { useNavigate } from "react-router-dom";
-import { Button } from "../ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import { Calendar, Mail } from "lucide-react";
+import { PageSection } from "../layout/PageSection";
+import { SectionHeader } from "../molecules/SectionHeader";
 import { Badge } from "../ui/badge";
-import { Label } from "../ui/label";
-import { Textarea } from "../ui/textarea";
+import { Button } from "../ui/button";
 import {
-  CONSULTING_INDUSTRIES,
-  CONSULTING_PACKAGES,
-  CONSULTING_TIMELINES,
-  buildConsultingContactMessage,
+  CONSULTORIA_FUNNEL_KICKOFF_ID,
+} from "../../lib/nav-config";
+import {
+  getConsultingPackage,
   type ConsultingPackageId,
 } from "../../data/vientonorte-consulting";
-import {
-  ONBOARDING_STEPS,
-  resolveOnboardingStartIndex,
-} from "../../lib/consultoria-onboarding-entry";
+import { openCalendarBooking } from "../../lib/site-contact";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
-import { navigateToContactAssistant } from "../../lib/navigate-to-contact";
-import { cn } from "../../lib/utils";
+import { analytics } from "../../lib/analytics";
+import { scrollToSection } from "../../lib/scroll-to-section";
 
 interface ConsultoriaOnboardingProps {
-  initialPackageId?: ConsultingPackageId;
-  /** Prefill del objetivo (ej. template C1 offline/N2N / educación) */
-  initialGoal?: string;
-  /** Industria preseleccionada (ej. Educación) */
-  initialIndustry?: string;
-  /**
-   * true si el usuario ya eligió modalidad fuera del wizard
-   * (hero, packs, árbol, C1) — salta welcome + package
-   */
-  packageLocked?: boolean;
+  packageId?: ConsultingPackageId;
 }
 
-export function ConsultoriaOnboarding({
-  initialPackageId,
-  initialGoal,
-  initialIndustry,
-  packageLocked = false,
-}: ConsultoriaOnboardingProps) {
-  const navigate = useNavigate();
+export function ConsultoriaOnboarding({ packageId }: ConsultoriaOnboardingProps) {
   const { language } = useLanguage();
-  const t = useTranslation(language).consultoria;
-  const prefersReducedMotion = useReducedMotion();
+  const landing = useTranslation(language).consultoria.landing;
+  const copy = landing.onboarding;
+  const pkg = packageId ? getConsultingPackage(packageId) : undefined;
 
-  const startIndex = resolveOnboardingStartIndex({
-    packagePreselected: packageLocked && Boolean(initialPackageId),
-    goalPrefill: initialGoal,
-  });
-
-  // Parent remounts via key when entry package/goal changes — init state only
-  const [stepIndex, setStepIndex] = useState(startIndex);
-  const [selectedPackage, setSelectedPackage] = useState<ConsultingPackageId>(
-    initialPackageId ?? "marco"
-  );
-  const [industry, setIndustry] = useState(
-    initialIndustry ?? CONSULTING_INDUSTRIES[language][0]
-  );
-  const [timeline, setTimeline] = useState(CONSULTING_TIMELINES[language][1]);
-  const [goal, setGoal] = useState(initialGoal ?? "");
-
-  const step = ONBOARDING_STEPS[stepIndex];
-  const progress = Math.round(((stepIndex + 1) / ONBOARDING_STEPS.length) * 100);
-
-  const pkg = useMemo(
-    () => CONSULTING_PACKAGES.find((p) => p.id === selectedPackage)!,
-    [selectedPackage]
-  );
-
-  const canContinue =
-    step === "welcome" ||
-    step === "package" ||
-    (step === "context" && goal.trim().length >= 20);
-
-  const goNext = () => {
-    if (stepIndex < ONBOARDING_STEPS.length - 1) setStepIndex((i) => i + 1);
-  };
-
-  const goBack = () => {
-    if (stepIndex <= 0) return;
-    // Paquete preelegido: no volver a welcome; desde package volver a context
-    if (packageLocked && stepIndex === 2) return;
-    if (packageLocked && stepIndex === 1) {
-      setStepIndex(2);
-      return;
-    }
-    setStepIndex((i) => i - 1);
-  };
-
-  const openPackageStep = () => {
-    setStepIndex(1);
-  };
-
-  const finish = () => {
-    const message = buildConsultingContactMessage(
-      language,
-      pkg,
-      industry,
-      goal,
-      timeline
-    );
-    navigateToContactAssistant(navigate, {
-      origin: "onboarding",
-      source: "onboarding",
-      intent: "consulting",
-      packageId: selectedPackage,
-      industry,
-      timeline,
-      message,
+  const book = () => {
+    analytics.generateLead({
+      lead_type: pkg ? "consulting_pack" : "kickoff",
+      channel: "google_calendar",
+      origin: "consultoria-onboarding",
+      package_id: packageId,
     });
+    if (!openCalendarBooking({ packageId, origin: "consultoria-onboarding" })) {
+      scrollToSection("contacto");
+    }
   };
-
-  const stepTitle = t.steps[step];
 
   return (
-    <section
-      className="section-pad-default section-atmosphere section-atmosphere-matte border-y border-border/30"
+    <PageSection
+      id={CONSULTORIA_FUNNEL_KICKOFF_ID}
+      padding="default"
+      width="narrow"
+      tone="default"
       aria-labelledby="consultoria-onboarding-heading"
     >
-      <div className="container mx-auto max-w-3xl">
-        <div className="mb-8 space-y-4">
-          <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
-            {t.progressLabel} · {stepIndex + 1}/{ONBOARDING_STEPS.length}
-          </p>
-          <div
-            className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
-            role="progressbar"
-            aria-valuenow={progress}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label={t.progressLabel}
-          >
-            <div
-              className="h-full rounded-full bg-brand-gradient transition-all duration-300"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          <h2
-            id="consultoria-onboarding-heading"
-            className="text-2xl font-semibold tracking-tight"
-          >
-            {stepTitle}
-          </h2>
+      <SectionHeader
+        badge={copy.badge}
+        title={
+          pkg
+            ? copy.titlePack.replace("{name}", pkg.name[language])
+            : copy.titleEmpty
+        }
+        description={pkg ? copy.bodyPack : copy.bodyEmpty}
+        titleId="consultoria-onboarding-heading"
+        align="left"
+      />
 
-          {/* Chip de modalidad preelegida — evita re-preguntar en silencio */}
-          {packageLocked && step !== "package" && (
-            <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated px-3 py-2.5">
-              <Package className="h-4 w-4 text-primary shrink-0" aria-hidden />
-              <span className="text-sm text-foreground">
-                <span className="text-muted-foreground">
-                  {t.entry.selectedPackage}{" "}
-                </span>
-                <span className="font-medium">{pkg.name[language]}</span>
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="ml-auto h-8 text-xs text-primary"
-                onClick={openPackageStep}
-              >
-                {t.entry.changePackage}
-              </Button>
-            </div>
-          )}
-        </div>
+      {pkg ? (
+        <p className="mb-6 flex flex-wrap items-center gap-2 text-sm">
+          <span className="text-muted-foreground">{copy.packLabel}</span>
+          <Badge variant="outline">{pkg.packLabel[language]}</Badge>
+          <span className="text-foreground">{pkg.youGet[language]}</span>
+        </p>
+      ) : null}
 
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={step}
-            initial={prefersReducedMotion ? undefined : { opacity: 0, x: 12 }}
-            animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
-            exit={prefersReducedMotion ? undefined : { opacity: 0, x: -12 }}
-            transition={{ duration: 0.25 }}
-          >
-            {step === "welcome" && (
-              <Card className="border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-none">
-                <CardHeader>
-                  <CardTitle>{t.welcome.title}</CardTitle>
-                  <CardDescription>{t.welcome.description}</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <p className="rounded-lg border border-dashed border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-                    {t.previewNote}
-                  </p>
-                  <ul className="space-y-3" role="list">
-                    {t.welcome.points.map((point) => (
-                      <li
-                        key={point}
-                        className="flex items-start gap-2 text-sm text-muted-foreground"
-                      >
-                        <Check
-                          className="mt-0.5 h-4 w-4 shrink-0 text-primary"
-                          aria-hidden
-                        />
-                        {point}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            )}
-
-            {step === "package" && (
-              <div className="grid gap-4">
-                {CONSULTING_PACKAGES.map((item) => {
-                  const active = item.id === selectedPackage;
-                  return (
-                    <button
-                      key={item.id}
-                      type="button"
-                      onClick={() => setSelectedPackage(item.id)}
-                      className={cn(
-                        "rounded-xl border-2 p-5 text-left transition-all min-h-[44px]",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-                        active
-                          ? "border-primary/50 bg-primary/5"
-                          : "border-[color:var(--logo-surface-border)] bg-surface-matte-elevated hover:border-primary/25"
-                      )}
-                      aria-pressed={active}
-                    >
-                      <div className="flex flex-wrap items-start justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                          <Package className="h-5 w-5 text-primary" aria-hidden />
-                          <span className="text-lg font-semibold">
-                            {item.name[language]}
-                          </span>
-                        </div>
-                        {item.featured && (
-                          <Badge className="bg-brand-gradient text-white hover:opacity-90">
-                            {t.recommended}
-                          </Badge>
-                        )}
-                      </div>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        {item.tagline[language]}
-                      </p>
-                      <p className="mt-3 flex flex-wrap items-center gap-2 font-mono text-xs text-foreground/80">
-                        <span>{item.duration[language]}</span>
-                        <Badge
-                          variant="outline"
-                          className="font-sans text-[10px] uppercase tracking-wide"
-                        >
-                          {t.previewOnly}
-                        </Badge>
-                      </p>
-                      <ul className="mt-4 space-y-1.5" role="list">
-                        {item.deliverables[language].map((d) => (
-                          <li key={d} className="text-sm text-muted-foreground">
-                            · {d}
-                          </li>
-                        ))}
-                      </ul>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-
-            {step === "context" && (
-              <Card className="border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-none">
-                <CardContent className="space-y-6 pt-6">
-                  <div className="space-y-2">
-                    <Label htmlFor="consultoria-industry">
-                      {t.context.industry}
-                    </Label>
-                    <div
-                      className="flex flex-wrap gap-2"
-                      role="group"
-                      aria-label={t.context.industry}
-                    >
-                      {CONSULTING_INDUSTRIES[language].map((opt) => (
-                        <Button
-                          key={opt}
-                          type="button"
-                          size="sm"
-                          variant={industry === opt ? "default" : "outline"}
-                          className={
-                            industry === opt
-                              ? "bg-brand-gradient hover:opacity-90 min-h-[40px]"
-                              : "min-h-[40px]"
-                          }
-                          onClick={() => setIndustry(opt)}
-                        >
-                          {opt}
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="consultoria-timeline">
-                      {t.context.timeline}
-                    </Label>
-                    <div
-                      className="flex flex-wrap gap-2"
-                      role="group"
-                      aria-label={t.context.timeline}
-                    >
-                      {CONSULTING_TIMELINES[language].map((opt) => (
-                        <Button
-                          key={opt}
-                          type="button"
-                          size="sm"
-                          variant={timeline === opt ? "default" : "outline"}
-                          className={
-                            timeline === opt
-                              ? "bg-brand-gradient hover:opacity-90 min-h-[40px]"
-                              : "min-h-[40px]"
-                          }
-                          onClick={() => setTimeline(opt)}
-                        >
-                          {opt}
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="consultoria-goal">{t.context.goal}</Label>
-                    <Textarea
-                      id="consultoria-goal"
-                      value={goal}
-                      onChange={(e) => setGoal(e.target.value)}
-                      placeholder={t.context.goalPlaceholder}
-                      rows={5}
-                      className="resize-y"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      {t.context.goalHint}
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-
-            {step === "summary" && (
-              <Card className="border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-none">
-                <CardHeader>
-                  <CardTitle>{pkg.name[language]}</CardTitle>
-                  <CardDescription>{pkg.tagline[language]}</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4 text-sm">
-                  <p>
-                    <span className="font-medium text-foreground">
-                      {t.context.industry}:{" "}
-                    </span>
-                    {industry}
-                  </p>
-                  <p>
-                    <span className="font-medium text-foreground">
-                      {t.context.timeline}:{" "}
-                    </span>
-                    {timeline}
-                  </p>
-                  <p>
-                    <span className="font-medium text-foreground">
-                      {t.context.goal}:{" "}
-                    </span>
-                    {goal}
-                  </p>
-                  <p className="text-muted-foreground">{t.summary.note}</p>
-                </CardContent>
-              </Card>
-            )}
-          </motion.div>
-        </AnimatePresence>
-
-        <div className="mt-8 flex flex-wrap justify-between gap-3">
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={goBack}
-            disabled={stepIndex === 0 || (packageLocked && stepIndex === 2)}
-            className="min-h-[44px]"
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
-            {t.back}
-          </Button>
-          {/* When locked and on context, back can go to package if they want change — allow back to package */}
-          {step !== "summary" ? (
-            <Button
-              type="button"
-              onClick={goNext}
-              disabled={!canContinue}
-              className="bg-brand-gradient font-semibold hover:opacity-90 min-h-[44px]"
-            >
-              {t.next}
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              onClick={finish}
-              className="bg-brand-gradient font-semibold hover:opacity-90 min-h-[44px]"
-            >
-              {t.summary.cta}
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-            </Button>
-          )}
-        </div>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <Button
+          className="min-h-[44px] bg-brand-gradient font-semibold"
+          onClick={book}
+        >
+          <Calendar className="mr-2 h-4 w-4" aria-hidden />
+          {copy.ctaCalendar}
+        </Button>
+        <Button
+          variant="outline"
+          className="min-h-[44px]"
+          onClick={() => scrollToSection("contacto")}
+        >
+          <Mail className="mr-2 h-4 w-4" aria-hidden />
+          {copy.ctaMail}
+        </Button>
       </div>
-    </section>
+    </PageSection>
   );
 }

--- a/src/lib/consulting-pack-url.ts
+++ b/src/lib/consulting-pack-url.ts
@@ -1,0 +1,35 @@
+import type { ConsultingPackageId } from "../data/vientonorte-consulting";
+
+const PACKS = new Set<ConsultingPackageId>(["radar", "marco", "ops"]);
+
+export function isConsultingPackageId(
+  value: string | null | undefined
+): value is ConsultingPackageId {
+  return Boolean(value && PACKS.has(value as ConsultingPackageId));
+}
+
+/** Lee `pack` de `?pack=radar` (HashRouter: query después del hash). */
+export function parsePackFromSearch(
+  search: string
+): ConsultingPackageId | undefined {
+  const raw = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search
+  ).get("pack");
+  return isConsultingPackageId(raw) ? raw : undefined;
+}
+
+/** Appointment Schedule: Rö añade el campo pack; el query llega en la URL. */
+export function withPackQuery(
+  url: string,
+  pack?: ConsultingPackageId
+): string {
+  if (!pack) return url;
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set("pack", pack);
+    return parsed.toString();
+  } catch {
+    const join = url.includes("?") ? "&" : "?";
+    return `${url}${join}pack=${pack}`;
+  }
+}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -324,6 +324,18 @@ export default {
           fit: 'Budget',
           ariaLabel: 'Consulting funnel',
         },
+        onboarding: {
+          badge: 'Start',
+          titleEmpty: 'Pick a scope and book',
+          titlePack: 'Start {name}',
+          bodyEmpty:
+            'Diagnostic, prototype, or process. 30 min on Calendar or a short email.',
+          bodyPack:
+            'Calendar or email. If you added the pack field on the booking page, it arrives prefilled.',
+          packLabel: 'Format',
+          ctaCalendar: 'Book 30 min',
+          ctaMail: 'Write by email',
+        },
       },
       n2n: {
         badge: 'How we work',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -85,7 +85,7 @@ export default {
           /** SEM final URL: https://vientonorte.io/#/consultoria — message-match Ads */
           title: 'Consultoría UX · Elige tu alcance',
           description:
-            'Diagnóstico, prototipo, proceso de equipo o app. Design sprint y flujos UX. Gratis: accesibilidad WCAG 2.2 AA de un flujo. Pymes · kickoff <24 h.',
+            'Diagnóstico 5–7 días, prototipo o proceso de equipo. Gratis: accesibilidad WCAG 2.2 AA de un flujo. Kickoff 30 min.',
           keywords:
             'consultoría UX, design sprint, arquitectura fintech, flujos UX, UXtech, módulos producto, accesibilidad WCAG, front office, Viento Norte',
         },
@@ -323,6 +323,18 @@ export default {
           contact: 'Contacto',
           fit: 'Presupuesto',
           ariaLabel: 'Embudo de consultoría',
+        },
+        onboarding: {
+          badge: 'Empezar',
+          titleEmpty: 'Elige un alcance y agenda',
+          titlePack: 'Empezar {name}',
+          bodyEmpty:
+            'Diagnóstico, prototipo o proceso. 30 min en Calendar o un mail con el motivo.',
+          bodyPack:
+            'Calendar o mail. Si añadiste el campo pack en la agenda, llega prellenado.',
+          packLabel: 'Modalidad',
+          ctaCalendar: 'Agendar 30 min',
+          ctaMail: 'Escribir por mail',
         },
       },
       n2n: {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -16,8 +16,9 @@ export const ROUTES = {
   designSystem: "/design-system",
 
   /**
-   * Landing SEM / paid · tour oferta módulos-producto (fullscreen Apple).
-   * Ads final URL: https://vientonorte.io/#/consultoria
+   * Landing SEM / paid · funnel 3 packs + OB (mismo craft que home).
+   * Ads crawler: https://vientonorte.io/s/consultoria
+   * Tour módulos: /consultoria/modulos/:id
    */
   consulting: "/consultoria",
 

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -1,7 +1,10 @@
 /** Contacto canónico — Viento Norte / Rodrigo Gaete */
 
+import type { ConsultingPackageId } from "../data/vientonorte-consulting";
+import { withPackQuery } from "./consulting-pack-url";
+
 /** Alias público (Email Routing → inbox privado). No publicar Gmail en el sitio. */
-export const PUBLIC_CONTACT_EMAIL = 'contacto@vientonorte.io';
+export const PUBLIC_CONTACT_EMAIL = "contacto@vientonorte.io";
 
 /**
  * Inbox real para FormSubmit (action del form, no se muestra en UI).
@@ -58,16 +61,28 @@ export function openA11yFreeScheduleOrFallback(fallback: () => void): boolean {
 }
 
 /** CTA único de agendamiento (Google Appointment) + registro Worker. */
-export function openCalendarBooking(): boolean {
+export function openCalendarBooking(opts?: {
+  packageId?: ConsultingPackageId;
+  origin?: string;
+}): boolean {
   if (!A11Y_FREE_SCHEDULE_URL) return false;
+  const packageId = opts?.packageId;
+  const origin = opts?.origin ?? "calendar-cta";
   void import("./vn-booking").then(({ recordBookingIntent }) =>
     recordBookingIntent({
-      origin: "calendar-cta",
-      intent: "radar-free",
-      notes: "Click Agendar · Google Appointment",
+      origin,
+      intent: packageId ? "consulting" : "radar-free",
+      notes: packageId
+        ? `Click Agendar · pack ${packageId}`
+        : "Click Agendar · Google Appointment",
+      packageId,
     })
   );
-  window.open(A11Y_FREE_SCHEDULE_URL, "_blank", "noopener,noreferrer");
+  window.open(
+    withPackQuery(A11Y_FREE_SCHEDULE_URL, packageId),
+    "_blank",
+    "noopener,noreferrer"
+  );
   return true;
 }
 

--- a/src/lib/vn-booking.ts
+++ b/src/lib/vn-booking.ts
@@ -12,6 +12,7 @@ export async function recordBookingIntent(params: {
   origin: string;
   intent?: BookingIntent;
   notes?: string;
+  packageId?: string;
 }): Promise<void> {
   const session = readContactSession();
   const name = session?.name.trim() ?? "";
@@ -22,6 +23,7 @@ export async function recordBookingIntent(params: {
     origin: params.origin,
     intent: params.intent ?? "kickoff",
     has_identity: Boolean(name && email),
+    package_id: params.packageId,
   });
 
   try {

--- a/src/pages/ConsultoriaVientoNorte.tsx
+++ b/src/pages/ConsultoriaVientoNorte.tsx
@@ -4,6 +4,7 @@ import { SEOHead } from "../components/atoms/SEOHead";
 import { PageShell } from "../components/layout/PageShell";
 import { ConsultoriaLandingHero } from "../components/organisms/ConsultoriaLandingHero";
 import { ConsultoriaPackages } from "../components/organisms/ConsultoriaPackages";
+import { ConsultoriaOnboarding } from "../components/organisms/ConsultoriaOnboarding";
 import { Contact } from "../components/organisms/Contact";
 import { ProcessNavigation } from "../components/molecules/ProcessNavigation";
 import { StickyCTA } from "../components/molecules/StickyCTA";
@@ -22,6 +23,8 @@ import {
 } from "../lib/navigate-to-section";
 import { consumePendingSectionScroll } from "../lib/normalize-hash-url";
 import { scrollToSection } from "../lib/scroll-to-section";
+import { parsePackFromSearch } from "../lib/consulting-pack-url";
+import { CONSULTORIA_FUNNEL_KICKOFF_ID } from "../lib/nav-config";
 import type { ProcessNavSection } from "../hooks/useProcessSectionSpy";
 
 type ConsultoriaLocationState = SectionScrollState & {
@@ -38,7 +41,7 @@ export default function ConsultoriaVientoNorte() {
 
   const [selectedPackage, setSelectedPackage] = useState<
     ConsultingPackageId | undefined
-  >(() => entryState?.recommendedPackage);
+  >(() => entryState?.recommendedPackage ?? parsePackFromSearch(location.search));
 
   useEffect(() => {
     const state = location.state as ConsultoriaLocationState | null;
@@ -54,9 +57,11 @@ export default function ConsultoriaVientoNorte() {
     });
   }, [location.pathname, location.state, navigate]);
 
-  const goContactWithPackage = (packageId?: ConsultingPackageId) => {
+  const goOnboardWithPackage = (packageId?: ConsultingPackageId) => {
     if (packageId) setSelectedPackage(packageId);
-    requestAnimationFrame(() => scrollToSection("contacto"));
+    requestAnimationFrame(() =>
+      scrollToSection(CONSULTORIA_FUNNEL_KICKOFF_ID)
+    );
   };
 
   const contactDraft = useMemo<ContactDraft>(
@@ -76,7 +81,12 @@ export default function ConsultoriaVientoNorte() {
   const funnelSections: ProcessNavSection[] = useMemo(
     () => [
       { id: "modalidades", label: funnelNav.packages, number: "01" },
-      { id: "contacto", label: funnelNav.contact, number: "02" },
+      {
+        id: CONSULTORIA_FUNNEL_KICKOFF_ID,
+        label: funnelNav.start,
+        number: "02",
+      },
+      { id: "contacto", label: funnelNav.contact, number: "03" },
     ],
     [funnelNav.contact, funnelNav.packages]
   );
@@ -109,7 +119,7 @@ export default function ConsultoriaVientoNorte() {
         data-role={isHomeSurface ? "fo-home" : "fo-sem-offer"}
         data-first-value-budget-ms={29000}
         data-calendar-sla-ms={30000}
-        data-analytics="deferred-no-gtm"
+        data-analytics="gtm-pm5lbqrp"
       >
         <SEOHead
           {...(isHomeSurface ? t.seo.pages.home : t.seo.pages.consultoria)}
@@ -139,8 +149,10 @@ export default function ConsultoriaVientoNorte() {
         />
 
         <ConsultoriaPackages
-          onSelectPackage={(id) => goContactWithPackage(id)}
+          onSelectPackage={(id) => goOnboardWithPackage(id)}
         />
+
+        <ConsultoriaOnboarding packageId={selectedPackage} />
 
         <section
           id="mas-del-sitio"
@@ -174,7 +186,13 @@ export default function ConsultoriaVientoNorte() {
           label={t.consultoria.stickyCta}
           ariaLabel={t.consultoria.stickyCta}
           onClick={() => {
-            if (!openCalendarBooking()) scrollToSection("contacto");
+            if (
+              !openCalendarBooking({
+                packageId: selectedPackage,
+                origin: "sticky-cta",
+              })
+            )
+              scrollToSection("contacto");
           }}
           showAfterScroll={480}
         />


### PR DESCRIPTION
## Decide
`/#/consultoria` se queda y se **arregla** como landing SEM. No deprecar. No pagar a `/`.

## Qué
- Misma superficie que el home: 3 packs → `#consultoria-onboarding` → Calendar / mail
- `?pack=radar|marco|ops` en HashRouter y en la URL de Appointment
- `book_call` / `generate_lead` llevan `package_id`
- Tour fullscreen solo en `/#/consultoria/modulos/:id`
- `docs/BLUEPRINT-SEO-SEM.md` + receta GTM v3

## QA
- Typecheck local OK
- Vitest local no arrancó (pool worker); CI es la evidencia

## No
Ads · Fastly · snippet gtag