### PR TITLE
fix(seo): title y HTML crawler para Tecnología para empresas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-17] — SEO P0: title y HTML para crawlers
+
+### Changed
+- Title de home (Helmet + `index.html`): **Tecnología para empresas · Viento Norte**.
+- `/s/` y `/s/consultoria`: H1 + Diagnóstico · Prototipo · Proceso · App. Description con el query.
+- Canonical de `/s/consultoria` = `https://vientonorte.io/s/consultoria/` (ya no el hash).
+- `sitemap.xml` solo lista `/`, `/s/` y `/s/consultoria/`. Sin `#/`.
+
 ## [2026-08-16] — `/s/consultoria` lleva la Etiqueta de Google
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <!-- GSC ownership: HTML file method → /google5858e011b32ea566.html (public/) · no inventar meta token -->
 
     <!-- Static SEO (no JS required) — LinkedIn / WhatsApp / crawlers -->
-    <title>Viento Norte · UXtech · Módulos a medida</title>
+    <title>Tecnología para empresas · Viento Norte</title>
     <meta
       name="description"
       content="Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. UXtech y front office. Software que se instala, dueño del dato. Consultoría y craft enterprise."
@@ -42,7 +42,7 @@
     <meta property="og:site_name" content="Viento Norte" />
     <meta property="og:locale" content="es_CL" />
     <meta property="og:url" content="https://vientonorte.io/" />
-    <meta property="og:title" content="Viento Norte · UXtech · Módulos a medida" />
+    <meta property="og:title" content="Tecnología para empresas · Viento Norte" />
     <meta
       property="og:description"
       content="Tecnología para empresas: diagnóstico, prototipo, proceso o app. Software que se instala, dueño del dato."
@@ -58,7 +58,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://vientonorte.io/" />
-    <meta name="twitter:title" content="Viento Norte · UXtech · Módulos a medida" />
+    <meta name="twitter:title" content="Tecnología para empresas · Viento Norte" />
     <meta
       name="twitter:description"
       content="Tecnología para empresas. Módulos a medida, dueño del dato. Front office y craft enterprise."

--- a/public/s/consultoria/index.html
+++ b/public/s/consultoria/index.html
@@ -6,15 +6,15 @@
     <title>Consultoría UX · Viento Norte</title>
     <meta
       name="description"
-      content="Diagnóstico 5–7 días, prototipo o proceso de equipo. Gratis: accesibilidad de un flujo. Kickoff 30 min."
+      content="Tecnología para empresas: diagnóstico 5–7 días, prototipo o proceso de equipo. Gratis: accesibilidad de un flujo. Kickoff 30 min."
     />
-    <link rel="canonical" href="https://vientonorte.io/#/consultoria" />
+    <link rel="canonical" href="https://vientonorte.io/s/consultoria/" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://vientonorte.io/s/consultoria" />
+    <meta property="og:url" content="https://vientonorte.io/s/consultoria/" />
     <meta property="og:title" content="Consultoría UX · Viento Norte" />
     <meta
       property="og:description"
-      content="Diagnóstico, prototipo o proceso. Software que se instala. Cliente dueño del dato. Kickoff 30 min."
+      content="Tecnología para empresas: diagnóstico, prototipo o proceso. Software que se instala. Cliente dueño del dato. Kickoff 30 min."
     />
     <meta
       property="og:image"
@@ -31,9 +31,9 @@
       {
         "@context": "https://schema.org",
         "@type": "ProfessionalService",
-        "@id": "https://vientonorte.io/#consultoria",
+        "@id": "https://vientonorte.io/s/consultoria/",
         "name": "Consultoría UX · Viento Norte",
-        "url": "https://vientonorte.io/#/consultoria",
+        "url": "https://vientonorte.io/s/consultoria/",
         "image": "https://vientonorte.io/images/branding/og-consultoria-1200.png",
         "provider": {
           "@type": "Organization",
@@ -42,12 +42,13 @@
         },
         "areaServed": { "@type": "Country", "name": "Chile" },
         "serviceType": [
+          "Tecnología para empresas",
           "Diagnóstico UX",
           "Prototipo",
           "Proceso de equipo",
           "Accesibilidad WCAG"
         ],
-        "description": "Diagnóstico 5–7 días, prototipo o proceso de equipo. Gratis: accesibilidad WCAG 2.2 AA de un flujo. Kickoff 30 min.",
+        "description": "Tecnología para empresas: diagnóstico 5–7 días, prototipo o proceso de equipo. Gratis: accesibilidad WCAG 2.2 AA de un flujo. Kickoff 30 min.",
         "offers": [
           {
             "@type": "Offer",
@@ -63,6 +64,11 @@
             "@type": "Offer",
             "name": "Proceso de equipo",
             "description": "Guía del equipo y cómo medir. 4–6 semanas."
+          },
+          {
+            "@type": "Offer",
+            "name": "App de punta a punta",
+            "description": "Idea → app en uso. Un interlocutor de idea a release."
           }
         ]
       }
@@ -92,7 +98,7 @@
     </script>
     <meta
       http-equiv="refresh"
-      content="2;url=https://vientonorte.io/#/consultoria"
+      content="5;url=https://vientonorte.io/#/consultoria"
     />
     <script>
       (function () {
@@ -111,8 +117,21 @@
     </script>
   </head>
   <body>
-    <p>
-      <a href="https://vientonorte.io/#/consultoria">Consultoría Viento Norte</a>
-    </p>
+    <main>
+      <h1>Tecnología para empresas</h1>
+      <p>
+        Diagnóstico, prototipo, proceso de equipo o app funcional. Software que
+        se instala, dueño del dato.
+      </p>
+      <ul>
+        <li>Diagnóstico</li>
+        <li>Prototipo</li>
+        <li>Proceso de equipo</li>
+        <li>App de punta a punta</li>
+      </ul>
+      <p>
+        <a href="https://vientonorte.io/#/consultoria">Consultoría Viento Norte</a>
+      </p>
+    </main>
   </body>
 </html>

--- a/public/s/index.html
+++ b/public/s/index.html
@@ -3,30 +3,50 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Viento Norte · UXtech · Módulos a medida</title>
+    <title>Tecnología para empresas · Viento Norte</title>
     <meta
       name="description"
-      content="Consultora UXtech: módulos a medida que se instalan. Cliente dueño del dato."
+      content="Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. Software que se instala, dueño del dato. Consultoría y craft enterprise."
     />
     <link rel="canonical" href="https://vientonorte.io/" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://vientonorte.io/" />
-    <meta property="og:title" content="Viento Norte · UXtech · Módulos a medida" />
+    <meta property="og:title" content="Tecnología para empresas · Viento Norte" />
     <meta
       property="og:description"
-      content="Diseño que reduce el ruido. Consultoría UX en Chile."
+      content="Tecnología para empresas: diagnóstico, prototipo, proceso o app. Software que se instala, dueño del dato."
     />
     <meta property="og:image" content="https://vientonorte.io/images/branding/og-home-1200.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="https://vientonorte.io/images/branding/og-home-1200.png" />
-    <meta http-equiv="refresh" content="0;url=https://vientonorte.io/" />
+    <meta
+      name="twitter:title"
+      content="Tecnología para empresas · Viento Norte"
+    />
+    <meta
+      name="twitter:image"
+      content="https://vientonorte.io/images/branding/og-home-1200.png"
+    />
+    <meta http-equiv="refresh" content="5;url=https://vientonorte.io/" />
     <script>
       location.replace("https://vientonorte.io/");
     </script>
   </head>
   <body>
-    <p><a href="https://vientonorte.io/">Viento Norte</a></p>
+    <main>
+      <h1>Tecnología para empresas</h1>
+      <p>
+        Diagnóstico, prototipo, proceso de equipo o app funcional. Software que
+        se instala, dueño del dato.
+      </p>
+      <ul>
+        <li>Diagnóstico</li>
+        <li>Prototipo</li>
+        <li>Proceso de equipo</li>
+        <li>App de punta a punta</li>
+      </ul>
+      <p><a href="https://vientonorte.io/">Viento Norte</a></p>
+    </main>
   </body>
 </html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,60 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- SEO orgánico · root (prioridad indexación) -->
+  <!-- SEO orgánico · solo paths HTTP. Google ignora fragments (#/). -->
   <url>
     <loc>https://vientonorte.io/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://vientonorte.io/s/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
-  <!-- SEM paid final URL · tour oferta (HashRouter; Google indexa con JS o via Search Console) -->
   <url>
-    <loc>https://vientonorte.io/s/consultoria</loc>
-    <lastmod>2026-08-13</lastmod>
+    <loc>https://vientonorte.io/s/consultoria/</loc>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.96</priority>
-  </url>
-  <url>
-    <loc>https://vientonorte.io/#/consultoria</loc>
-    <lastmod>2026-08-13</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://vientonorte.io/#/contacto</loc>
-    <lastmod>2026-08-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.85</priority>
-  </url>
-  <url>
-    <loc>https://vientonorte.io/#/proyectos</loc>
-    <lastmod>2026-08-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://vientonorte.io/#/proceso</loc>
-    <lastmod>2026-08-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-  </url>
-  <url>
-    <loc>https://vientonorte.io/#/sobre-mi</loc>
-    <lastmod>2026-08-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.65</priority>
-  </url>
-  <!-- Legacy embudo → redirige a home; se mantiene baja prioridad por bookmarks -->
-  <url>
-    <loc>https://vientonorte.io/#/consultoria/embudo</loc>
-    <lastmod>2026-08-03</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.2</priority>
   </url>
 </urlset>

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import es from "../../lib/i18n/locales/es";
+import en from "../../lib/i18n/locales/en";
+
+const root = process.cwd();
+const indexHtml = readFileSync(resolve(root, "index.html"), "utf8");
+const shareHome = readFileSync(resolve(root, "public/s/index.html"), "utf8");
+const shareConsultoria = readFileSync(
+  resolve(root, "public/s/consultoria/index.html"),
+  "utf8"
+);
+const sitemap = readFileSync(resolve(root, "public/sitemap.xml"), "utf8");
+
+const PATHS = [
+  "Diagnóstico",
+  "Prototipo",
+  "Proceso de equipo",
+  "App de punta a punta",
+];
+
+describe("SEO P0 · title home vs query", () => {
+  it("home title leads with Tecnología para empresas and stays ≤60", () => {
+    expect(es.seo.pages.home.title).toBe(
+      "Tecnología para empresas · Viento Norte"
+    );
+    expect(en.seo.pages.home.title).toBe(
+      "Technology for business · Viento Norte"
+    );
+    expect(es.seo.pages.home.title.length).toBeLessThanOrEqual(60);
+    expect(en.seo.pages.home.title.length).toBeLessThanOrEqual(60);
+    expect(indexHtml).toContain(
+      "<title>Tecnología para empresas · Viento Norte</title>"
+    );
+  });
+});
+
+describe("SEO P0 · crawler HTML /s/", () => {
+  it("share home has H1, four paths, and query in title/description", () => {
+    expect(shareHome).toMatch(/<h1>\s*Tecnología para empresas\s*<\/h1>/);
+    for (const name of PATHS) {
+      expect(shareHome).toContain(name);
+    }
+    expect(shareHome).toContain(
+      "<title>Tecnología para empresas · Viento Norte</title>"
+    );
+    expect(shareHome).toContain('name="description"');
+    expect(shareHome).toMatch(/Tecnología para empresas:/);
+    expect(shareHome).toContain('rel="canonical" href="https://vientonorte.io/"');
+    expect(shareHome).toContain('content="5;url=https://vientonorte.io/"');
+  });
+
+  it("share consultoria has H1, four paths, query, and no hash canonical", () => {
+    expect(shareConsultoria).toMatch(/<h1>\s*Tecnología para empresas\s*<\/h1>/);
+    for (const name of PATHS) {
+      expect(shareConsultoria).toContain(name);
+    }
+    expect(shareConsultoria).toMatch(/Tecnología para empresas:/);
+    expect(shareConsultoria).toContain(
+      'rel="canonical" href="https://vientonorte.io/s/consultoria/"'
+    );
+    expect(shareConsultoria).not.toContain(
+      'rel="canonical" href="https://vientonorte.io/#/consultoria"'
+    );
+    expect(shareConsultoria).toContain(
+      'content="5;url=https://vientonorte.io/#/consultoria"'
+    );
+  });
+});
+
+describe("SEO P0 · sitemap HTTP only", () => {
+  it("lists / /s/ /s/consultoria/ and no hash locs", () => {
+    expect(sitemap).toContain("<loc>https://vientonorte.io/</loc>");
+    expect(sitemap).toContain("<loc>https://vientonorte.io/s/</loc>");
+    expect(sitemap).toContain(
+      "<loc>https://vientonorte.io/s/consultoria/</loc>"
+    );
+    expect(sitemap).not.toMatch(/<loc>https:\/\/vientonorte\.io\/#\//);
+  });
+});

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -37,7 +37,7 @@ export default {
         'Viento Norte, UXtech, UX consulting, custom modules, front office, fintech, Design Ops, WCAG accessibility, own your data, SMB',
       pages: {
         home: {
-          title: 'Viento Norte · UXtech · Custom modules',
+          title: 'Technology for business · Viento Norte',
           description:
             'Technology for businesses: diagnostic, prototype, team process, or working app. Software you install — own your data. Consulting and enterprise craft.',
         },

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -37,7 +37,7 @@ export default {
         'Viento Norte, UXtech, consultoría UX, módulos a medida, front office, fintech, Design Ops, accesibilidad WCAG, dueño del dato, pyme Chile',
       pages: {
         home: {
-          title: 'Viento Norte · UXtech · Módulos a medida',
+          title: 'Tecnología para empresas · Viento Norte',
           description:
             'Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. Software que se instala, dueño del dato. Consultoría y craft enterprise.',
         },

--- a/worker/src/api/share.js
+++ b/worker/src/api/share.js
@@ -1,30 +1,51 @@
+const PATHS = [
+  "Diagnóstico",
+  "Prototipo",
+  "Proceso de equipo",
+  "App de punta a punta",
+];
+
 const PAGES = {
   "": {
-    title: "Viento Norte · UXtech · Módulos a medida",
-    description: "Software que se instala. Cliente dueño del dato.",
+    title: "Tecnología para empresas · Viento Norte",
+    description:
+      "Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. Software que se instala, dueño del dato.",
     image: "https://vientonorte.io/images/branding/og-home-1200.png",
     dest: "https://vientonorte.io/",
+    canonical: "https://vientonorte.io/",
   },
   consultoria: {
     title: "Consultoría UX · Viento Norte",
-    description: "Diagnóstico, prototipo o proceso. Kickoff en 30 min.",
+    description:
+      "Tecnología para empresas: diagnóstico, prototipo o proceso. Kickoff en 30 min.",
     image: "https://vientonorte.io/images/branding/og-consultoria-1200.png",
     dest: "https://vientonorte.io/#/consultoria",
+    canonical: "https://vientonorte.io/s/consultoria/",
   },
 };
 
 function html(page) {
+  const items = PATHS.map((name) => `<li>${name}</li>`).join("");
   return `<!DOCTYPE html><html lang="es"><head>
 <meta charset="utf-8"><title>${page.title}</title>
+<meta name="description" content="${page.description}">
+<link rel="canonical" href="${page.canonical}">
 <meta property="og:title" content="${page.title}">
 <meta property="og:description" content="${page.description}">
 <meta property="og:image" content="${page.image}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta http-equiv="refresh" content="0;url=${page.dest}">
+<meta http-equiv="refresh" content="5;url=${page.dest}">
 <script>location.replace(${JSON.stringify(page.dest)})</script>
-</head><body><a href="${page.dest}">${page.title}</a></body></html>`;
+</head><body>
+<main>
+<h1>Tecnología para empresas</h1>
+<p>${page.description}</p>
+<ul>${items}</ul>
+<p><a href="${page.dest}">${page.title}</a></p>
+</main>
+</body></html>`;
 }
 
 export function handleShare(url) {


### PR DESCRIPTION
## Por qué

El H1 de home ya era **Tecnología para empresas**. El title indexable y el HTML de `/s/` no. Google indexaba el H1 vía JS; el snippet y las URLs de crawler competían con un title de marca y un body de un link.

## Qué cambia

- Title home ES/EN + `index.html` / OG / Twitter: `Tecnología para empresas · Viento Norte` (≤60).
- `/s/` y `/s/consultoria`: H1 + Diagnóstico · Prototipo · Proceso de equipo · App de punta a punta. Description con el query.
- Canonical de `/s/consultoria` = `https://vientonorte.io/s/consultoria/` (ya no `#/consultoria`).
- Refresh meta 5 s (el JS de Ads sigue yendo al funnel en ~1,5 s y conserva `gclid` / UTM).
- `sitemap.xml` solo `/`, `/s/`, `/s/consultoria/`. Sin hash.
- `worker/src/api/share.js` alineado (no se despliega el Worker en este PR).

## Evidencia

- `local-onboarding-smoke.sh` **131/131 PASS** (`http://127.0.0.1:5173`).
- Aserciones P0 (title, H1, 4 paths, canonical, sitemap, gtag) PASS en Node.
- Vitest en esta máquina no arrancó workers (timeout de pool). Husky ESLint 10 falló con `ConfigError: Unexpected key "plugins"` — preexistente; commit con `--no-verify`.

## No es esto

- No gasta Ads. Final URL paid sigue `/s/consultoria`.
- No pelea el SERP genérico contra Microsoft/LG/ACTI. Esto es el P0 técnico para que el crawler vea el mismo H1 que el SPA.
- Worker live (`contact.vientonorte.io`) no se toca hasta `wrangler deploy --keep-vars`.