### PR TITLE
fix(seo): /s/consultoria etiquetada con GTM-PM5LBQRP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — `/s/consultoria` lleva GTM
+
+### Fixed
+- La final URL paid ya no está “sin etiquetar”: snippet `GTM-PM5LBQRP` en el HTML estático (sin segundo gtag).
+- El redirect a `/#/consultoria` espera el hit y conserva `gclid` / UTM.
+
 ## [2026-08-16] — Demo timed: marca VN + a11y AA
 
 ### Changed

--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -4,7 +4,8 @@
 **Contenedor:** `GTM-PM5LBQRP` (Web · Viento Norte / vientonorte.io).  
 **GA4:** `G-G7JXJKGCDV` — solo como **Etiqueta de Google** dentro de GTM.  
 **Secret:** `VITE_GTM_ID` seteado 2026-08-15. **No** `VITE_GA_MEASUREMENT_ID` (apuesta A: no segundo snippet gtag).  
-**Anti-patrón:** no pegar el snippet GTM ni el de `gtag.js` en `index.html`.
+**Anti-patrón:** no pegar el snippet GTM ni el de `gtag.js` en el `index.html` del SPA (ahí entra por `VITE_GTM_ID` + `initGTM`).  
+**Excepción:** `public/s/consultoria/index.html` sí lleva el snippet `GTM-PM5LBQRP` (sin `gtag.js`). Es la final URL paid; GA4/Ads leen ese HTML y lo marcaban *Sin etiquetar*.
 
 El ID es público (sale en el bundle). El valor vive en GitHub Secrets para no hardcodear.
 

--- a/docs/SEO-DOMAIN-AND-GTM.md
+++ b/docs/SEO-DOMAIN-AND-GTM.md
@@ -16,10 +16,13 @@
 
 ## Search Console
 
-Ver guía hub: `vientonorte.github.io/docs/SEO-AND-SEARCH-CONSOLE.md`
+**16 ago 2026 — vinculación GA4 creada (humano).**  
+Tipo: **prefijo de URL** `https://vientonorte.io/` · property `vientonorte.io`.  
+GA4 `G-G7JXJKGCDV` ↔ esa property. Datos orgánicos en GA4 pueden tardar 24–48 h.
 
-1. Property dominio `vientonorte.io`  
-2. Sitemap principal: `https://vientonorte.io/sitemap.xml`  
+1. Property **prefijo** `https://vientonorte.io/` (hecha). Property de **dominio** (DNS) = opcional, cubre http/www.
+2. Sitemap: `https://vientonorte.io/sitemap.xml` — enviar en GSC si aún no está.
+3. Verificación en repo: `public/google5858e011b32ea566.html`  
 
 ## GTM unificado (plan-gtm) — parked post-Test path
 

--- a/public/s/consultoria/index.html
+++ b/public/s/consultoria/index.html
@@ -67,12 +67,60 @@
         ]
       }
     </script>
-    <meta http-equiv="refresh" content="0;url=https://vientonorte.io/#/consultoria" />
+    <!--
+      Final URL paid / GA4 “Detalles de páginas”.
+      El SPA carga GTM por initGTM; este HTML estático no ejecuta la app,
+      así que el crawler veía “Sin etiquetar”. Un solo contenedor, sin gtag.js.
+    -->
     <script>
-      location.replace("https://vientonorte.io/#/consultoria");
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "page_view",
+        page_path: "/s/consultoria",
+        page_location: "https://vientonorte.io/s/consultoria/",
+        page_title: "Consultoría UX · Viento Norte",
+      });
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        j.setAttribute("data-gtm-id", i);
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-PM5LBQRP");
+    </script>
+    <meta
+      http-equiv="refresh"
+      content="2;url=https://vientonorte.io/#/consultoria"
+    />
+    <script>
+      (function () {
+        var q = window.location.search || "";
+        var dest = "https://vientonorte.io/" + q + "#/consultoria" + q;
+        function go() {
+          window.location.replace(dest);
+        }
+        var gtm = document.querySelector('script[data-gtm-id="GTM-PM5LBQRP"]');
+        if (gtm) gtm.addEventListener("load", function () { window.setTimeout(go, 400); });
+        window.setTimeout(go, 1500);
+      })();
     </script>
   </head>
   <body>
-    <p><a href="https://vientonorte.io/#/consultoria">Consultoría Viento Norte</a></p>
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-PM5LBQRP"
+        title="Google Tag Manager"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe>
+    </noscript>
+    <p>
+      <a href="https://vientonorte.io/#/consultoria">Consultoría Viento Norte</a>
+    </p>
   </body>
 </html>

--- a/src/__tests__/lib/share-consultoria-gtm.test.ts
+++ b/src/__tests__/lib/share-consultoria-gtm.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const html = readFileSync(
+  resolve(process.cwd(), "public/s/consultoria/index.html"),
+  "utf8"
+);
+
+describe("share /s/consultoria GTM", () => {
+  it("embeds the single GTM container and no parallel gtag snippet", () => {
+    expect(html).toContain("GTM-PM5LBQRP");
+    expect(html).toContain('data-gtm-id');
+    expect(html).toContain("page_location");
+    expect(html).toContain("/s/consultoria/");
+    expect(html).not.toMatch(/gtag\/js\?id=G-/);
+    expect(html).not.toContain("G-G7JXJKGCDV");
+  });
+
+  it("keeps Ads click IDs on the funnel redirect", () => {
+    expect(html).toContain("location.search");
+    expect(html).toContain("#/consultoria");
+  });
+
+  it("names the noscript iframe for a11y", () => {
+    expect(html).toMatch(/iframe[\s\S]*title="Google Tag Manager"/);
+  });
+});


### PR DESCRIPTION
## Por qué
GA4 **Detalles de páginas** marca `vientonorte.io/s/consultoria/` como **Sin etiquetar**. Esa URL es la final paid: el HTML estático redirige y no corre el SPA, así que no pasaba por `initGTM`.

## Qué cambia
- Snippet **solo** `GTM-PM5LBQRP` en `public/s/consultoria/index.html` (sin `gtag.js` / sin `G-`).
- `page_view` con `page_location` de `/s/consultoria/`.
- Redirect a `/#/consultoria` espera ~1.5 s y conserva `gclid` / UTM.
- iframe noscript con `title`.

## No
- No segundo gtag.
- No spend Ads.