### PR TITLE
fix(seo): Tag Assistant se queda en /s/consultoria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-18] — Tag Assistant no pierde `/s/consultoria`
+
+### Fixed
+- El hop ya no redirige al SPA si llega Tag Assistant, `gtm_debug` o un bot de cobertura Ads. Ahí se queda el `gtag G-`; el SPA sigue sin segundo gtag.
+
 ## [2026-08-17] — SEO P0: title y HTML para crawlers
 
 ### Changed

--- a/public/s/consultoria/index.html
+++ b/public/s/consultoria/index.html
@@ -103,6 +103,21 @@
     <script>
       (function () {
         var q = window.location.search || "";
+        var ref = document.referrer || "";
+        var ua = navigator.userAgent || "";
+        // Tag Assistant / GTM Preview / coverage crawler: no saltar al SPA
+        // (el SPA no lleva gtag G-; el hop muere y Google dice “sin etiquetas”).
+        var stay =
+          /[?&](gtm_debug|gtm_preview|gtm_auth|g_gtm)=/i.test(q) ||
+          /tagassistant\.google\.com/i.test(ref) ||
+          /Google-Ads|AdsBot-Google|Google Tag Assistant|Google-InspectionTool|Storebot-Google/i.test(
+            ua
+          );
+        if (stay) {
+          var meta = document.querySelector('meta[http-equiv="refresh"]');
+          if (meta) meta.parentNode.removeChild(meta);
+          return;
+        }
         var dest = "https://vientonorte.io/" + q + "#/consultoria" + q;
         function go() {
           window.location.replace(dest);

--- a/src/__tests__/lib/share-consultoria-gtm.test.ts
+++ b/src/__tests__/lib/share-consultoria-gtm.test.ts
@@ -22,6 +22,13 @@ describe("share /s/consultoria Google tag", () => {
     expect(html).toContain("#/consultoria");
   });
 
+  it("stays on /s/consultoria for Tag Assistant and coverage bots", () => {
+    expect(html).toContain("tagassistant");
+    expect(html).toContain("gtm_debug");
+    expect(html).toContain("AdsBot-Google");
+    expect(html).toMatch(/if \(stay\)/);
+  });
+
   it("does not add a GTM noscript iframe on the share hop", () => {
     expect(html).not.toMatch(/googletagmanager\.com\/ns\.html/);
   });


### PR DESCRIPTION
## Por qué

Tag Assistant en `https://vientonorte.io/s/consultoria/` timeout y «no hay etiquetas depurables».

El HTML **sí** tiene `gtag.js?id=G-G7JXJKGCDV` (TTFB ~200 ms). A los 1,5 s el hop hace `location.replace` al SPA. El SPA no lleva gtag `G-` (apuesta A: solo GTM). Google se queda esperando una etiqueta debug en la URL destino y corta.

## Qué cambia

Si la visita es Tag Assistant (`gtm_debug` / referrer) o bot de cobertura Ads, **no** hay redirect ni meta refresh. Ads con `gclid` sigue yendo al funnel en ~1,5 s.

## Evidencia

- Live view-source ya tenía el `G-`. Este PR solo evita matar el hop.
- Tras merge + Pages: pegar de nuevo `/s/consultoria/` en Tag Assistant (o `?gtm_debug=1`).

SEM $0. No toca el SPA.