### PR TITLE
feat(api): Measurement Protocol generate_lead + book_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — Measurement Protocol desde el Worker
+
+### Added
+- El API manda `generate_lead` y `book_call` a GA4 (`G-G7JXJKGCDV`) al guardar lead o agenda.
+- Secreto `GA4_MP_API_SECRET` solo en Wrangler (no en git).
+
 ## [2026-08-16] — `/s/consultoria` lleva GTM
 
 ### Fixed

--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -4,6 +4,10 @@
 **Contenedor:** `GTM-PM5LBQRP` (Web · Viento Norte / vientonorte.io).  
 **GA4:** `G-G7JXJKGCDV` — solo como **Etiqueta de Google** dentro de GTM.  
 **Secret:** `VITE_GTM_ID` seteado 2026-08-15. **No** `VITE_GA_MEASUREMENT_ID` (apuesta A: no segundo snippet gtag).  
+**Measurement Protocol (Worker):** secreto `GA4_MP_API_SECRET` (apodo GA4 `ia`) vía `wrangler secret put`.  
+`GA4_MEASUREMENT_ID=G-G7JXJKGCDV` en `worker/wrangler.toml`.  
+El Worker manda `generate_lead` / `book_call` al persistir lead o agenda. **Nunca** commitear el valor del secreto.
+
 **Anti-patrón:** no pegar el snippet GTM ni el de `gtag.js` en el `index.html` del SPA (ahí entra por `VITE_GTM_ID` + `initGTM`).  
 **Excepción:** `public/s/consultoria/index.html` sí lleva el snippet `GTM-PM5LBQRP` (sin `gtag.js`). Es la final URL paid; GA4/Ads leen ese HTML y lo marcaban *Sin etiquetar*.
 

--- a/src/lib/vn-booking.ts
+++ b/src/lib/vn-booking.ts
@@ -36,6 +36,7 @@ export async function recordBookingIntent(params: {
         notes: params.notes ?? "",
         intent: params.intent ?? "kickoff",
         origin: params.origin,
+        packageId: params.packageId,
       }),
     });
   } catch {

--- a/worker/src/__tests__/ga4-mp.test.js
+++ b/worker/src/__tests__/ga4-mp.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildGa4MpPayload, ga4MpConfigured } from '../lib/ga4-mp.js';
+
+describe('ga4-mp', () => {
+  it('is off without secret', () => {
+    expect(ga4MpConfigured({})).toBe(false);
+    expect(ga4MpConfigured({ GA4_MP_API_SECRET: 'x' })).toBe(true);
+  });
+
+  it('builds a collect payload without empty params', () => {
+    const payload = buildGa4MpPayload({
+      clientId: 'cid.1',
+      eventName: 'book_call',
+      params: { origin: 'sticky-cta', package_id: 'radar', skip: '' },
+    });
+    expect(payload.client_id).toBe('cid.1');
+    expect(payload.events[0].name).toBe('book_call');
+    expect(payload.events[0].params.origin).toBe('sticky-cta');
+    expect(payload.events[0].params.package_id).toBe('radar');
+    expect(payload.events[0].params.skip).toBeUndefined();
+    expect(payload.events[0].params.engagement_time_msec).toBe(1);
+  });
+});

--- a/worker/src/api/public.js
+++ b/worker/src/api/public.js
@@ -2,6 +2,7 @@ import { json } from '../lib/cors.js';
 import { getCases, getCompany, getServices } from '../data/catalog.js';
 import { listRecords, newId, nowIso, prependRecord, updateRecord } from '../lib/store.js';
 import { notifyInbox, notifyVisitor } from '../lib/notify.js';
+import { ga4MpConfigured, sendGa4MpEvent } from '../lib/ga4-mp.js';
 
 const MAX_NAME = 120;
 const MAX_EMAIL = 254;
@@ -27,6 +28,7 @@ export function handleHealth(env, cors) {
       service: 'vientonorte-api',
       time: nowIso(),
       kv: Boolean(env.ADMIN_KV),
+      ga4Mp: ga4MpConfigured(env),
     },
     200,
     cors
@@ -145,6 +147,17 @@ export async function handleCreateLead(request, env, cors, { persistOnly = false
     channel: 'leads',
   });
 
+  const packageId =
+    typeof body.packageId === 'string' ? body.packageId.trim().slice(0, 40) : '';
+  await sendGa4MpEvent(env, {
+    eventName: 'generate_lead',
+    params: {
+      lead_type: intent || 'form',
+      channel: 'leads',
+      package_id: packageId,
+    },
+  });
+
   return json({ ok: true, lead: { id: record.id, status: record.status } }, 201, cors);
 }
 
@@ -161,6 +174,12 @@ export async function handleCreateBooking(request, env, cors) {
   const notes = typeof body.notes === 'string' ? body.notes.trim().slice(0, MAX_TEXT) : '';
   const intent = typeof body.intent === 'string' ? body.intent.trim().slice(0, 80) : 'kickoff';
   const origin = typeof body.origin === 'string' ? body.origin.trim().slice(0, 80) : '';
+  const packageId =
+    typeof body.packageId === 'string'
+      ? body.packageId.trim().slice(0, 40)
+      : typeof body.package_id === 'string'
+        ? body.package_id.trim().slice(0, 40)
+        : '';
   const phone = typeof body.phone === 'string' ? body.phone.trim().slice(0, 40) : '';
   const website = typeof body.website === 'string' ? body.website.trim().slice(0, 400) : '';
   const startAt = typeof body.startAt === 'string' ? body.startAt.trim().slice(0, 40) : '';
@@ -187,6 +206,14 @@ export async function handleCreateBooking(request, env, cors) {
       };
       const updated = await updateRecord(env, 'bookings', dup.id, merged);
       await upsertLeadFromBooking(env, { ...dup, ...merged, intent, origin });
+      await sendGa4MpEvent(env, {
+        eventName: 'book_call',
+        params: {
+          origin,
+          intent,
+          package_id: packageId,
+        },
+      });
       return json({ ok: true, booking: updated, deduped: true }, 200, cors);
     }
   }
@@ -209,6 +236,14 @@ export async function handleCreateBooking(request, env, cors) {
   };
   await prependRecord(env, 'bookings', record);
   await upsertLeadFromBooking(env, record);
+  await sendGa4MpEvent(env, {
+    eventName: 'book_call',
+    params: {
+      origin,
+      intent,
+      package_id: packageId,
+    },
+  });
 
   const subject = email
     ? `VN · agenda · ${name}${startAt ? ` · ${startAt}` : ''}`

--- a/worker/src/contact.js
+++ b/worker/src/contact.js
@@ -1,6 +1,7 @@
 import { json } from './lib/cors.js';
 import { persistLead } from './api/public.js';
 import { buildAdminEmail, buildVisitorConfirmation } from './lib/email-templates.js';
+import { sendGa4MpEvent } from './lib/ga4-mp.js';
 
 const MAX_NAME = 120;
 const MAX_EMAIL = 254;
@@ -184,6 +185,21 @@ export async function handleContact(request, env, cors) {
       fromEmail,
       fromName,
       language: safeLanguage,
+    });
+  }
+
+  if (stored || sent.ok) {
+    const packageId =
+      typeof body.packageId === 'string'
+        ? body.packageId.trim().slice(0, 40)
+        : '';
+    await sendGa4MpEvent(env, {
+      eventName: 'generate_lead',
+      params: {
+        lead_type: safeIntent || 'contact',
+        channel: 'contact',
+        package_id: packageId,
+      },
     });
   }
 

--- a/worker/src/lib/ga4-mp.js
+++ b/worker/src/lib/ga4-mp.js
@@ -1,0 +1,56 @@
+/**
+ * GA4 Measurement Protocol (server). Secret: wrangler secret put GA4_MP_API_SECRET
+ * Never log the secret. Skip if unset.
+ */
+
+const MP_URL = 'https://www.google-analytics.com/mp/collect';
+const DEFAULT_MEASUREMENT_ID = 'G-G7JXJKGCDV';
+
+export function ga4MpConfigured(env) {
+  return Boolean(env?.GA4_MP_API_SECRET && (env.GA4_MEASUREMENT_ID || DEFAULT_MEASUREMENT_ID));
+}
+
+export function buildGa4MpPayload({
+  clientId,
+  eventName,
+  params = {},
+}) {
+  const clean = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    clean[key] = value;
+  }
+  return {
+    client_id: clientId || crypto.randomUUID(),
+    events: [
+      {
+        name: eventName,
+        params: {
+          engagement_time_msec: 1,
+          ...clean,
+        },
+      },
+    ],
+  };
+}
+
+export async function sendGa4MpEvent(env, { eventName, params, clientId }) {
+  const secret = env?.GA4_MP_API_SECRET;
+  const measurementId = env?.GA4_MEASUREMENT_ID || DEFAULT_MEASUREMENT_ID;
+  if (!secret || !eventName) return { ok: false, skipped: true };
+
+  const payload = buildGa4MpPayload({ clientId, eventName, params });
+  const url = `${MP_URL}?measurement_id=${encodeURIComponent(measurementId)}&api_secret=${encodeURIComponent(secret)}`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return { ok: res.ok, status: res.status };
+  } catch (err) {
+    console.warn('[ga4-mp] send failed:', err?.message || err);
+    return { ok: false, error: 'network' };
+  }
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -21,9 +21,12 @@ WEBAUTHN_RP_ID = "vientonorte.io"
 CALENDAR_BOOKING_URL = "https://calendar.app.google/NvXgpHrpSnJ2186X7"
 # R2_PUBLIC_BASE = "https://pub-xxxx.r2.dev"  # tras habilitar acceso público al bucket
 
+GA4_MEASUREMENT_ID = "G-G7JXJKGCDV"
+
 # Secrets (wrangler secret put):
 #   CONTACT_INBOX, SESSION_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET,
 #   VN_API_KEY, GITHUB_CONTENTS_TOKEN (repo contents+PR → PR desde #/admin/fotos)
+#   GA4_MP_API_SECRET (Measurement Protocol · nunca en git)
 
 [[send_email]]
 name = "EMAIL"


### PR DESCRIPTION
## Por qué
Rö creó el secreto MP de GA4 (apodo \`ia\`). GTM v3 no se puede publicar desde acá; el Worker sí puede mandar conversiones al persistir lead/agenda.

## Qué
- \`sendGa4MpEvent\` en el Worker.
- \`POST /api/booking\` → \`book_call\`
- \`POST /api/contact\` y \`/api/leads\` → \`generate_lead\`
- \`GET /api/health\` incluye \`ga4Mp: true\` si el secreto está.
- \`packageId\` viaja en el body de agenda.

## Secretos
- \`GA4_MP_API_SECRET\` en Wrangler (no en git).
- \`GA4_MEASUREMENT_ID=G-G7JXJKGCDV\` en vars.

Live health ya muestra \`ga4Mp: true\` (worker desplegado).