### PR TITLE
fix(consultoria): el paso 02 del funnel se ve (no hueco blanco)

### DIFF
--- a/src/components/molecules/ProcessNavigation.tsx
+++ b/src/components/molecules/ProcessNavigation.tsx
@@ -19,7 +19,7 @@ export function ProcessNavigation({ sections, mobileAriaLabel }: ProcessNavigati
     <>
       {/* Mobile: sticky horizontal section nav */}
       <nav
-        className="process-nav-mobile xl:hidden sticky z-40 border-b border-border/50 bg-background/95 backdrop-blur-md supports-[backdrop-filter]:bg-background/85"
+        className="process-nav-mobile lg:hidden sticky z-40 border-b border-border/50 bg-background/95 backdrop-blur-md supports-[backdrop-filter]:bg-background/85"
         style={{ top: "var(--process-nav-mobile-top, 3.25rem)" }}
         aria-label={mobileAriaLabel ?? "Secciones de la página"}
       >
@@ -60,7 +60,7 @@ export function ProcessNavigation({ sections, mobileAriaLabel }: ProcessNavigati
             ? { duration: 0 }
             : { duration: 0.25, ease: [0.4, 0, 0.2, 1], delay: 0.15 }
         }
-        className="hidden xl:block fixed right-8 top-1/2 -translate-y-1/2 z-30"
+        className="hidden lg:block fixed right-6 top-1/2 z-30 -translate-y-1/2"
       >
         <Card className="p-4 bg-background/95 backdrop-blur-lg border-2 shadow-xl max-w-[200px]">
           <nav aria-label={mobileAriaLabel ?? "Process navigation"}>

--- a/src/components/organisms/ConsultoriaOnboarding.tsx
+++ b/src/components/organisms/ConsultoriaOnboarding.tsx
@@ -44,7 +44,7 @@ export function ConsultoriaOnboarding({ packageId }: ConsultoriaOnboardingProps)
       aria-labelledby="consultoria-onboarding-heading"
     >
       <div className="container mx-auto max-w-xl rounded-2xl border-2 border-primary/25 bg-background p-5 shadow-sm md:p-6">
-        <p className="mb-2 text-xs font-bold uppercase tracking-wide text-primary">
+        <p className="mb-2 text-xs font-bold uppercase tracking-wide text-foreground">
           02 · {copy.badge}
         </p>
         <h2

--- a/src/components/organisms/ConsultoriaOnboarding.tsx
+++ b/src/components/organisms/ConsultoriaOnboarding.tsx
@@ -1,11 +1,7 @@
 import { Calendar, Mail } from "lucide-react";
-import { PageSection } from "../layout/PageSection";
-import { SectionHeader } from "../molecules/SectionHeader";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import {
-  CONSULTORIA_FUNNEL_KICKOFF_ID,
-} from "../../lib/nav-config";
+import { CONSULTORIA_FUNNEL_KICKOFF_ID } from "../../lib/nav-config";
 import {
   getConsultingPackage,
   type ConsultingPackageId,
@@ -25,6 +21,9 @@ export function ConsultoriaOnboarding({ packageId }: ConsultoriaOnboardingProps)
   const landing = useTranslation(language).consultoria.landing;
   const copy = landing.onboarding;
   const pkg = packageId ? getConsultingPackage(packageId) : undefined;
+  const title = pkg
+    ? copy.titlePack.replace("{name}", pkg.name[language])
+    : copy.titleEmpty;
 
   const book = () => {
     analytics.generateLead({
@@ -39,50 +38,49 @@ export function ConsultoriaOnboarding({ packageId }: ConsultoriaOnboardingProps)
   };
 
   return (
-    <PageSection
+    <section
       id={CONSULTORIA_FUNNEL_KICKOFF_ID}
-      padding="default"
-      width="narrow"
-      tone="default"
+      className="scroll-mt-[calc(var(--header-height)+0.75rem)] border-y border-border/60 bg-muted/25 px-4 py-8 md:py-10"
       aria-labelledby="consultoria-onboarding-heading"
     >
-      <SectionHeader
-        badge={copy.badge}
-        title={
-          pkg
-            ? copy.titlePack.replace("{name}", pkg.name[language])
-            : copy.titleEmpty
-        }
-        description={pkg ? copy.bodyPack : copy.bodyEmpty}
-        titleId="consultoria-onboarding-heading"
-        align="left"
-      />
-
-      {pkg ? (
-        <p className="mb-6 flex flex-wrap items-center gap-2 text-sm">
-          <span className="text-muted-foreground">{copy.packLabel}</span>
-          <Badge variant="outline">{pkg.packLabel[language]}</Badge>
-          <span className="text-foreground">{pkg.youGet[language]}</span>
+      <div className="container mx-auto max-w-xl rounded-2xl border-2 border-primary/25 bg-background p-5 shadow-sm md:p-6">
+        <p className="mb-2 text-xs font-bold uppercase tracking-wide text-primary">
+          02 · {copy.badge}
         </p>
-      ) : null}
-
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Button
-          className="min-h-[44px] bg-brand-gradient font-semibold"
-          onClick={book}
+        <h2
+          id="consultoria-onboarding-heading"
+          className="text-xl font-semibold tracking-tight md:text-2xl"
         >
-          <Calendar className="mr-2 h-4 w-4" aria-hidden />
-          {copy.ctaCalendar}
-        </Button>
-        <Button
-          variant="outline"
-          className="min-h-[44px]"
-          onClick={() => scrollToSection("contacto")}
-        >
-          <Mail className="mr-2 h-4 w-4" aria-hidden />
-          {copy.ctaMail}
-        </Button>
+          {title}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {pkg ? copy.bodyPack : copy.bodyEmpty}
+        </p>
+        {pkg ? (
+          <p className="mt-3 flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-muted-foreground">{copy.packLabel}</span>
+            <Badge variant="outline">{pkg.packLabel[language]}</Badge>
+            <span>{pkg.youGet[language]}</span>
+          </p>
+        ) : null}
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+          <Button
+            className="min-h-[44px] bg-brand-gradient font-semibold"
+            onClick={book}
+          >
+            <Calendar className="mr-2 h-4 w-4" aria-hidden />
+            {copy.ctaCalendar}
+          </Button>
+          <Button
+            variant="outline"
+            className="min-h-[44px]"
+            onClick={() => scrollToSection("contacto")}
+          >
+            <Mail className="mr-2 h-4 w-4" aria-hidden />
+            {copy.ctaMail}
+          </Button>
+        </div>
       </div>
-    </PageSection>
+    </section>
   );
 }


### PR DESCRIPTION
En live el funnel existe (01 Modalidades · 02 Empezar · 03 Contacto) pero el paso 02 quedaba en blanco: \`SectionHeader\` arranca en opacity 0 y \`whileInView\` no disparaba.

## Qué
- Card **02 · Empezar** siempre visible (título + Calendar + mail)
- Rail del funnel desde \`lg\` (no solo \`xl\`)

## No
Ads.