### PR TITLE
fix(consultoria): QA /vn-agent en SEM (Gratis a11y + Ver opciones)

### DIFF
--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import { ArrowRight } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -5,6 +6,7 @@ import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { trackEvent } from "../../lib/analytics";
 import { openCalendarBooking } from "../../lib/site-contact";
+import { openFreeRadarEntry } from "../../lib/free-radar-entry";
 import { scrollToSection } from "../../lib/scroll-to-section";
 
 interface ConsultoriaLandingHeroProps {
@@ -18,6 +20,7 @@ interface ConsultoriaLandingHeroProps {
 export function ConsultoriaLandingHero({
   onExploreEvidence,
 }: ConsultoriaLandingHeroProps) {
+  const navigate = useNavigate();
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.landing;
   const es = language === "es";
@@ -74,6 +77,18 @@ export function ConsultoriaLandingHero({
               {t.ctaPrimary}
               <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
             </Button>
+            <button
+              type="button"
+              onClick={() => {
+                trackEvent("consultoria_hero_cta", { action: "free_a11y" });
+                openFreeRadarEntry(navigate, language, "consultoria-hero", {
+                  mode: "auto",
+                });
+              }}
+              className="min-h-[44px] text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              {t.ctaFreeA11y}
+            </button>
             <button
               type="button"
               onClick={seeOptions}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -254,7 +254,8 @@ export default {
         transparencyLine:
           'Free Diagnostic entry: WCAG 2.2 AA review of one critical flow. If it fits, let’s talk full Diagnostic (5–7 days).',
         ctaPrimary: 'Book on Google Calendar',
-        ctaSecondary: 'See scopes',
+        ctaSecondary: 'See options',
+        ctaFreeA11y: 'Free · accessibility',
         /** Lead magnet — regulated-product job language, not WCAG jargon in the link */
         ctaFreeLink: 'Free review of one critical flow',
         ctaFreeLinkSchedule: 'Book 30 free minutes on Google Calendar',
@@ -1058,7 +1059,7 @@ export default {
     
     // Contact
     contact: {
-      badge: 'Let\'s talk',
+      badge: "Let's talk",
       title: 'Get in touch',
       description: 'Available for freelance projects and full-time opportunities. Typical reply: under 24 h.',
       responseBadge: 'Typical reply: under 24 h',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -254,7 +254,8 @@ export default {
         transparencyLine:
           'Entrada gratis a Diagnóstico: revisión WCAG 2.2 AA de un flujo crítico. Si aplica, conversemos el Diagnóstico completo (5–7 días).',
         ctaPrimary: 'Agendar en Google Calendar',
-        ctaSecondary: 'Ver alcances',
+        ctaSecondary: 'Ver opciones',
+        ctaFreeA11y: 'Gratis · accesibilidad',
         /** Free a11y — con agenda: copy de Calendar; sin agenda: mensaje */
         ctaFreeLink: 'Revisión gratis de un flujo crítico',
         ctaFreeLinkSchedule: 'Reservar 30 min gratis en Google Calendar',

--- a/src/pages/ConsultoriaVientoNorte.tsx
+++ b/src/pages/ConsultoriaVientoNorte.tsx
@@ -155,6 +155,49 @@ export default function ConsultoriaVientoNorte() {
         <ConsultoriaOnboarding packageId={selectedPackage} />
 
         <section
+          id="metodo-n2n"
+          className="container mx-auto max-w-2xl px-4 py-8 text-center"
+        >
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            {t.consultoria.n2n.badge}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t.consultoria.n2n.description}
+          </p>
+          <Link
+            className="mt-3 inline-block text-sm underline-offset-4 hover:underline"
+            to={ROUTES.process}
+          >
+            {language === "es" ? "Ver método" : "See method"}
+          </Link>
+        </section>
+
+        <section
+          id="consultoria-demo"
+          className="container mx-auto max-w-2xl px-4 pb-8 text-center"
+        >
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            {funnelNav.evidence}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {language === "es"
+              ? "Demos y casos viven en páginas interiores, no en este landing SEM."
+              : "Demos and cases live on interior pages, not on this SEM landing."}
+          </p>
+          <div className="mt-3 flex flex-wrap justify-center gap-3 text-sm">
+            <Link className="underline-offset-4 hover:underline" to={ROUTES.projects}>
+              {language === "es" ? "Proyectos" : "Projects"}
+            </Link>
+            <Link
+              className="underline-offset-4 hover:underline"
+              to={ROUTES.consultingModule("dashboard")}
+            >
+              {language === "es" ? "Tour de módulos" : "Module tour"}
+            </Link>
+          </div>
+        </section>
+
+        <section
           id="mas-del-sitio"
           className="container mx-auto max-w-2xl px-4 py-8 text-center"
         >
@@ -163,17 +206,6 @@ export default function ConsultoriaVientoNorte() {
               ? "Método, casos y oferta completa están en páginas interiores."
               : "Method, cases, and the full offer live on interior pages."}
           </p>
-          <div className="flex flex-wrap justify-center gap-3 text-sm">
-            <Link className="underline-offset-4 hover:underline" to={ROUTES.process}>
-              {language === "es" ? "Proceso" : "Process"}
-            </Link>
-            <Link className="underline-offset-4 hover:underline" to={ROUTES.projects}>
-              {language === "es" ? "Proyectos" : "Projects"}
-            </Link>
-            <Link className="underline-offset-4 hover:underline" to={ROUTES.consulting}>
-              {language === "es" ? "Oferta / tour" : "Offer / tour"}
-            </Link>
-          </div>
         </section>
 
         <Contact


### PR DESCRIPTION
El QA Playwright 28/28 no era /vn-agent. La matrix seo-vn + google-ads-vn fallaba 19 checks.

## Qué
- CTA **Gratis · accesibilidad** → openFreeRadarEntry (no /#/auditoria)
- **Ver opciones** (antes Ver alcances)
- Anclas \`#metodo-n2n\` y \`#consultoria-demo\` (interiores, slim)
- Tour de módulos ya no apunta a sí mismo

## Evidence
\`local-onboarding-smoke.sh\` 111/111 PASS
\`local-ads-scenarios.sh\` ADS_STATIC 8/8 PASS