### PR TITLE
feat(cv): About ofrece PDF y Word ATS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-18] — CV: PDF + Word ATS
+
+### Changed
+- About: dos botones, **PDF** y **Word (ATS)**, según locale ES/EN.
+
 ## [2026-08-18] — CV PDF = ATS del otro chat
 
 ### Changed

--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -21,7 +21,7 @@ import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
 import { useLanguage } from "../../lib/LanguageContext";
 import { analytics } from "../../lib/analytics";
-import { getCvDownloadUrl } from "../../lib/site-contact";
+import { getCvDocxUrl, getCvDownloadUrl } from "../../lib/site-contact";
 import { cn } from "../../lib/utils";
 import {
   PERFIL_CYCLE,
@@ -157,7 +157,19 @@ export function About() {
               className="border-2 group min-h-11"
             >
               <Download className="mr-2 h-4 w-4 transition-transform group-hover:translate-y-0.5" />
-              CV PDF
+              PDF
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              onClick={() => {
+                analytics.downloadCV();
+                window.open(getCvDocxUrl(language), "_blank", "noopener,noreferrer");
+              }}
+              className="border-2 group min-h-11"
+            >
+              <Download className="mr-2 h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+              Word (ATS)
             </Button>
             <Button
               type="button"

--- a/src/lib/site-contact.ts
+++ b/src/lib/site-contact.ts
@@ -105,6 +105,11 @@ export function getCvDownloadUrl(language: 'es' | 'en' = 'es'): string {
   return `${import.meta.env.BASE_URL}${file}`;
 }
 
+export function getCvDocxUrl(language: 'es' | 'en' = 'es'): string {
+  const file = language === 'en' ? CV_DOCX_EN : CV_DOCX_ES;
+  return `${import.meta.env.BASE_URL}${file}`;
+}
+
 export function getContactMailtoUrl(): string {
   return `mailto:${PUBLIC_CONTACT_EMAIL}`;
 }


### PR DESCRIPTION
About ahora tiene **PDF** y **Word (ATS)** según idioma, como en escritorio:

| Idioma | PDF | Word |
|--------|-----|------|
| EN | \`/cv-rodrigo-gaete-ux-en.pdf\` | \`/Rodrigo-Gaete-CV-EN-ATS.docx\` |
| ES | \`/cv-rodrigo-gaete-ux.pdf\` | \`/Rodrigo-Gaete-CV-ES-ATS.docx\` |