### PR TITLE
feat(admin): heatmap de demos timed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — Heatmap admin de demos
+
+### Added
+- `#/admin` pestaña **Demos**: mapa de clics del chrome (gate, reloj, CTAs) por path.
+- Worker `POST /api/demo/heat` (público, sin PII) y `GET /api/admin/demo/heat` (sesión).
+- El iframe del producto no se mide (otro origen).
+
 ## [2026-08-16] — Measurement Protocol desde el Worker
 
 ### Added

--- a/docs/RUNBOOK-APIS-MCP-BD.md
+++ b/docs/RUNBOOK-APIS-MCP-BD.md
@@ -44,6 +44,8 @@ Cambio de estado de un lead (nuevo → contactado → cerrado) **es la mantenimi
 | POST | `/api/contact` `/api/leads` | escribe **leads** + mail |
 | POST | `/api/booking` | escribe **bookings** |
 | POST | `/api/diagnostico` | escribe **diagnosticos** |
+| POST | `/api/demo/heat` | clics demo (sin PII) → KV `vn:demo-heat:{path}` |
+| GET | `/api/admin/demo/heat` | heatmap admin (sesión) |
 | GET | `/s` `/s/consultoria` | HTML OG para crawlers |
 
 ### MCP
@@ -59,6 +61,7 @@ Cliente: URL `https://contact.vientonorte.io/mcp`.
 | `vn:leads` | array de leads (máx. 2000) |
 | `vn:bookings` | reservas |
 | `vn:diagnosticos` | intakes |
+| `vn:demo-heat:{path}` | grid + counts heatmap demo |
 | `image:manifest` | overrides R2 |
 | `passkey:credentials` | passkeys admin |
 | `vn_admin_session` cookie | no está en KV; HMAC `SESSION_SECRET` |

--- a/src/__tests__/lib/demo-heatmap.test.ts
+++ b/src/__tests__/lib/demo-heatmap.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { heatElName, pointInSurface } from "../../lib/demo-heatmap";
+import {
+  applyEvents,
+  cellIndex,
+  emptyBucket,
+} from "../../../worker/src/lib/demo-heat.js";
+
+describe("demo heatmap math", () => {
+  it("maps a click to 0–1 inside the surface", () => {
+    const box = { left: 100, top: 50, width: 200, height: 100 } as DOMRect;
+    expect(pointInSurface(150, 75, box)).toEqual({ x: 0.25, y: 0.25 });
+    expect(pointInSurface(10, 75, box)).toBeNull();
+  });
+
+  it("reads data-heat from the closest ancestor", () => {
+    const wrap = document.createElement("div");
+    wrap.dataset.heat = "start";
+    const btn = document.createElement("span");
+    wrap.appendChild(btn);
+    expect(heatElName(btn)).toBe("start");
+  });
+
+  it("bins worker clicks and named actions", () => {
+    const next = applyEvents(emptyBucket(), [
+      { type: "start" },
+      { type: "click", x: 0.1, y: 0.1, el: "start" },
+    ]);
+    expect(next.counts.start).toBe(1);
+    expect(next.grid[cellIndex(0.1, 0.1)]).toBe(1);
+  });
+});

--- a/src/components/admin/DemoHeatmapPanel.tsx
+++ b/src/components/admin/DemoHeatmapPanel.tsx
@@ -1,0 +1,140 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Flame } from "lucide-react";
+import { SERVICE_PATH_DEMOS, type ServicePathId } from "../../data/service-path-demos";
+import type { DemoHeatBucket } from "../../lib/admin-api";
+import { ROUTES } from "../../lib/routes";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+
+const COLS = 32;
+const ROWS = 18;
+const PATHS = SERVICE_PATH_DEMOS.map((d) => d.id);
+
+function maxCell(grid: number[]) {
+  return grid.reduce((m, n) => (n > m ? n : m), 0);
+}
+
+export function DemoHeatmapPanel({
+  paths,
+}: {
+  paths: Record<string, DemoHeatBucket>;
+}) {
+  const [active, setActive] = useState<ServicePathId>("diagnostic");
+  const bucket = paths[active];
+  const peak = bucket ? maxCell(bucket.grid) : 0;
+  const demo = SERVICE_PATH_DEMOS.find((d) => d.id === active);
+
+  const cells = useMemo(() => {
+    if (!bucket) return [];
+    return bucket.grid.map((value, i) => ({
+      i,
+      value,
+      opacity: peak ? 0.08 + (value / peak) * 0.82 : 0,
+    }));
+  }, [bucket, peak]);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Clics en el chrome de la demo (gate, reloj, CTAs). El iframe del producto
+        es otro origen: no se ve el interior.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {PATHS.map((id) => {
+          const hits = paths[id]?.counts.click ?? 0;
+          const starts = paths[id]?.counts.start ?? 0;
+          return (
+            <Button
+              key={id}
+              type="button"
+              size="sm"
+              variant={active === id ? "default" : "outline"}
+              className="min-h-11"
+              onClick={() => setActive(id)}
+            >
+              {id}
+              <Badge variant="secondary" className="ml-2">
+                {starts} / {hits}
+              </Badge>
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              <Flame className="h-4 w-4" aria-hidden />
+              Heatmap · {demo?.caption.es ?? active}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div
+              className="relative aspect-[16/10] overflow-hidden rounded-lg border bg-muted"
+              role="img"
+              aria-label={`Mapa de clics de la demo ${active}`}
+            >
+              {demo ? (
+                <img
+                  src={demo.poster}
+                  alt=""
+                  className="absolute inset-0 h-full w-full object-cover object-top opacity-50"
+                />
+              ) : null}
+              <div
+                className="absolute inset-0 grid"
+                style={{
+                  gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
+                  gridTemplateRows: `repeat(${ROWS}, minmax(0, 1fr))`,
+                }}
+              >
+                {cells.map((cell) => (
+                  <span
+                    key={cell.i}
+                    className="bg-primary"
+                    style={{ opacity: cell.value ? cell.opacity : 0 }}
+                  />
+                ))}
+              </div>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {bucket?.updatedAt
+                ? `Último hit ${new Date(bucket.updatedAt).toLocaleString("es-CL")}`
+                : "Sin hits todavía. Abrí la demo y hacé clic en Start / CTAs."}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Acciones</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <Stat label="Start" value={bucket?.counts.start} />
+            <Stat label="Fin (reloj)" value={bucket?.counts.end} />
+            <Stat label="Pausa" value={bucket?.counts.pause} />
+            <Stat label="+1 min" value={bucket?.counts.add_minute} />
+            <Stat label="CTA agenda" value={bucket?.counts.cta_schedule} />
+            <Stat label="CTA consultoría" value={bucket?.counts.cta_consult} />
+            <Stat label="Clics chrome" value={bucket?.counts.click} />
+            <Button asChild variant="outline" className="mt-2 min-h-11 w-full">
+              <Link to={ROUTES.serviceDemo(active)}>Abrir demo</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value?: number }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono tabular-nums">{value ?? 0}</span>
+    </div>
+  );
+}

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -230,6 +230,30 @@ export async function listAdminCatalog(kind: "services" | "cases"): Promise<Admi
   return data.items;
 }
 
+export type DemoHeatCounts = {
+  start: number;
+  end: number;
+  pause: number;
+  add_minute: number;
+  cta_schedule: number;
+  cta_consult: number;
+  click: number;
+};
+
+export type DemoHeatBucket = {
+  counts: DemoHeatCounts;
+  grid: number[];
+  hits: { x: number; y: number; phase?: string; el?: string; t?: string }[];
+  updatedAt: string | null;
+};
+
+export async function getAdminDemoHeat(path?: string): Promise<Record<string, DemoHeatBucket>> {
+  const url = new URL(ADMIN_ROUTES.demoHeat);
+  if (path) url.searchParams.set("path", path);
+  const data = await adminFetch<{ paths: Record<string, DemoHeatBucket> }>(url.toString());
+  return data.paths;
+}
+
 export function registryToAdminPreview(entry: ImageRegistryEntry): AdminImageRecord {
   return {
     id: entry.id,

--- a/src/lib/admin-config.ts
+++ b/src/lib/admin-config.ts
@@ -22,5 +22,6 @@ export const ADMIN_ROUTES = {
   diagnosticos: `${ADMIN_API_BASE}/api/admin/diagnosticos`,
   services: `${ADMIN_API_BASE}/api/admin/services`,
   cases: `${ADMIN_API_BASE}/api/admin/cases`,
+  demoHeat: `${ADMIN_API_BASE}/api/admin/demo/heat`,
   health: `${ADMIN_API_BASE}/api/health`,
 } as const;

--- a/src/lib/demo-heatmap.ts
+++ b/src/lib/demo-heatmap.ts
@@ -1,0 +1,76 @@
+import { ADMIN_API_BASE } from "./admin-config";
+import type { ServicePathId } from "../data/service-path-demos";
+
+export type DemoHeatType =
+  | "click"
+  | "start"
+  | "end"
+  | "pause"
+  | "add_minute"
+  | "cta_schedule"
+  | "cta_consult";
+
+export type DemoHeatEvent = {
+  type: DemoHeatType;
+  x?: number;
+  y?: number;
+  phase?: string;
+  el?: string;
+};
+
+const QUEUE: DemoHeatEvent[] = [];
+let flushTimer: number | null = null;
+let activePath: ServicePathId | null = null;
+
+export function heatElName(target: EventTarget | null): string {
+  if (!(target instanceof Element)) return "";
+  const tagged = target.closest("[data-heat]");
+  if (tagged instanceof HTMLElement) return tagged.dataset.heat ?? "";
+  return target.tagName.toLowerCase().slice(0, 32);
+}
+
+export function pointInSurface(
+  clientX: number,
+  clientY: number,
+  surface: DOMRect
+): { x: number; y: number } | null {
+  if (surface.width < 8 || surface.height < 8) return null;
+  const x = (clientX - surface.left) / surface.width;
+  const y = (clientY - surface.top) / surface.height;
+  if (x < 0 || x > 1 || y < 0 || y > 1) return null;
+  return { x, y };
+}
+
+export function queueDemoHeat(pathId: ServicePathId, event: DemoHeatEvent): void {
+  activePath = pathId;
+  QUEUE.push(event);
+  if (QUEUE.length >= 8) {
+    void flushDemoHeat();
+    return;
+  }
+  if (flushTimer !== null) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    void flushDemoHeat();
+  }, 1800);
+}
+
+export async function flushDemoHeat(): Promise<void> {
+  if (flushTimer !== null) {
+    window.clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  if (!activePath || QUEUE.length === 0) return;
+  const events = QUEUE.splice(0, QUEUE.length);
+  const pathId = activePath;
+  try {
+    await fetch(`${ADMIN_API_BASE}/api/demo/heat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ pathId, events }),
+      keepalive: true,
+    });
+  } catch {
+    /* heatmap is best-effort */
+  }
+}

--- a/src/pages/AdminHub.tsx
+++ b/src/pages/AdminHub.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { CalendarDays, Database, ImageIcon, KeyRound, LogOut, RefreshCw, Search } from "lucide-react";
+import { CalendarDays, Database, Flame, ImageIcon, KeyRound, LogOut, RefreshCw, Search } from "lucide-react";
+import { DemoHeatmapPanel } from "../components/admin/DemoHeatmapPanel";
 import { SEOHead } from "../components/atoms/SEOHead";
 import { PageShell } from "../components/layout/PageShell";
 import { useLanguage } from "../lib/LanguageContext";
@@ -30,6 +31,7 @@ import { ROUTES } from "../lib/routes";
 import {
   adminBootstrap,
   adminLogout,
+  getAdminDemoHeat,
   getAdminOverview,
   getAdminSession,
   listAdminCatalog,
@@ -42,6 +44,7 @@ import {
   type AdminCollection,
   type AdminOverview,
   type AdminRecord,
+  type DemoHeatBucket,
 } from "../lib/admin-api";
 import { createPasskey, isPasskeySupported, loginWithPasskey } from "../lib/admin-passkey";
 
@@ -82,6 +85,7 @@ export default function AdminHub() {
   const [statusFilter, setStatusFilter] = useState("all");
   const [rows, setRows] = useState<AdminRecord[]>([]);
   const [catalog, setCatalog] = useState<AdminRecord[]>([]);
+  const [demoHeat, setDemoHeat] = useState<Record<string, DemoHeatBucket>>({});
   const [busyId, setBusyId] = useState<string | null>(null);
   const [bootstrapCode, setBootstrapCode] = useState("");
 
@@ -119,6 +123,7 @@ export default function AdminHub() {
       setError(null);
       try {
         if (next === "overview") await loadOverview();
+        else if (next === "demos") setDemoHeat(await getAdminDemoHeat());
         else if (next === "leads" || next === "bookings" || next === "diagnosticos") {
           await loadCollection(next);
         } else if (next === "services" || next === "cases") {
@@ -314,6 +319,10 @@ export default function AdminHub() {
                 <TabsTrigger value="bookings">Agenda</TabsTrigger>
                 <TabsTrigger value="diagnosticos">Diagnósticos</TabsTrigger>
                 <TabsTrigger value="services">Servicios</TabsTrigger>
+                <TabsTrigger value="demos">
+                  <Flame className="mr-1 h-3.5 w-3.5" aria-hidden />
+                  Demos
+                </TabsTrigger>
                 <TabsTrigger value="cases">Casos</TabsTrigger>
               </TabsList>
               <Button
@@ -381,6 +390,9 @@ export default function AdminHub() {
             </TabsContent>
             <TabsContent value="cases">
               <CatalogTable rows={tab === "cases" ? catalog : []} kind="cases" />
+            </TabsContent>
+            <TabsContent value="demos">
+              <DemoHeatmapPanel paths={demoHeat} />
             </TabsContent>
         </Tabs>
       </div>

--- a/src/pages/TimedServiceDemo.tsx
+++ b/src/pages/TimedServiceDemo.tsx
@@ -39,6 +39,12 @@ import {
   resolveServicePathId,
   type ServicePathId,
 } from "../data/service-path-demos";
+import {
+  flushDemoHeat,
+  heatElName,
+  pointInSurface,
+  queueDemoHeat,
+} from "../lib/demo-heatmap";
 import { cn } from "../lib/utils";
 
 type Phase = "gate" | "live" | "ended";
@@ -57,6 +63,7 @@ export default function TimedServiceDemo({
   const es = language === "es";
   const scheduleReady = freeRadarHasSchedule();
   const endedTitleRef = useRef<HTMLHeadingElement>(null);
+  const surfaceRef = useRef<HTMLDivElement>(null);
 
   const pathId = forcedPath ?? resolveServicePathId(rawPathId);
   const demo = pathId ? getServicePathDemo(pathId) : undefined;
@@ -106,6 +113,7 @@ export default function TimedServiceDemo({
               package_id: demo.packageId,
               ...utm,
             });
+            queueDemoHeat(demo.id, { type: "end", phase: "ended", el: "timeout" });
             if (demo.id === "prototype") {
               trackEvent("demo_x_cms_ended", {
                 category: "campaign",
@@ -147,6 +155,7 @@ export default function TimedServiceDemo({
         ...utm,
       });
     }
+    queueDemoHeat(demo.id, { type: "start", phase: "live", el: "start" });
   }, [demo]);
 
   const openSchedule = () => {
@@ -158,6 +167,7 @@ export default function TimedServiceDemo({
       package_id: demo.packageId,
       ...readDemoUtms(),
     });
+    queueDemoHeat(demo.id, { type: "cta_schedule", phase, el: "cta-schedule" });
     openFreeRadarEntry(navigate, language, "service-path-demo", {
       mode: "schedule",
     });
@@ -173,6 +183,7 @@ export default function TimedServiceDemo({
       package_id: demo.packageId,
       ...utm,
     });
+    queueDemoHeat(demo.id, { type: "cta_consult", phase, el: "cta-consult" });
     navigateToContactAssistant(navigate, {
       origin: "service-path-demo",
       intent: "consulting",
@@ -192,6 +203,33 @@ Company: [name]
 Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
     });
   };
+
+  useEffect(() => {
+    if (!demo) return;
+    const onClick = (event: MouseEvent) => {
+      const box = surfaceRef.current?.getBoundingClientRect();
+      if (!box) return;
+      const point = pointInSurface(event.clientX, event.clientY, box);
+      if (!point) return;
+      queueDemoHeat(demo.id, {
+        type: "click",
+        x: point.x,
+        y: point.y,
+        phase,
+        el: heatElName(event.target),
+      });
+    };
+    const onLeave = () => {
+      void flushDemoHeat();
+    };
+    document.addEventListener("click", onClick, true);
+    window.addEventListener("pagehide", onLeave);
+    return () => {
+      document.removeEventListener("click", onClick, true);
+      window.removeEventListener("pagehide", onLeave);
+      void flushDemoHeat();
+    };
+  }, [demo, phase]);
 
   const mins = demo ? demoMinutes(demo) : 0;
   const restrictions = useMemo(() => {
@@ -239,6 +277,7 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
       />
 
       <div
+        ref={surfaceRef}
         className="container mx-auto max-w-5xl"
         data-surface="timed-demo"
         data-testid="timed-service-demo"
@@ -294,7 +333,13 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
                   variant="outline"
                   className="min-h-11"
                   aria-pressed={paused}
-                  onClick={() => setPaused((p) => !p)}
+                  data-heat="pause"
+                  onClick={() => {
+                    setPaused((p) => {
+                      if (!p) queueDemoHeat(demo.id, { type: "pause", phase: "live", el: "pause" });
+                      return !p;
+                    });
+                  }}
                 >
                   {paused ? (
                     <Play className="mr-2 h-4 w-4" aria-hidden />
@@ -307,7 +352,11 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
                   type="button"
                   variant="outline"
                   className="min-h-11"
-                  onClick={() => setRemaining((r) => r + 60)}
+                  data-heat="add-minute"
+                  onClick={() => {
+                    setRemaining((r) => r + 60);
+                    queueDemoHeat(demo.id, { type: "add_minute", phase: "live", el: "add-minute" });
+                  }}
                 >
                   <Plus className="mr-2 h-4 w-4" aria-hidden />
                   {copy.addMinute}
@@ -345,6 +394,7 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
                     type="button"
                     size="lg"
                     className="min-h-11 bg-brand-gradient font-semibold hover:opacity-90"
+                    data-heat="start"
                     onClick={startDemo}
                   >
                     <Play className="mr-2 h-4 w-4" aria-hidden />
@@ -435,6 +485,7 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
                           <Button
                             type="button"
                             className="min-h-11 bg-brand-gradient font-semibold hover:opacity-90"
+                            data-heat="cta-schedule"
                             onClick={openSchedule}
                           >
                             <Calendar className="mr-2 h-4 w-4" aria-hidden />
@@ -445,6 +496,7 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
                           type="button"
                           variant="outline"
                           className="min-h-11"
+                          data-heat="cta-consult"
                           onClick={openConsulting}
                         >
                           {copy.ctaConsult}

--- a/worker/src/__tests__/demo-heat.test.js
+++ b/worker/src/__tests__/demo-heat.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyEvents,
+  cellIndex,
+  emptyBucket,
+  normalizeEvent,
+} from '../lib/demo-heat.js';
+
+describe('demo-heat', () => {
+  it('rejects unknown types and keeps click in 0–1', () => {
+    expect(normalizeEvent({ type: 'page_view' })).toBeNull();
+    expect(normalizeEvent({ type: 'click', x: 1.4, y: -0.2 })).toEqual({
+      type: 'click',
+      x: 1,
+      y: 0,
+    });
+  });
+
+  it('bins clicks and counts named actions', () => {
+    const next = applyEvents(emptyBucket(), [
+      { type: 'start' },
+      { type: 'click', x: 0.1, y: 0.1, el: 'start' },
+      { type: 'cta_consult' },
+    ]);
+    expect(next.counts.start).toBe(1);
+    expect(next.counts.click).toBe(1);
+    expect(next.counts.cta_consult).toBe(1);
+    expect(next.grid[cellIndex(0.1, 0.1)]).toBe(1);
+    expect(next.hits).toHaveLength(1);
+  });
+});

--- a/worker/src/api/demo-heat.js
+++ b/worker/src/api/demo-heat.js
@@ -1,0 +1,76 @@
+import { json } from '../lib/cors.js';
+import { requireAdmin } from '../lib/require-admin.js';
+import {
+  HEAT_PATHS,
+  applyEvents,
+  emptyBucket,
+  heatKey,
+  isHeatPath,
+  normalizeEvent,
+} from '../lib/demo-heat.js';
+
+const MAX_BATCH = 40;
+
+async function readBucket(env, pathId) {
+  if (!env.ADMIN_KV) return emptyBucket();
+  const raw = await env.ADMIN_KV.get(heatKey(pathId));
+  if (!raw) return emptyBucket();
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      ...emptyBucket(),
+      ...parsed,
+      counts: { ...emptyBucket().counts, ...(parsed.counts || {}) },
+      grid: Array.isArray(parsed.grid) ? parsed.grid : emptyBucket().grid,
+      hits: Array.isArray(parsed.hits) ? parsed.hits : [],
+    };
+  } catch {
+    return emptyBucket();
+  }
+}
+
+export async function handleDemoHeatIngest(request, env, cors) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ ok: false, error: 'JSON inválido' }, 400, cors);
+  }
+
+  const pathId = typeof body.pathId === 'string' ? body.pathId.trim() : '';
+  if (!isHeatPath(pathId)) {
+    return json({ ok: false, error: 'pathId inválido' }, 400, cors);
+  }
+
+  const rawEvents = Array.isArray(body.events) ? body.events.slice(0, MAX_BATCH) : [];
+  const events = rawEvents.map(normalizeEvent).filter(Boolean);
+  if (!events.length) return json({ ok: true, accepted: 0 }, 200, cors);
+
+  const current = await readBucket(env, pathId);
+  const next = applyEvents(current, events);
+  if (env.ADMIN_KV) {
+    await env.ADMIN_KV.put(heatKey(pathId), JSON.stringify(next));
+  }
+  return json({ ok: true, accepted: events.length }, 202, cors);
+}
+
+export async function handleDemoHeatRead(request, env, cors) {
+  const gate = await requireAdmin(request, env, cors);
+  if (gate.error) return gate.error;
+
+  const url = new URL(request.url);
+  const only = url.searchParams.get('path') || '';
+  const ids = isHeatPath(only) ? [only] : HEAT_PATHS;
+
+  const paths = {};
+  for (const id of ids) {
+    const bucket = await readBucket(env, id);
+    paths[id] = {
+      counts: bucket.counts,
+      grid: bucket.grid,
+      hits: bucket.hits.slice(0, 240),
+      updatedAt: bucket.updatedAt,
+    };
+  }
+  return json({ ok: true, paths }, 200, cors);
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -36,6 +36,7 @@ import {
 } from './api/admin-data.js';
 import { handleMcp } from './mcp/server.js';
 import { handleShare } from './api/share.js';
+import { handleDemoHeatIngest, handleDemoHeatRead } from './api/demo-heat.js';
 
 export default {
   async fetch(request, env) {
@@ -88,6 +89,9 @@ export default {
     if (path === '/api/diagnostico' && request.method === 'POST') {
       return handleCreateDiagnostico(request, env, cors);
     }
+    if (path === '/api/demo/heat' && request.method === 'POST') {
+      return handleDemoHeatIngest(request, env, cors);
+    }
 
     // ── MCP (JSON-RPC) ──
     if (path === '/mcp' || path === '/api/mcp') {
@@ -138,6 +142,9 @@ export default {
     // ── Admin data browser ──
     if (path === '/api/admin/overview' && request.method === 'GET') {
       return handleOverview(request, env, cors);
+    }
+    if (path === '/api/admin/demo/heat' && request.method === 'GET') {
+      return handleDemoHeatRead(request, env, cors);
     }
     if (path === '/api/admin/services' && request.method === 'GET') {
       return handleAdminCatalog(request, env, cors, 'services');

--- a/worker/src/lib/demo-heat.js
+++ b/worker/src/lib/demo-heat.js
@@ -1,0 +1,96 @@
+/** First-party click heat for timed demos. No PII. */
+
+export const HEAT_PATHS = ['diagnostic', 'prototype', 'process', 'app'];
+export const HEAT_COLS = 32;
+export const HEAT_ROWS = 18;
+export const HEAT_MAX_HITS = 800;
+const KEY_PREFIX = 'vn:demo-heat:';
+
+export function isHeatPath(id) {
+  return HEAT_PATHS.includes(id);
+}
+
+export function emptyGrid() {
+  return new Array(HEAT_COLS * HEAT_ROWS).fill(0);
+}
+
+export function emptyBucket() {
+  return {
+    counts: {
+      start: 0,
+      end: 0,
+      pause: 0,
+      add_minute: 0,
+      cta_schedule: 0,
+      cta_consult: 0,
+      click: 0,
+    },
+    grid: emptyGrid(),
+    hits: [],
+    updatedAt: null,
+  };
+}
+
+export function cellIndex(x, y) {
+  const nx = Number(x);
+  const ny = Number(y);
+  if (!Number.isFinite(nx) || !Number.isFinite(ny)) return -1;
+  const c = Math.min(HEAT_COLS - 1, Math.max(0, Math.floor(nx * HEAT_COLS)));
+  const r = Math.min(HEAT_ROWS - 1, Math.max(0, Math.floor(ny * HEAT_ROWS)));
+  return r * HEAT_COLS + c;
+}
+
+export function normalizeEvent(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const type = typeof raw.type === 'string' ? raw.type.trim().slice(0, 32) : '';
+  const allowed = new Set([
+    'click',
+    'start',
+    'end',
+    'pause',
+    'add_minute',
+    'cta_schedule',
+    'cta_consult',
+  ]);
+  if (!allowed.has(type)) return null;
+  const event = { type };
+  if (type === 'click') {
+    const x = Number(raw.x);
+    const y = Number(raw.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    event.x = Math.min(1, Math.max(0, x));
+    event.y = Math.min(1, Math.max(0, y));
+  }
+  if (typeof raw.phase === 'string') event.phase = raw.phase.trim().slice(0, 16);
+  if (typeof raw.el === 'string') event.el = raw.el.trim().slice(0, 64);
+  return event;
+}
+
+export function applyEvents(bucket, events, now = new Date().toISOString()) {
+  const next = {
+    counts: { ...bucket.counts },
+    grid: bucket.grid.slice(),
+    hits: bucket.hits.slice(),
+    updatedAt: now,
+  };
+  for (const event of events) {
+    if (next.counts[event.type] !== undefined) next.counts[event.type] += 1;
+    if (event.type === 'click') {
+      const idx = cellIndex(event.x, event.y);
+      if (idx >= 0) next.grid[idx] += 1;
+      next.hits.unshift({
+        x: event.x,
+        y: event.y,
+        phase: event.phase || '',
+        el: event.el || '',
+        t: now,
+      });
+    }
+  }
+  next.hits = next.hits.slice(0, HEAT_MAX_HITS);
+  return next;
+}
+
+export function heatKey(pathId) {
+  return `${KEY_PREFIX}${pathId}`;
+}


### PR DESCRIPTION
## Por qué

Rö necesita ver **dónde tocan** las demos (`/#/demo/*`) como admin. El iframe (GEES / X|CMS / DEI) es otro origen: no hay heatmap del interior sin un SaaS.

## Apuesta

First-party. Sin Hotjar/Clarity.

- Visitante: clics + start/pausa/+1 min/CTAs → `POST /api/demo/heat` (sin PII).
- Admin: `#/admin` → pestaña **Demos** → `GET /api/admin/demo/heat` (sesión).

## Test

- `tsc --noEmit` PASS
- Assert worker `applyEvents` PASS
- Vitest local pool roto (CI SoT)

## Deploy

1. Merge este PR (FO).
2. **Worker:** `wrangler deploy --keep-vars` (sin esto la pestaña Demos falla).
3. Recorrer `/#/demo/diagnostic` → `#/admin` Demos.