### PR TITLE
fix(consultoria): oculta duct-juice Figma Sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — Demo Diagnóstico 1 min
+
+### Changed
+- Reloj de `/#/demo/diagnostic` de 3 min a **1 min** (poster; 3 min era largo).
+
 ## [2026-08-16] — GEES Sites oculta
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — Demo: sesión real, no solo Start
+
+### Changed
+- Admin Demos mide vista, start, tiempo en vivo (tick 5 s), abandono y CTAs.
+- Mapa = clics/movimiento sobre poster y chrome. El iframe de Figma no se lee.
+
 ## [2026-08-16] — Demo Diagnóstico 1 min
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-16] — GEES Sites oculta
+
+### Changed
+- `duct-juice-51509104.figma.site` ya no se iframea ni se abre desde el FO. Diagnóstico usa poster; la card va a `/#/demo/diagnostic`.
+
 ## [2026-08-16] — Heatmap admin de demos
 
 ### Added

--- a/docs/URL-CANON-VIENTONORTE.md
+++ b/docs/URL-CANON-VIENTONORTE.md
@@ -12,7 +12,7 @@
 | Módulo SEM | `/#/consultoria/modulos/:id` | … | Deep link tour |
 | Proceso | `/#/proceso` | … | Macros método |
 | Demo X\|CMS | `/#/demo/x-cms` | … | Gate campaña · alias de Prototipo |
-| Demo Diagnóstico | `/#/demo/diagnostic` | … | Reloj 3 min |
+| Demo Diagnóstico | `/#/demo/diagnostic` | … | Reloj 1 min |
 | Demo Prototipo | `/#/demo/prototype` | … | Reloj 5 min |
 | Demo Proceso | `/#/demo/process` | … | Reloj 4 min |
 | Demo App | `/#/demo/app` | … | Reloj 5 min |

--- a/src/__tests__/data/service-path-demos.test.ts
+++ b/src/__tests__/data/service-path-demos.test.ts
@@ -32,6 +32,7 @@ describe("service-path-demos", () => {
       DEMO_X_CMS_DURATION_SEC
     );
     expect(getServicePathDemo("diagnostic")?.durationSec).toBe(3 * 60);
+    expect(getServicePathDemo("diagnostic")?.iframeUrl).toBeUndefined();
     expect(getServicePathDemo("process")?.durationSec).toBe(4 * 60);
     expect(getServicePathDemo("app")?.durationSec).toBe(5 * 60);
   });

--- a/src/__tests__/data/service-path-demos.test.ts
+++ b/src/__tests__/data/service-path-demos.test.ts
@@ -16,7 +16,7 @@ describe("service-path-demos", () => {
       HERO_ROLES.map((r) => r.id)
     );
     for (const demo of SERVICE_PATH_DEMOS) {
-      expect(demo.durationSec).toBeGreaterThanOrEqual(3 * 60);
+      expect(demo.durationSec).toBeGreaterThanOrEqual(60);
       expect(demo.durationSec).toBeLessThanOrEqual(5 * 60);
       expect(demo.warnSec).toBeGreaterThan(0);
       expect(demo.warnSec).toBeLessThan(demo.durationSec);
@@ -31,7 +31,7 @@ describe("service-path-demos", () => {
     expect(getServicePathDemo("prototype")?.durationSec).toBe(
       DEMO_X_CMS_DURATION_SEC
     );
-    expect(getServicePathDemo("diagnostic")?.durationSec).toBe(3 * 60);
+    expect(getServicePathDemo("diagnostic")?.durationSec).toBe(60);
     expect(getServicePathDemo("diagnostic")?.iframeUrl).toBeUndefined();
     expect(getServicePathDemo("process")?.durationSec).toBe(4 * 60);
     expect(getServicePathDemo("app")?.durationSec).toBe(5 * 60);

--- a/src/__tests__/lib/demo-heatmap.test.ts
+++ b/src/__tests__/lib/demo-heatmap.test.ts
@@ -28,5 +28,10 @@ describe("demo heatmap math", () => {
     ]);
     expect(next.counts.start).toBe(1);
     expect(next.grid[cellIndex(0.1, 0.1)]).toBe(1);
+    const sess = applyEvents(emptyBucket(), [
+      { type: "start" },
+      { type: "tick", ms: 5000 },
+    ]);
+    expect(sess.sessions.dwellMs).toBe(5000);
   });
 });

--- a/src/__tests__/lib/demo-heatmap.test.ts
+++ b/src/__tests__/lib/demo-heatmap.test.ts
@@ -27,7 +27,7 @@ describe("demo heatmap math", () => {
       { type: "click", x: 0.1, y: 0.1, el: "start" },
     ]);
     expect(next.counts.start).toBe(1);
-    expect(next.grid[cellIndex(0.1, 0.1)]).toBe(1);
+    expect(next.grid[cellIndex(0.1, 0.1)]).toBe(3);
     const sess = applyEvents(emptyBucket(), [
       { type: "start" },
       { type: "tick", ms: 5000 },

--- a/src/components/admin/DemoHeatmapPanel.tsx
+++ b/src/components/admin/DemoHeatmapPanel.tsx
@@ -16,6 +16,13 @@ function maxCell(grid: number[]) {
   return grid.reduce((m, n) => (n > m ? n : m), 0);
 }
 
+function fmtMs(ms: number) {
+  if (!ms) return "0s";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  return `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
 export function DemoHeatmapPanel({
   paths,
 }: {
@@ -25,6 +32,10 @@ export function DemoHeatmapPanel({
   const bucket = paths[active];
   const peak = bucket ? maxCell(bucket.grid) : 0;
   const demo = SERVICE_PATH_DEMOS.find((d) => d.id === active);
+  const sess = bucket?.sessions;
+  const started = sess?.started ?? bucket?.counts.start ?? 0;
+  const dwell = sess?.dwellMs ?? 0;
+  const avg = started ? dwell / started : 0;
 
   const cells = useMemo(() => {
     if (!bucket) return [];
@@ -38,13 +49,14 @@ export function DemoHeatmapPanel({
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        Clics en el chrome de la demo (gate, reloj, CTAs). El iframe del producto
-        es otro origen: no se ve el interior.
+        Sesión real: vista, start, tiempo en vivo, abandono y CTAs. El mapa
+        son clics y movimiento sobre el poster / chrome VN. Un iframe de
+        Figma Sites no se puede leer (otro origen).
       </p>
       <div className="flex flex-wrap gap-2">
         {PATHS.map((id) => {
-          const hits = paths[id]?.counts.click ?? 0;
-          const starts = paths[id]?.counts.start ?? 0;
+          const n = paths[id]?.sessions?.started ?? paths[id]?.counts.start ?? 0;
+          const d = paths[id]?.sessions?.dwellMs ?? 0;
           return (
             <Button
               key={id}
@@ -56,11 +68,20 @@ export function DemoHeatmapPanel({
             >
               {id}
               <Badge variant="secondary" className="ml-2">
-                {starts} / {hits}
+                {n} · {fmtMs(d)}
               </Badge>
             </Button>
           );
         })}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Metric label="Sesiones start" value={String(started)} />
+        <Metric label="Tiempo medio" value={fmtMs(avg)} />
+        <Metric
+          label="Fin / abandono / CTA"
+          value={`${sess?.ended ?? 0} / ${sess?.left ?? 0} / ${sess?.cta ?? 0}`}
+        />
       </div>
 
       <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
@@ -68,14 +89,14 @@ export function DemoHeatmapPanel({
           <CardHeader className="pb-2">
             <CardTitle className="flex items-center gap-2 text-sm font-medium">
               <Flame className="h-4 w-4" aria-hidden />
-              Heatmap · {demo?.caption.es ?? active}
+              Mapa · {demo?.caption.es ?? active}
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div
               className="relative aspect-[16/10] overflow-hidden rounded-lg border bg-muted"
               role="img"
-              aria-label={`Mapa de clics de la demo ${active}`}
+              aria-label={`Mapa de la demo ${active}`}
             >
               {demo ? (
                 <img
@@ -101,25 +122,30 @@ export function DemoHeatmapPanel({
               </div>
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
-              {bucket?.updatedAt
-                ? `Último hit ${new Date(bucket.updatedAt).toLocaleString("es-CL")}`
-                : "Sin hits todavía. Abrí la demo y hacé clic en Start / CTAs."}
+              {peak
+                ? `Último hit ${
+                    bucket?.updatedAt
+                      ? new Date(bucket.updatedAt).toLocaleString("es-CL")
+                      : "—"
+                  }`
+                : "Mapa vacío: no hubo clics en el poster. Abrí la demo, tocá la imagen, esperá 5 s y volvé."}
             </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">Acciones</CardTitle>
+            <CardTitle className="text-sm font-medium">Eventos</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
+            <Stat label="Vistas gate" value={bucket?.counts.view} />
             <Stat label="Start" value={bucket?.counts.start} />
-            <Stat label="Fin (reloj)" value={bucket?.counts.end} />
-            <Stat label="Pausa" value={bucket?.counts.pause} />
-            <Stat label="+1 min" value={bucket?.counts.add_minute} />
+            <Stat label="Tick 5s" value={bucket?.counts.tick as number | undefined} />
+            <Stat label="Abandono" value={bucket?.counts.leave} />
+            <Stat label="Fin reloj" value={bucket?.counts.end} />
             <Stat label="CTA agenda" value={bucket?.counts.cta_schedule} />
             <Stat label="CTA consultoría" value={bucket?.counts.cta_consult} />
-            <Stat label="Clics chrome" value={bucket?.counts.click} />
+            <Stat label="Clics poster/chrome" value={bucket?.counts.click} />
             <Button asChild variant="outline" className="mt-2 min-h-11 w-full">
               <Link to={ROUTES.serviceDemo(active)}>Abrir demo</Link>
             </Button>
@@ -127,6 +153,19 @@ export function DemoHeatmapPanel({
         </Card>
       </div>
     </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-1">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-semibold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/data/consultoria-demos.ts
+++ b/src/data/consultoria-demos.ts
@@ -27,10 +27,9 @@ export const CONSULTORIA_DEMO_X_CMS = {
   poster: "xCmsDashboard",
 } as const satisfies ConsultoriaDemoConfig;
 
-/** GEES · consultoría / propuesta ejecutiva */
+/** GEES · consultoría / propuesta ejecutiva. Sites URL oculta (no iframe, no href público). */
 export const CONSULTORIA_DEMO_GEES = {
   id: "gees-propuesta",
-  figmaSitesUrl: "https://duct-juice-51509104.figma.site",
   poster: "geesDashboard",
 } as const satisfies ConsultoriaDemoConfig;
 

--- a/src/data/service-path-demos.ts
+++ b/src/data/service-path-demos.ts
@@ -33,24 +33,24 @@ export const SERVICE_PATH_DEMOS: readonly ServicePathDemo[] = [
   {
     id: "diagnostic",
     packageId: "radar",
-    durationSec: 3 * 60,
-    warnSec: 45,
+    durationSec: 60,
+    warnSec: 15,
     poster: portfolioImages.consultoria.geesDashboard,
     caption: {
       es: "GEES · propuesta de diagnóstico",
       en: "GEES · diagnostic proposal",
     },
     kicker: {
-      es: "Path Diagnóstico · Radar · 3 min",
-      en: "Diagnostic path · Radar · 3 min",
+      es: "Path Diagnóstico · Radar · 1 min",
+      en: "Diagnostic path · Radar · 1 min",
     },
     headline: {
       es: "Así se ve un diagnóstico.\nLuego el informe.",
       en: "This is what a diagnostic looks like.\nThen the report.",
     },
     body: {
-      es: "Demo de 3 minutos: propuesta ejecutiva publicada. Sin datos de tu empresa. Al terminar, agenda Radar o pide la revisión gratis de un flujo.",
-      en: "3-minute demo: published executive proposal. No data from your company. Then book Radar or request the free flow review.",
+      es: "Demo de 1 minuto: propuesta ejecutiva. Sin datos de tu empresa. Al terminar, agenda Radar o pide la revisión gratis de un flujo.",
+      en: "1-minute demo: executive proposal. No data from your company. Then book Radar or request the free flow review.",
     },
   },
   {

--- a/src/data/service-path-demos.ts
+++ b/src/data/service-path-demos.ts
@@ -4,10 +4,7 @@
  */
 import type { HeroRoleId } from "./consultoria-hero-roles";
 import type { ConsultingPackageId } from "./vientonorte-consulting";
-import {
-  CONSULTORIA_DEMO_GEES,
-  CONSULTORIA_DEMO_X_CMS,
-} from "./consultoria-demos";
+import { CONSULTORIA_DEMO_X_CMS } from "./consultoria-demos";
 import { TRANSVIP_APP_PROTO_URL } from "./value-content-arsenal";
 import type { Language } from "../lib/i18n";
 import { portfolioImages } from "../lib/portfolio-image-urls";
@@ -38,7 +35,6 @@ export const SERVICE_PATH_DEMOS: readonly ServicePathDemo[] = [
     packageId: "radar",
     durationSec: 3 * 60,
     warnSec: 45,
-    iframeUrl: CONSULTORIA_DEMO_GEES.figmaSitesUrl,
     poster: portfolioImages.consultoria.geesDashboard,
     caption: {
       es: "GEES · propuesta de diagnóstico",

--- a/src/data/value-content-arsenal.ts
+++ b/src/data/value-content-arsenal.ts
@@ -1,10 +1,7 @@
 import type { Language } from "../lib/i18n";
 import { getPortfolioImages } from "../lib/image-overrides";
 import { ROUTES } from "../lib/routes";
-import {
-  CONSULTORIA_DEMO_GEES,
-  CONSULTORIA_DEMO_X_CMS,
-} from "./consultoria-demos";
+import { CONSULTORIA_DEMO_X_CMS } from "./consultoria-demos";
 import type { ConsultingPackageId } from "./vientonorte-consulting";
 
 /** Figma · System Design App Cliente Transvip (handoff navegable). */
@@ -76,23 +73,22 @@ export const VALUE_PROOF_ITEMS: ValueProofItem[] = [
     id: "gees-propuesta",
     kind: "prototype",
     imagePath: img((i) => i.consultoria.geesDashboard),
-    href: CONSULTORIA_DEMO_GEES.figmaSitesUrl,
-    external: true,
+    href: ROUTES.serviceDemo("diagnostic"),
     bundleId: "marco",
     copy: {
       es: {
         kindLabel: "Propuesta publicada",
         title: "GEES · Dashboard de cotización",
         outcome:
-          "Propuesta ejecutiva en Figma Sites — cotización digital, KPIs en tiempo real y decisión estratégica.",
-        metric: "Figma Sites",
+          "Propuesta ejecutiva — cotización digital, KPIs en tiempo real y decisión estratégica.",
+        metric: "Dashboard",
       },
       en: {
         kindLabel: "Published proposal",
         title: "GEES · Quoting dashboard",
         outcome:
-          "Executive proposal on Figma Sites — digital quoting, real-time KPIs, and strategic decisions.",
-        metric: "Figma Sites",
+          "Executive proposal — digital quoting, real-time KPIs, and strategic decisions.",
+        metric: "Dashboard",
       },
     },
   },
@@ -875,7 +871,6 @@ export const VALUE_PROOF_ITEMS: ValueProofItem[] = [
 
 export const VALUE_PROOF_EXTERNAL_URLS: Record<string, string> = {
   "x-cms-demo": CONSULTORIA_DEMO_X_CMS.figmaSitesUrl,
-  "gees-propuesta": CONSULTORIA_DEMO_GEES.figmaSitesUrl,
   "ria-us": RIA_US_PROTO_URL,
   "poc-ia-dei": "https://badge-sweet-21070688.figma.site",
   "transvip-mobile": TRANSVIP_APP_PROTO_URL,

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -231,17 +231,30 @@ export async function listAdminCatalog(kind: "services" | "cases"): Promise<Admi
 }
 
 export type DemoHeatCounts = {
+  view?: number;
   start: number;
   end: number;
+  leave?: number;
+  tick?: number;
   pause: number;
   add_minute: number;
   cta_schedule: number;
   cta_consult: number;
   click: number;
+  move?: number;
+};
+
+export type DemoHeatSessions = {
+  started: number;
+  ended: number;
+  left: number;
+  cta: number;
+  dwellMs: number;
 };
 
 export type DemoHeatBucket = {
   counts: DemoHeatCounts;
+  sessions?: DemoHeatSessions;
   grid: number[];
   hits: { x: number; y: number; phase?: string; el?: string; t?: string }[];
   updatedAt: string | null;

--- a/src/lib/demo-heatmap.ts
+++ b/src/lib/demo-heatmap.ts
@@ -3,8 +3,12 @@ import type { ServicePathId } from "../data/service-path-demos";
 
 export type DemoHeatType =
   | "click"
+  | "move"
+  | "view"
   | "start"
   | "end"
+  | "leave"
+  | "tick"
   | "pause"
   | "add_minute"
   | "cta_schedule"
@@ -14,6 +18,7 @@ export type DemoHeatEvent = {
   type: DemoHeatType;
   x?: number;
   y?: number;
+  ms?: number;
   phase?: string;
   el?: string;
 };

--- a/src/pages/TimedServiceDemo.tsx
+++ b/src/pages/TimedServiceDemo.tsx
@@ -64,6 +64,10 @@ export default function TimedServiceDemo({
   const scheduleReady = freeRadarHasSchedule();
   const endedTitleRef = useRef<HTMLHeadingElement>(null);
   const surfaceRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const liveStartedAt = useRef<number | null>(null);
+  const lastTickAt = useRef<number | null>(null);
+  const lastMoveAt = useRef(0);
 
   const pathId = forcedPath ?? resolveServicePathId(rawPathId);
   const demo = pathId ? getServicePathDemo(pathId) : undefined;
@@ -113,7 +117,11 @@ export default function TimedServiceDemo({
               package_id: demo.packageId,
               ...utm,
             });
-            queueDemoHeat(demo.id, { type: "end", phase: "ended", el: "timeout" });
+            const started = liveStartedAt.current;
+            const ms = started ? Date.now() - started : 0;
+            liveStartedAt.current = null;
+            lastTickAt.current = null;
+            queueDemoHeat(demo.id, { type: "end", phase: "ended", el: "timeout", ms });
             if (demo.id === "prototype") {
               trackEvent("demo_x_cms_ended", {
                 category: "campaign",
@@ -155,6 +163,8 @@ export default function TimedServiceDemo({
         ...utm,
       });
     }
+    liveStartedAt.current = Date.now();
+    lastTickAt.current = Date.now();
     queueDemoHeat(demo.id, { type: "start", phase: "live", el: "start" });
   }, [demo]);
 
@@ -206,8 +216,17 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
 
   useEffect(() => {
     if (!demo) return;
-    const onClick = (event: MouseEvent) => {
-      const box = surfaceRef.current?.getBoundingClientRect();
+    queueDemoHeat(demo.id, { type: "view", phase: "gate", el: "view" });
+  }, [demo]);
+
+  useEffect(() => {
+    if (!demo) return;
+
+    const stageBox = () =>
+      (stageRef.current ?? surfaceRef.current)?.getBoundingClientRect();
+
+    const onPointerDown = (event: PointerEvent) => {
+      const box = stageBox();
       if (!box) return;
       const point = pointInSurface(event.clientX, event.clientY, box);
       if (!point) return;
@@ -219,17 +238,74 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
         el: heatElName(event.target),
       });
     };
-    const onLeave = () => {
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (phase !== "live") return;
+      const now = Date.now();
+      if (now - lastMoveAt.current < 450) return;
+      lastMoveAt.current = now;
+      const box = stageBox();
+      if (!box) return;
+      const point = pointInSurface(event.clientX, event.clientY, box);
+      if (!point) return;
+      queueDemoHeat(demo.id, {
+        type: "move",
+        x: point.x,
+        y: point.y,
+        phase: "live",
+        el: "stage",
+      });
+    };
+
+    const flushLeave = () => {
+      if (phase === "live" && liveStartedAt.current) {
+        const now = Date.now();
+        const sinceTick = lastTickAt.current ? now - lastTickAt.current : 0;
+        queueDemoHeat(demo.id, {
+          type: "leave",
+          phase: "live",
+          el: "leave",
+          ms: sinceTick,
+        });
+        liveStartedAt.current = null;
+        lastTickAt.current = null;
+      }
       void flushDemoHeat();
     };
-    document.addEventListener("click", onClick, true);
-    window.addEventListener("pagehide", onLeave);
+
+    const onHidden = () => {
+      if (document.visibilityState === "hidden") flushLeave();
+    };
+
+    const root = surfaceRef.current;
+    root?.addEventListener("pointerdown", onPointerDown);
+    root?.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("visibilitychange", onHidden);
+    window.addEventListener("pagehide", flushLeave);
     return () => {
-      document.removeEventListener("click", onClick, true);
-      window.removeEventListener("pagehide", onLeave);
+      root?.removeEventListener("pointerdown", onPointerDown);
+      root?.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("visibilitychange", onHidden);
+      window.removeEventListener("pagehide", flushLeave);
       void flushDemoHeat();
     };
   }, [demo, phase]);
+
+  useEffect(() => {
+    if (!demo || phase !== "live" || paused) return;
+    const id = window.setInterval(() => {
+      const now = Date.now();
+      const prev = lastTickAt.current ?? now;
+      lastTickAt.current = now;
+      queueDemoHeat(demo.id, {
+        type: "tick",
+        phase: "live",
+        el: "tick",
+        ms: now - prev,
+      });
+    }, 5000);
+    return () => window.clearInterval(id);
+  }, [demo, phase, paused]);
 
   const mins = demo ? demoMinutes(demo) : 0;
   const restrictions = useMemo(() => {
@@ -417,7 +493,11 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
               </CardContent>
             </Card>
 
-            <figure className="overflow-hidden rounded-xl border-2 border-[color:var(--logo-surface-border)] bg-muted">
+            <figure
+              ref={stageRef}
+              data-heat="poster"
+              className="overflow-hidden rounded-xl border-2 border-[color:var(--logo-surface-border)] bg-muted"
+            >
               <img
                 src={demo.poster}
                 alt={caption}
@@ -432,7 +512,11 @@ Next step: ${demo.packageId}${demo.appGoal ? " · end-to-end app" : ""}.`,
 
         {(phase === "live" || phase === "ended") && (
           <div className="space-y-4">
-            <div className="relative overflow-hidden rounded-xl border-2 border-[color:var(--logo-surface-border)] bg-muted shadow-sm">
+            <div
+              ref={stageRef}
+              data-heat="stage"
+              className="relative overflow-hidden rounded-xl border-2 border-[color:var(--logo-surface-border)] bg-muted shadow-sm"
+            >
               {phase === "live" && demo.iframeUrl ? (
                 <iframe
                   title={iframeTitle}

--- a/worker/src/__tests__/demo-heat.test.js
+++ b/worker/src/__tests__/demo-heat.test.js
@@ -28,4 +28,15 @@ describe('demo-heat', () => {
     expect(next.grid[cellIndex(0.1, 0.1)]).toBe(1);
     expect(next.hits).toHaveLength(1);
   });
+
+  it("accumulates session dwell from tick and leave", () => {
+    const next = applyEvents(emptyBucket(), [
+      { type: "start" },
+      { type: "tick", ms: 5000 },
+      { type: "leave", ms: 2000 },
+    ]);
+    expect(next.sessions.started).toBe(1);
+    expect(next.sessions.left).toBe(1);
+    expect(next.sessions.dwellMs).toBe(7000);
+  });
 });

--- a/worker/src/api/demo-heat.js
+++ b/worker/src/api/demo-heat.js
@@ -67,6 +67,7 @@ export async function handleDemoHeatRead(request, env, cors) {
     const bucket = await readBucket(env, id);
     paths[id] = {
       counts: bucket.counts,
+      sessions: bucket.sessions,
       grid: bucket.grid,
       hits: bucket.hits.slice(0, 240),
       updatedAt: bucket.updatedAt,

--- a/worker/src/lib/demo-heat.js
+++ b/worker/src/lib/demo-heat.js
@@ -17,13 +17,23 @@ export function emptyGrid() {
 export function emptyBucket() {
   return {
     counts: {
+      view: 0,
       start: 0,
       end: 0,
+      leave: 0,
       pause: 0,
       add_minute: 0,
       cta_schedule: 0,
       cta_consult: 0,
       click: 0,
+      move: 0,
+    },
+    sessions: {
+      started: 0,
+      ended: 0,
+      left: 0,
+      cta: 0,
+      dwellMs: 0,
     },
     grid: emptyGrid(),
     hits: [],
@@ -45,8 +55,12 @@ export function normalizeEvent(raw) {
   const type = typeof raw.type === 'string' ? raw.type.trim().slice(0, 32) : '';
   const allowed = new Set([
     'click',
+    'move',
+    'view',
     'start',
     'end',
+    'leave',
+    'tick',
     'pause',
     'add_minute',
     'cta_schedule',
@@ -54,13 +68,15 @@ export function normalizeEvent(raw) {
   ]);
   if (!allowed.has(type)) return null;
   const event = { type };
-  if (type === 'click') {
+  if (type === 'click' || type === 'move') {
     const x = Number(raw.x);
     const y = Number(raw.y);
     if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
     event.x = Math.min(1, Math.max(0, x));
     event.y = Math.min(1, Math.max(0, y));
   }
+  const ms = Number(raw.ms);
+  if (Number.isFinite(ms) && ms >= 0) event.ms = Math.min(ms, 30 * 60 * 1000);
   if (typeof raw.phase === 'string') event.phase = raw.phase.trim().slice(0, 16);
   if (typeof raw.el === 'string') event.el = raw.el.trim().slice(0, 64);
   return event;
@@ -68,23 +84,35 @@ export function normalizeEvent(raw) {
 
 export function applyEvents(bucket, events, now = new Date().toISOString()) {
   const next = {
-    counts: { ...bucket.counts },
+    counts: { ...emptyBucket().counts, ...bucket.counts },
+    sessions: { ...emptyBucket().sessions, ...(bucket.sessions || {}) },
     grid: bucket.grid.slice(),
     hits: bucket.hits.slice(),
     updatedAt: now,
   };
   for (const event of events) {
     if (next.counts[event.type] !== undefined) next.counts[event.type] += 1;
-    if (event.type === 'click') {
+    if (event.type === 'start') next.sessions.started += 1;
+    if (event.type === 'end') next.sessions.ended += 1;
+    if (event.type === 'leave') next.sessions.left += 1;
+    if (event.type === 'cta_schedule' || event.type === 'cta_consult') {
+      next.sessions.cta += 1;
+    }
+    if ((event.type === 'tick' || event.type === 'leave' || event.type === 'end') && event.ms) {
+      next.sessions.dwellMs += event.ms;
+    }
+    if (event.type === 'click' || event.type === 'move') {
       const idx = cellIndex(event.x, event.y);
-      if (idx >= 0) next.grid[idx] += 1;
-      next.hits.unshift({
-        x: event.x,
-        y: event.y,
-        phase: event.phase || '',
-        el: event.el || '',
-        t: now,
-      });
+      if (idx >= 0) next.grid[idx] += event.type === 'click' ? 3 : 1;
+      if (event.type === 'click') {
+        next.hits.unshift({
+          x: event.x,
+          y: event.y,
+          phase: event.phase || '',
+          el: event.el || '',
+          t: now,
+        });
+      }
     }
   }
   next.hits = next.hits.slice(0, HEAT_MAX_HITS);


### PR DESCRIPTION
## Qué

`https://duct-juice-51509104.figma.site` deja de ser iframe y de ser href público.

- Demo Diagnóstico: poster (sin «abrir en pestaña»).
- Card GEES: navega a `/#/demo/diagnostic`.
- El script de captura ops puede seguir usando la URL.