### PR TITLE
fix(seo): /s/consultoria lleva gtag G-G7JXJKGCDV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — `/s/consultoria` lleva la Etiqueta de Google
+
+### Fixed
+- Cobertura GA4 *Sin etiquetar*: el HTML share ahora incluye `gtag.js` `G-G7JXJKGCDV` (lo que el crawler de la Etiqueta de Google busca).
+- Sin GTM en esa hop de 2 s (el SPA sigue solo con `initGTM`) para no duplicar `page_view`.
+
 ## [2026-08-16] — Measurement Protocol desde el Worker
 
 ### Added

--- a/docs/BLUEPRINT-SEO-SEM.md
+++ b/docs/BLUEPRINT-SEO-SEM.md
@@ -33,7 +33,7 @@ Vault (misma decisión): `Viento Norte/Resources/SEM/2026-08-15 BLUEPRINT SEO-SE
 
 | # | Check |
 |---|--------|
-| D1 | GTM `GTM-PM5LBQRP` + GA4 `G-G7JXJKGCDV` · `page_view` |
+| D1 | SPA: GTM `GTM-PM5LBQRP` · share `/s/consultoria`: gtag `G-G7JXJKGCDV` · `page_view` |
 | D2 | Tag evento `generate_lead` + `book_call` (GTM v3 · humano) |
 | D3 | Evento clave GA4 |
 | D4 | Filtro IP `casa-vn` Activo |

--- a/docs/CHECKLIST-CANALES-PAID.md
+++ b/docs/CHECKLIST-CANALES-PAID.md
@@ -67,7 +67,8 @@ Código ya emite `generate_lead`, `book_call`, `submit_contact_form`, `page_view
 - [x] `gh secret set VITE_GTM_ID` (15 ago)
 - [ ] `VITE_GA_MEASUREMENT_ID` — **no** (apuesta A: GA4 = tag en GTM)
 - [x] Redeploy Pages con el secret ([run 31908951330](https://github.com/vientonorte/mi-portafolio/actions/runs/31908951330) success)
-- [x] Bundle live contiene `GTM-PM5LBQRP` (`/assets/index-DklCOEAE.js` · no view-source estático: `initGTM` es JS)
+- [x] Bundle live contiene `GTM-PM5LBQRP` (`initGTM` en el SPA)
+- [x] `/s/consultoria` view-source contiene `gtag/js?id=G-G7JXJKGCDV` (cobertura Etiqueta de Google; no GTM en esa hop)
 - [ ] GTM Preview: click agenda o form → evento `generate_lead` o `book_call`
 - [ ] Tag GA4 Event (o Ads conversion) escuchando esos custom events
 - [ ] Receta: `docs/GTM-KICKOFF.md`

--- a/docs/GTM-KICKOFF.md
+++ b/docs/GTM-KICKOFF.md
@@ -9,7 +9,7 @@
 El Worker manda `generate_lead` / `book_call` al persistir lead o agenda. **Nunca** commitear el valor del secreto.
 
 **Anti-patrón:** no pegar el snippet GTM ni el de `gtag.js` en el `index.html` del SPA (ahí entra por `VITE_GTM_ID` + `initGTM`).  
-**Excepción:** `public/s/consultoria/index.html` sí lleva el snippet `GTM-PM5LBQRP` (sin `gtag.js`). Es la final URL paid; GA4/Ads leen ese HTML y lo marcaban *Sin etiquetar*.
+**Excepción share:** `public/s/consultoria/index.html` lleva el snippet oficial **gtag.js** `G-G7JXJKGCDV` (mismo Google tag que `GT-P8VJH8TQ`). La cobertura de *Etiqueta de Google* busca ese ID en el source; `GTM-PM5LBQRP` no alcanza. El SPA no lleva gtag paralelo.
 
 El ID es público (sale en el bundle). El valor vive en GitHub Secrets para no hardcodear.
 

--- a/public/s/consultoria/index.html
+++ b/public/s/consultoria/index.html
@@ -68,29 +68,27 @@
       }
     </script>
     <!--
-      Final URL paid / GA4 “Detalles de páginas”.
-      El SPA carga GTM por initGTM; este HTML estático no ejecuta la app,
-      así que el crawler veía “Sin etiquetar”. Un solo contenedor, sin gtag.js.
+      Final URL paid. La cobertura de “Etiqueta de Google” busca gtag.js
+      + el ID G- en el source; el contenedor GTM no cuenta para ese
+      informe. El SPA sigue solo con initGTM — no pegar este snippet
+      en index.html.
     -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-G7JXJKGCDV"
+      data-ga4-id="G-G7JXJKGCDV"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      window.dataLayer.push({
-        event: "page_view",
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-G7JXJKGCDV", {
         page_path: "/s/consultoria",
         page_location: "https://vientonorte.io/s/consultoria/",
         page_title: "Consultoría UX · Viento Norte",
       });
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        j.setAttribute("data-gtm-id", i);
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-PM5LBQRP");
     </script>
     <meta
       http-equiv="refresh"
@@ -103,22 +101,16 @@
         function go() {
           window.location.replace(dest);
         }
-        var gtm = document.querySelector('script[data-gtm-id="GTM-PM5LBQRP"]');
-        if (gtm) gtm.addEventListener("load", function () { window.setTimeout(go, 400); });
+        var tag = document.querySelector('script[data-ga4-id="G-G7JXJKGCDV"]');
+        if (tag)
+          tag.addEventListener("load", function () {
+            window.setTimeout(go, 400);
+          });
         window.setTimeout(go, 1500);
       })();
     </script>
   </head>
   <body>
-    <noscript>
-      <iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-PM5LBQRP"
-        title="Google Tag Manager"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe>
-    </noscript>
     <p>
       <a href="https://vientonorte.io/#/consultoria">Consultoría Viento Norte</a>
     </p>

--- a/src/__tests__/lib/share-consultoria-gtm.test.ts
+++ b/src/__tests__/lib/share-consultoria-gtm.test.ts
@@ -7,14 +7,14 @@ const html = readFileSync(
   "utf8"
 );
 
-describe("share /s/consultoria GTM", () => {
-  it("embeds the single GTM container and no parallel gtag snippet", () => {
-    expect(html).toContain("GTM-PM5LBQRP");
-    expect(html).toContain('data-gtm-id');
-    expect(html).toContain("page_location");
-    expect(html).toContain("/s/consultoria/");
-    expect(html).not.toMatch(/gtag\/js\?id=G-/);
-    expect(html).not.toContain("G-G7JXJKGCDV");
+describe("share /s/consultoria Google tag", () => {
+  it("embeds gtag.js with G-G7JXJKGCDV for tag-coverage crawlers", () => {
+    expect(html).toContain("gtag/js?id=G-G7JXJKGCDV");
+    expect(html).toContain('data-ga4-id="G-G7JXJKGCDV"');
+    expect(html).toContain('gtag("config", "G-G7JXJKGCDV"');
+    expect(html).toContain("https://vientonorte.io/s/consultoria/");
+    expect(html).not.toContain("GTM-PM5LBQRP");
+    expect(html).not.toContain("gtag/js?id=GT-");
   });
 
   it("keeps Ads click IDs on the funnel redirect", () => {
@@ -22,7 +22,7 @@ describe("share /s/consultoria GTM", () => {
     expect(html).toContain("#/consultoria");
   });
 
-  it("names the noscript iframe for a11y", () => {
-    expect(html).toMatch(/iframe[\s\S]*title="Google Tag Manager"/);
+  it("does not add a GTM noscript iframe on the share hop", () => {
+    expect(html).not.toMatch(/googletagmanager\.com\/ns\.html/);
   });
 });


### PR DESCRIPTION
## Por qué

La pantalla **Etiqueta de Google** (`G-G7JXJKGCDV` + `GT-P8VJH8TQ`) marca `vientonorte.io/s/consultoria/` como **Sin etiquetar**.

#190 puso `GTM-PM5LBQRP` en ese HTML. Ese informe no busca el contenedor GTM: busca `gtag.js` + el ID `G-`.

## Qué cambia

- `public/s/consultoria/index.html`: snippet oficial `gtag.js?id=G-G7JXJKGCDV` (un `config`, sin `GT-` paralelo).
- Se saca GTM de esa hop de 2 s para no duplicar `page_view`.
- El SPA sigue apuesta A: solo `initGTM`, sin gtag en `index.html`.
- Redirect sigue conservando `gclid` / UTM.

## Test

- Vitest: `share-consultoria-gtm.test.ts` ahora exige `G-G7JXJKGCDV` y prohíbe GTM en el share.
- Assert local del HTML: PASS.
- Vite sirve el archivo en `/s/consultoria/index.html` (el fallback SPA de `/s/consultoria/` es solo local; Pages usa el `index.html` del directorio).

## Humano después del merge

1. En Etiqueta de Google → Detalles de páginas → volver a comprobar `https://vientonorte.io/s/consultoria/`.
2. **No** activar medición multidominio para `vientonorte.github.io`. `www` ya 301 a apex.
3. Ads $0 hasta «activar campañas».