### PR TITLE
feat(consultoria): Radio de tres nombres (DS-2026-08-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-20] — Radio de tres nombres (consultoría SEM)
+
+### Changed
+- `/#/consultoria`: tres radios Diagnóstico / Prototipo / Proceso. SKU Radar·Marco·Ops no se pinta.
+- Un CTA **Agendar 30 min** (`?pack=` interno). Gratis = nota, misma agenda Diagnóstico.
+- Hero sin Calendar ni CTAs duales. `/s/consultoria` lista 3 alcances + kickoff 30 min.
+
 ## [2026-08-18] — CV: PDF + Word ATS
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-20] — `/poc#/auditoria` deprecado
+
+### Changed
+- `https://vientonorte.io/poc#/auditoria` redirige a `/#/consultoria`. No es freemium.
+- `/#/auditoria` = muestra mentoría, `noindex`. Paid = `/s/consultoria`.
+
 ## [2026-08-20] — Radio de tres nombres (consultoría SEM)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-20] — Radio `?pack=ops` al listón Design Ops
+
+### Changed
+- Un H1 (sin duplicar «Elige tu alcance»). Alcance es **h2**. Un Agendar 30 min si hay pack.
+- Copy SEM: sin app / Design Ops / `vientonorte.cl`. Selección con tokens `--vn-color-brand`.
+
 ## [2026-08-20] — `/poc#/auditoria` deprecado
 
 ### Changed

--- a/docs/CONSULTORIA-MVP-SCOPE.md
+++ b/docs/CONSULTORIA-MVP-SCOPE.md
@@ -31,7 +31,7 @@ Demo campaña → /#/demo/x-cms
 | `/consultoria/modulos/:moduleId` | Deep link módulo SEM | … |
 | `/consultoria/embudo` | **Legacy** → `/` | redirect |
 | `/demo/x-cms` | Demo campaña | https://vientonorte.io/#/demo/x-cms |
-| `/poc/product-onboarding` | Legacy → SEM | redirect |
+| `/poc` · `/poc#/auditoria` | **Deprecado** → SEM | redirect `/#/consultoria` |
 | `/proceso` | Macros de método | https://vientonorte.io/#/proceso |
 
 **Local:** home `http://127.0.0.1:5173/#/` · SEM `…/#/consultoria`

--- a/docs/URL-CANON-VIENTONORTE.md
+++ b/docs/URL-CANON-VIENTONORTE.md
@@ -40,7 +40,10 @@
 |-------|--------|
 | `/#/consultoria/embudo` | `/` (home) |
 | `/#/poc/product-onboarding` | `/#/consultoria` (SEM) |
+| **`/poc` · `/poc#/auditoria`** | **`/#/consultoria`** (deprecado · no freemium) |
 | `/mi-portafolio/…` | root `.io` |
+
+`/#/auditoria` sigue vivo como **muestra mentoría** (noIndex). **Nunca** Ads ni lead pyme. Freemium = nota a11y en `/#/consultoria` → Calendar Diagnóstico. Paid crawler = `/s/consultoria`.
 
 ## Repo git
 

--- a/index.html
+++ b/index.html
@@ -2,16 +2,22 @@
 <html lang="es">
   <head>
     <script>
-      // Legacy /mi-portafolio/* → root (preserves hash). Soft-404 SPA shell also hits this.
+      // Legacy paths. Soft-404 SPA shell also hits this (Pages 404.html = index).
       (function () {
         var p = location.pathname || "/";
+        var q = location.search || "";
         if (p === "/mi-portafolio" || p.indexOf("/mi-portafolio/") === 0) {
           var h = location.hash || "#/";
           if (h.charAt(0) !== "#") h = "#" + h;
           if (h.indexOf("#/mi-portafolio") === 0) {
             h = "#" + (h.slice("#/mi-portafolio".length) || "/");
           }
-          location.replace("https://vientonorte.io/" + h + location.search);
+          location.replace("https://vientonorte.io/" + h + q);
+          return;
+        }
+        // Deprecated: /poc#/auditoria is NOT freemium. Paid = /s/consultoria.
+        if (p === "/poc" || p.indexOf("/poc/") === 0) {
+          location.replace(location.origin + "/#/consultoria" + q);
         }
       })();
     </script>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,4 +10,8 @@ Disallow: /admin/
 Disallow: /#/admin
 Disallow: /#/admin/fotos
 Disallow: /#/grafo
+Disallow: /poc
+Disallow: /poc/
+Disallow: /#/poc
+Disallow: /#/auditoria
 Disallow: /ops/

--- a/public/s/consultoria/index.html
+++ b/public/s/consultoria/index.html
@@ -64,11 +64,6 @@
             "@type": "Offer",
             "name": "Proceso de equipo",
             "description": "Guía del equipo y cómo medir. 4–6 semanas."
-          },
-          {
-            "@type": "Offer",
-            "name": "App de punta a punta",
-            "description": "Idea → app en uso. Un interlocutor de idea a release."
           }
         ]
       }
@@ -135,14 +130,13 @@
     <main>
       <h1>Tecnología para empresas</h1>
       <p>
-        Diagnóstico, prototipo, proceso de equipo o app funcional. Software que
-        se instala, dueño del dato.
+        Diagnóstico, prototipo o proceso de equipo. Kickoff 30 min. Precio en la
+        llamada. Gratis: accesibilidad de un flujo.
       </p>
       <ul>
         <li>Diagnóstico</li>
         <li>Prototipo</li>
         <li>Proceso de equipo</li>
-        <li>App de punta a punta</li>
       </ul>
       <p>
         <a href="https://vientonorte.io/#/consultoria">Consultoría Viento Norte</a>

--- a/public/s/index.html
+++ b/public/s/index.html
@@ -6,7 +6,7 @@
     <title>Tecnología para empresas · Viento Norte</title>
     <meta
       name="description"
-      content="Tecnología para empresas: diagnóstico, prototipo, proceso de equipo o app. Software que se instala, dueño del dato. Consultoría y craft enterprise."
+      content="Tecnología para empresas: diagnóstico, prototipo o proceso de equipo. Kickoff 30 min. Gratis: accesibilidad de un flujo."
     />
     <link rel="canonical" href="https://vientonorte.io/" />
     <meta property="og:type" content="website" />
@@ -14,7 +14,7 @@
     <meta property="og:title" content="Tecnología para empresas · Viento Norte" />
     <meta
       property="og:description"
-      content="Tecnología para empresas: diagnóstico, prototipo, proceso o app. Software que se instala, dueño del dato."
+      content="Tecnología para empresas: diagnóstico, prototipo o proceso. Kickoff 30 min."
     />
     <meta property="og:image" content="https://vientonorte.io/images/branding/og-home-1200.png" />
     <meta property="og:image:width" content="1200" />
@@ -37,14 +37,13 @@
     <main>
       <h1>Tecnología para empresas</h1>
       <p>
-        Diagnóstico, prototipo, proceso de equipo o app funcional. Software que
-        se instala, dueño del dato.
+        Diagnóstico, prototipo o proceso de equipo. Kickoff 30 min. Precio en la
+        llamada. Gratis: accesibilidad de un flujo.
       </p>
       <ul>
         <li>Diagnóstico</li>
         <li>Prototipo</li>
         <li>Proceso de equipo</li>
-        <li>App de punta a punta</li>
       </ul>
       <p><a href="https://vientonorte.io/">Viento Norte</a></p>
     </main>

--- a/scripts/qa-routes.mjs
+++ b/scripts/qa-routes.mjs
@@ -182,7 +182,7 @@ async function checkRoute(page, { path, label }) {
   }
 }
 
-/** Home FO = embudo: hero #inicio + CTAs (ya no path cards de portafolio). */
+/** Home FO = Radio: H1 en #inicio, CTA único en #modalidades (no CTAs en hero). */
 async function checkHeroMobileSuggestions(browser) {
   const ctx = await browser.newContext({
     serviceWorkers: 'block',
@@ -193,19 +193,23 @@ async function checkHeroMobileSuggestions(browser) {
     await mPage.goto(hashUrl('/'), { waitUntil: 'domcontentloaded', timeout: 45000 });
     await mPage.waitForSelector('[data-testid="consultoria-funnel"]', { timeout: 25000 });
     await mPage.waitForSelector('#inicio', { timeout: 15000 });
-    const startCta = mPage.locator('#inicio').getByRole('button').first();
-    const visible = await startCta.isVisible();
-    const modalidades = await mPage.locator('#modalidades').count();
+    const h1 = mPage.locator('#inicio h1').first();
+    const h1Visible = await h1.isVisible();
+    const radios = mPage.locator('#modalidades [role="radiogroup"]');
+    const cta = mPage.locator('#modalidades').getByRole('button').first();
+    const hasRadios = (await radios.count()) > 0;
+    const ctaVisible = await cta.isVisible();
+    const ok = h1Visible && hasRadios && ctaVisible;
     return {
       label: 'Home embudo mobile hero',
-      ok: visible && modalidades > 0,
-      errors:
-        visible && modalidades > 0
-          ? []
-          : [
-              !visible ? 'CTA no visible en #inicio' : '',
-              modalidades === 0 ? 'falta #modalidades' : '',
-            ].filter(Boolean),
+      ok,
+      errors: ok
+        ? []
+        : [
+            !h1Visible ? 'H1 no visible en #inicio' : '',
+            !hasRadios ? 'falta radiogroup en #modalidades' : '',
+            !ctaVisible ? 'CTA no visible en #modalidades' : '',
+          ].filter(Boolean),
     };
   } catch (err) {
     return { label: 'Home embudo mobile hero', ok: false, errors: [err.message.split('\n')[0]] };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,6 +171,15 @@ function AppRoutes() {
             <Route path="/empresa/:companyId" element={<CompanyDetailRoute />} />
             <Route path="/proyecto/:projectId" element={<ProjectDetailRoute />} />
             <Route path="/auditoria" element={<AuditoriaPortfolio />} />
+            {/* /poc y /poc#/auditoria deprecados → SEM. Freemium ≠ mentoría. */}
+            <Route
+              path="/poc"
+              element={<Navigate to={ROUTES.consulting} replace />}
+            />
+            <Route
+              path="/poc/*"
+              element={<Navigate to={ROUTES.consulting} replace />}
+            />
             {/* Embudo legacy → home */}
             <Route
               path={LEGACY_ROUTES.consultingFunnelLegacy}

--- a/src/__tests__/lib/routes.test.ts
+++ b/src/__tests__/lib/routes.test.ts
@@ -8,6 +8,7 @@ import {
   isConsultingPath,
   isAdminPath,
   isTimedDemoPath,
+  isDeprecatedPocPath,
 } from '@/lib/routes';
 
 describe('routes', () => {
@@ -51,6 +52,14 @@ describe('routes', () => {
     expect(isTimedDemoPath('/demo/x-cms')).toBe(true);
     expect(isTimedDemoPath('/demo/diagnostic')).toBe(true);
     expect(isTimedDemoPath('/consultoria')).toBe(false);
+  });
+
+  it('deprecated /poc (incl. /poc#/auditoria) is not SEM', () => {
+    expect(isDeprecatedPocPath('/poc')).toBe(true);
+    expect(isDeprecatedPocPath('/poc/product-onboarding')).toBe(true);
+    expect(isDeprecatedPocPath('/auditoria')).toBe(false);
+    expect(isDeprecatedPocPath('/consultoria')).toBe(false);
+    expect(LEGACY_ROUTES.pocRoot).toBe('/poc');
   });
 
   it('admin hub and photos are admin paths', () => {

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -13,12 +13,7 @@ const shareConsultoria = readFileSync(
 );
 const sitemap = readFileSync(resolve(root, "public/sitemap.xml"), "utf8");
 
-const PATHS = [
-  "Diagnóstico",
-  "Prototipo",
-  "Proceso de equipo",
-  "App de punta a punta",
-];
+const PATHS = ["Diagnóstico", "Prototipo", "Proceso de equipo"];
 
 describe("SEO P0 · title home vs query", () => {
   it("home title leads with Tecnología para empresas and stays ≤60", () => {
@@ -37,7 +32,7 @@ describe("SEO P0 · title home vs query", () => {
 });
 
 describe("SEO P0 · crawler HTML /s/", () => {
-  it("share home has H1, four paths, and query in title/description", () => {
+  it("share home has H1, three paths, and query in title/description", () => {
     expect(shareHome).toMatch(/<h1>\s*Tecnología para empresas\s*<\/h1>/);
     for (const name of PATHS) {
       expect(shareHome).toContain(name);
@@ -51,7 +46,7 @@ describe("SEO P0 · crawler HTML /s/", () => {
     expect(shareHome).toContain('content="5;url=https://vientonorte.io/"');
   });
 
-  it("share consultoria has H1, four paths, query, and no hash canonical", () => {
+  it("share consultoria has H1, three paths, query, and no hash canonical", () => {
     expect(shareConsultoria).toMatch(/<h1>\s*Tecnología para empresas\s*<\/h1>/);
     for (const name of PATHS) {
       expect(shareConsultoria).toContain(name);

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -1,45 +1,15 @@
-import { useNavigate } from "react-router-dom";
-import { ArrowRight } from "lucide-react";
 import { Badge } from "../ui/badge";
-import { Button } from "../ui/button";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
-import { trackEvent } from "../../lib/analytics";
-import { openCalendarBooking } from "../../lib/site-contact";
-import { openFreeRadarEntry } from "../../lib/free-radar-entry";
-import { scrollToSection } from "../../lib/scroll-to-section";
-
-interface ConsultoriaLandingHeroProps {
-  onExploreEvidence?: () => void;
-}
 
 /**
- * Hero FO: un solo CTA = Google Calendar.
- * Alcance y mail viven más abajo; método/casos en páginas interiores.
+ * Hero SEM/FO · Radio de tres nombres.
+ * Alcance y CTA único viven en #modalidades. Calendar no va en el hero (parking DS).
  */
-export function ConsultoriaLandingHero({
-  onExploreEvidence,
-}: ConsultoriaLandingHeroProps) {
-  const navigate = useNavigate();
+export function ConsultoriaLandingHero() {
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.landing;
   const es = language === "es";
-
-  const bookCalendar = () => {
-    trackEvent("consultoria_hero_cta", { action: "calendar_booking" });
-    if (!openCalendarBooking()) {
-      scrollToSection("contacto");
-    }
-  };
-
-  const seeOptions = () => {
-    trackEvent("consultoria_hero_cta", { action: "secondary_modalidades" });
-    if (onExploreEvidence) {
-      onExploreEvidence();
-      return;
-    }
-    scrollToSection("modalidades");
-  };
 
   return (
     <section
@@ -67,36 +37,6 @@ export function ConsultoriaLandingHero({
           <p className="mx-auto max-w-md text-base leading-relaxed text-muted-foreground md:text-lg">
             {t.description}
           </p>
-
-          <div className="flex flex-col items-center justify-center gap-3">
-            <Button
-              size="lg"
-              className="funnel-cta-primary min-h-[48px] bg-brand-gradient px-8 font-semibold hover:opacity-90 focus-visible:ring-offset-2"
-              onClick={bookCalendar}
-            >
-              {t.ctaPrimary}
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-            </Button>
-            <button
-              type="button"
-              onClick={() => {
-                trackEvent("consultoria_hero_cta", { action: "free_a11y" });
-                openFreeRadarEntry(navigate, language, "consultoria-hero", {
-                  mode: "auto",
-                });
-              }}
-              className="inline-flex min-h-11 items-center text-sm font-medium text-primary underline-offset-4 hover:underline"
-            >
-              {t.ctaFreeA11y}
-            </button>
-            <button
-              type="button"
-              onClick={seeOptions}
-              className="inline-flex min-h-11 items-center text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              {t.ctaSecondary}
-            </button>
-          </div>
 
           <ul
             className="flex flex-wrap items-center justify-center gap-2"

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -30,8 +30,13 @@ export function ConsultoriaLandingHero() {
             id="consultoria-hero-heading"
             className="text-3xl font-bold tracking-tight sm:text-4xl md:text-[2.5rem] md:leading-[1.12]"
           >
-            {t.title}{" "}
-            <span className="text-brand-gradient">{t.titleAccent}</span>
+            {t.title}
+            {t.titleAccent ? (
+              <>
+                {" "}
+                <span className="text-brand-gradient">{t.titleAccent}</span>
+              </>
+            ) : null}
           </h1>
 
           <p className="mx-auto max-w-md text-base leading-relaxed text-muted-foreground md:text-lg">

--- a/src/components/organisms/ConsultoriaOnboarding.tsx
+++ b/src/components/organisms/ConsultoriaOnboarding.tsx
@@ -64,13 +64,15 @@ export function ConsultoriaOnboarding({ packageId }: ConsultoriaOnboardingProps)
           </p>
         ) : null}
         <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-          <Button
-            className="min-h-[44px] bg-brand-gradient font-semibold"
-            onClick={book}
-          >
-            <Calendar className="mr-2 h-4 w-4" aria-hidden />
-            {copy.ctaCalendar}
-          </Button>
+          {pkg ? null : (
+            <Button
+              className="min-h-[44px] bg-brand-gradient font-semibold"
+              onClick={book}
+            >
+              <Calendar className="mr-2 h-4 w-4" aria-hidden />
+              {copy.ctaCalendar}
+            </Button>
+          )}
           <Button
             variant="outline"
             className="min-h-[44px]"

--- a/src/components/organisms/ConsultoriaOnboarding.tsx
+++ b/src/components/organisms/ConsultoriaOnboarding.tsx
@@ -59,7 +59,7 @@ export function ConsultoriaOnboarding({ packageId }: ConsultoriaOnboardingProps)
         {pkg ? (
           <p className="mt-3 flex flex-wrap items-center gap-2 text-sm">
             <span className="text-muted-foreground">{copy.packLabel}</span>
-            <Badge variant="outline">{pkg.packLabel[language]}</Badge>
+            <Badge variant="outline">{pkg.name[language]}</Badge>
             <span>{pkg.youGet[language]}</span>
           </p>
         ) : null}

--- a/src/components/organisms/ConsultoriaPackages.tsx
+++ b/src/components/organisms/ConsultoriaPackages.tsx
@@ -75,6 +75,7 @@ export function ConsultoriaPackages({
         title={t.title}
         description={t.description}
         titleId="consultoria-packages-heading"
+        titleAs="h2"
         align="left"
       />
 
@@ -88,10 +89,11 @@ export function ConsultoriaPackages({
           return (
             <label
               key={pkg.id}
+              data-selected={checked ? "true" : "false"}
               className={cn(
-                "funnel-pack-card flex cursor-pointer flex-col rounded-2xl border-2 bg-surface-matte-elevated p-5 shadow-sm transition-colors",
+                "funnel-pack-card flex min-h-[44px] cursor-pointer flex-col rounded-2xl border-2 bg-surface-matte-elevated p-5 shadow-sm transition-colors focus-within:outline focus-within:outline-2 focus-within:outline-offset-2",
                 checked
-                  ? "border-primary ring-2 ring-primary/30"
+                  ? "border-[color:var(--vn-color-brand)]"
                   : "border-[color:var(--logo-surface-border)] hover:border-primary/40"
               )}
             >
@@ -147,10 +149,9 @@ export function ConsultoriaPackages({
           {landing.onboarding.ctaCalendar}
         </Button>
         <p className="max-w-xl text-sm text-muted-foreground">
-          {t.freeNote}{" "}
           <button
             type="button"
-            className="font-medium text-primary underline-offset-4 hover:underline"
+            className="min-h-11 text-left font-normal text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
             onClick={() => {
               trackEvent("consultoria_hero_cta", { action: "free_a11y_note" });
               openFreeRadarEntry(navigate, language, "consultoria-packages", {
@@ -158,7 +159,7 @@ export function ConsultoriaPackages({
               });
             }}
           >
-            {landing.ctaFreeA11y}
+            {t.freeNote}
           </button>
         </p>
       </div>

--- a/src/components/organisms/ConsultoriaPackages.tsx
+++ b/src/components/organisms/ConsultoriaPackages.tsx
@@ -1,65 +1,64 @@
-import { ArrowRight, Clock, Package, Play, Smartphone, Star } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Calendar, Clock } from "lucide-react";
 import { PageSection } from "../layout/PageSection";
 import { SectionHeader } from "../molecules/SectionHeader";
-import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../ui/card";
 import {
   CONSULTING_PACKAGES,
   type ConsultingPackageId,
 } from "../../data/vientonorte-consulting";
-import {
-  demoMinutes,
-  getServicePathDemo,
-  packToServicePath,
-} from "../../data/service-path-demos";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
 import { trackEvent } from "../../lib/analytics";
-import { ROUTES } from "../../lib/routes";
+import { openCalendarBooking } from "../../lib/site-contact";
+import { openFreeRadarEntry } from "../../lib/free-radar-entry";
+import { scrollToSection } from "../../lib/scroll-to-section";
 import { cn } from "../../lib/utils";
+import { useNavigate } from "react-router-dom";
 
 export type PackageSelectOptions = { appGoal?: boolean };
 
 interface ConsultoriaPackagesProps {
+  selectedPackageId?: ConsultingPackageId;
   onSelectPackage?: (
     packageId: ConsultingPackageId,
     options?: PackageSelectOptions
   ) => void;
+  /** Home FO only. SEM Radio = tres nombres, sin 4ª card. */
   showAppStrip?: boolean;
 }
 
 export function ConsultoriaPackages({
+  selectedPackageId,
   onSelectPackage,
-  showAppStrip = true,
+  showAppStrip = false,
 }: ConsultoriaPackagesProps) {
   const navigate = useNavigate();
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.packagesSection;
-  const rec = useTranslation(language).consultoria.recommended;
+  const landing = useTranslation(language).consultoria.landing;
+  void showAppStrip;
 
-  const select = (id: ConsultingPackageId, options?: PackageSelectOptions) => {
+  const select = (id: ConsultingPackageId) => {
     trackEvent("consultoria_package_select", {
       package_id: id,
-      app: Boolean(options?.appGoal),
+      radio: true,
     });
-    onSelectPackage?.(id, options);
+    onSelectPackage?.(id);
   };
 
-  const openDemo = (
-    pathId: ReturnType<typeof packToServicePath> | "app",
-    origin: string,
-    packId?: ConsultingPackageId
-  ) => {
-    const demo = getServicePathDemo(pathId);
-    if (!demo) return;
-    trackEvent("service_path_demo_open", {
-      path_id: demo.id,
-      package_id: packId ?? demo.packageId,
-      origin,
+  const book = () => {
+    trackEvent("consultoria_hero_cta", {
+      action: "calendar_booking",
+      package_id: selectedPackageId ?? "none",
     });
-    navigate(ROUTES.serviceDemo(demo.id));
+    if (
+      !openCalendarBooking({
+        packageId: selectedPackageId,
+        origin: "scope-radio",
+      })
+    ) {
+      scrollToSection("contacto");
+    }
   };
 
   return (
@@ -73,147 +72,96 @@ export function ConsultoriaPackages({
     >
       <SectionHeader
         badge={t.badge}
-        badgeIcon={Package}
         title={t.title}
         description={t.description}
         titleId="consultoria-packages-heading"
         align="left"
       />
 
-      <ul className="grid gap-5 md:grid-cols-3" role="list">
-        {CONSULTING_PACKAGES.map((pkg) => (
-          <li key={pkg.id} className="h-full">
-            <Card
+      <div
+        role="radiogroup"
+        aria-labelledby="consultoria-packages-heading"
+        className="grid gap-4 md:grid-cols-3"
+      >
+        {CONSULTING_PACKAGES.map((pkg) => {
+          const checked = selectedPackageId === pkg.id;
+          return (
+            <label
+              key={pkg.id}
               className={cn(
-                "funnel-pack-card flex h-full flex-col border-2 border-[color:var(--logo-surface-border)] bg-surface-matte-elevated shadow-sm",
-                pkg.featured && "border-primary/40 ring-1 ring-primary/30 shadow-md"
+                "funnel-pack-card flex cursor-pointer flex-col rounded-2xl border-2 bg-surface-matte-elevated p-5 shadow-sm transition-colors",
+                checked
+                  ? "border-primary ring-2 ring-primary/30"
+                  : "border-[color:var(--logo-surface-border)] hover:border-primary/40"
               )}
             >
-              <CardHeader className="space-y-3">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                    {/* packLabel técnico (Radar · Marco · Ops); nombre humano abajo */}
-                    <Badge
-                      variant="outline"
-                      className="border-border text-foreground"
-                    >
-                      {pkg.packLabel[language]}
-                    </Badge>
-                    {pkg.featured ? (
-                      <Badge className="gap-1 bg-foreground text-background hover:bg-foreground/90">
-                        <Star className="h-3 w-3" aria-hidden />
-                        {rec}
-                      </Badge>
-                    ) : null}
-                  </div>
-                  <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-                    <Clock className="h-3.5 w-3.5" aria-hidden />
-                    {pkg.duration[language]}
-                  </span>
-                </div>
-                <CardTitle className="text-xl">{pkg.name[language]}</CardTitle>
-                <p className="text-xs font-medium text-primary/90">
-                  {pkg.youGet[language]}
-                </p>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  {pkg.tagline[language]}
-                </p>
-              </CardHeader>
-              <CardContent className="flex-1">
-                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-foreground">
-                  {t.deliverablesLabel}
-                </p>
-                <ul className="space-y-2" role="list">
-                  {pkg.deliverables[language].map((d) => (
-                    <li
-                      key={d}
-                      className="flex gap-2 text-sm text-muted-foreground"
-                    >
-                      <span
-                        className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
-                        aria-hidden
-                      />
-                      {d}
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-              <CardFooter className="flex flex-col gap-2">
-                <Button
+              <input
+                type="radio"
+                name="consultoria-alcance"
+                value={pkg.id}
+                checked={checked}
+                onChange={() => select(pkg.id)}
+                className="sr-only"
+              />
+              <span className="flex items-start justify-between gap-3">
+                <span className="text-lg font-semibold tracking-tight">
+                  {pkg.name[language]}
+                </span>
+                <span
                   className={cn(
-                    "w-full min-h-[44px]",
-                    pkg.featured
-                      ? "funnel-cta-primary bg-brand-gradient font-semibold hover:opacity-90"
-                      : "funnel-cta-ghost"
+                    "mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2",
+                    checked
+                      ? "border-primary bg-primary"
+                      : "border-muted-foreground/40"
                   )}
-                  variant={pkg.featured ? "default" : "outline"}
-                  onClick={() => select(pkg.id)}
+                  aria-hidden
                 >
-                  {t.cta}
-                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-                </Button>
-                {(() => {
-                  const demo = getServicePathDemo(packToServicePath(pkg.id));
-                  if (!demo) return null;
-                  return (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      className="w-full min-h-[44px] text-muted-foreground"
-                      onClick={() => openDemo(demo.id, "pack-card", pkg.id)}
-                    >
-                      <Play className="mr-2 h-4 w-4" aria-hidden />
-                      {t.ctaDemo.replace("{min}", String(demoMinutes(demo)))}
-                    </Button>
-                  );
-                })()}
-              </CardFooter>
-            </Card>
-          </li>
-        ))}
-      </ul>
+                  {checked ? (
+                    <span className="h-2 w-2 rounded-full bg-primary-foreground" />
+                  ) : null}
+                </span>
+              </span>
+              <span className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground">
+                <Clock className="h-3.5 w-3.5" aria-hidden />
+                {pkg.duration[language]}
+              </span>
+              <span className="mt-2 text-sm font-medium text-primary/90">
+                {pkg.youGet[language]}
+              </span>
+              <span className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                {pkg.tagline[language]}
+              </span>
+            </label>
+          );
+        })}
+      </div>
 
-      {showAppStrip ? (
-      <Card className="mt-3 border border-primary/20 bg-surface-matte-elevated shadow-none">
-        <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex gap-3 min-w-0">
-            <span
-              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-logo-surface text-primary"
-              aria-hidden
-            >
-              <Smartphone className="h-5 w-5" />
-            </span>
-            <div className="min-w-0 space-y-1">
-              <p className="text-base font-semibold tracking-tight">
-                {t.appStripTitle}
-              </p>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {t.appStripBody}
-              </p>
-            </div>
-          </div>
-          <div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto">
-            <Button
-              className="w-full min-h-[44px] sm:w-auto"
-              variant="outline"
-              onClick={() => select("marco", { appGoal: true })}
-            >
-              {t.appStripCta}
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              className="w-full min-h-[44px] text-muted-foreground sm:w-auto"
-              onClick={() => openDemo("app", "app-strip", "marco")}
-            >
-              <Play className="mr-2 h-4 w-4" aria-hidden />
-              {t.ctaDemo.replace("{min}", "5")}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-      ) : null}
+      <div className="mt-6 flex flex-col items-stretch gap-3 sm:items-start">
+        <Button
+          size="lg"
+          className="funnel-cta-primary min-h-[48px] bg-brand-gradient px-8 font-semibold hover:opacity-90"
+          disabled={!selectedPackageId}
+          onClick={book}
+        >
+          <Calendar className="mr-2 h-4 w-4" aria-hidden />
+          {landing.onboarding.ctaCalendar}
+        </Button>
+        <p className="max-w-xl text-sm text-muted-foreground">
+          {t.freeNote}{" "}
+          <button
+            type="button"
+            className="font-medium text-primary underline-offset-4 hover:underline"
+            onClick={() => {
+              trackEvent("consultoria_hero_cta", { action: "free_a11y_note" });
+              openFreeRadarEntry(navigate, language, "consultoria-packages", {
+                mode: "auto",
+              });
+            }}
+          >
+            {landing.ctaFreeA11y}
+          </button>
+        </p>
+      </div>
 
       <p className="mt-6 text-center text-xs text-muted-foreground">{t.note}</p>
     </PageSection>

--- a/src/lib/consulting-contact-motive.ts
+++ b/src/lib/consulting-contact-motive.ts
@@ -12,8 +12,8 @@ const MOTIVE_COPY: Record<ContactMotive, { es: string; en: string }> = {
     en: "Reason: Prototype / screens ready to build.\n\n",
   },
   ops: {
-    es: "Motivo: Proceso de equipo / Design Ops.\n\n",
-    en: "Reason: Team process / Design Ops.\n\n",
+    es: "Motivo: Proceso de equipo.\n\n",
+    en: "Reason: Team process.\n\n",
   },
   help: {
     es: "Motivo: necesito ayuda para elegir alcance.\n\n",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -502,8 +502,8 @@ export default {
         title: "Let's start",
         description: 'Four short steps. Pick a deliverable and leave a ready message.',
         points: [
-          'Diagnostic · Prototype · Process · App end to end',
-          'Live app: one partner from idea to release',
+          'Diagnostic · Prototype · Process',
+          'Kickoff 30 min. Price on the call',
           'Reply within 24 business hours',
         ],
       },

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -85,7 +85,7 @@ export default {
           /** SEM final URL: https://vientonorte.io/#/consultoria — Ads message-match */
           title: 'UX Consulting · Choose your scope',
           description:
-            'Diagnostic, prototype, team process, or app. Design sprint and UX flows. Free: WCAG 2.2 AA on one critical flow. SMBs · kickoff <24h.',
+            'Diagnostic, prototype, or team process. Free: WCAG 2.2 AA on one flow. 30 min kickoff.',
           keywords:
             'UX consulting, design sprint, fintech architecture, UX flows, UXtech, product modules, WCAG accessibility, front office, Viento Norte',
         },
@@ -250,7 +250,7 @@ export default {
         title: 'Technology for business.',
         titleAccent: 'Choose your scope.',
         description:
-          'Diagnostic, prototype, team process, or working app.',
+          'Diagnostic, prototype, or team process. 30 min kickoff. Price on the call.',
         transparencyLine:
           'Free Diagnostic entry: WCAG 2.2 AA review of one critical flow. If it fits, let’s talk full Diagnostic (5–7 days).',
         ctaPrimary: 'Book on Google Calendar',
@@ -261,7 +261,7 @@ export default {
         ctaFreeLinkSchedule: 'Book 30 free minutes on Google Calendar',
         ctaFree: 'Request free review',
         trustLine: 'Reply within 24 h',
-        trustChips: ['Reply <24 h', '5–7 days', 'No prices on the site'],
+        trustChips: ['Reply <24 h', '30 min kickoff', 'No prices on the site'],
         segmentsLabel: 'What do you need?',
         segmentsHint: 'One tap = service and what you get.',
         segments: {
@@ -273,12 +273,12 @@ export default {
           prototype: {
             title: 'Prototype',
             hint: 'Screens ready to build',
-            cta: 'Start Marco',
+            cta: 'Start Prototype',
           },
           process: {
             title: 'Team process',
             hint: 'How the team designs and delivers',
-            cta: 'Start Ops',
+            cta: 'Start Process',
           },
           app: {
             title: 'App end to end',
@@ -454,9 +454,11 @@ export default {
       },
       packagesSection: {
         badge: 'How you hire',
-        title: 'Three formats + modules that install',
+        title: 'Choose your scope',
         description:
-          'Interfaces, Design Systems, and research/AI data. Pick diagnostic, prototype, or process. You keep the data and the code.',
+          'One tap: Diagnostic, Prototype, or Team process. One step: Book 30 min. No prices on the site.',
+        freeNote:
+          'Same calendar if you only want a WCAG review of one flow.',
         deliverablesLabel: 'Includes',
         cta: 'Start',
         ctaDemo: 'See demo · {min} min',

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -248,7 +248,7 @@ export default {
         badge: 'Viento Norte · SMBs',
         principleBadge: 'UX consulting',
         title: 'Technology for business.',
-        titleAccent: 'Choose your scope.',
+        titleAccent: '',
         description:
           'Diagnostic, prototype, or team process. 30 min kickoff. Price on the call.',
         transparencyLine:
@@ -328,11 +328,10 @@ export default {
         onboarding: {
           badge: 'Start',
           titleEmpty: 'Pick a scope and book',
-          titlePack: 'Start {name}',
+          titlePack: '30 min kickoff · {name}',
           bodyEmpty:
             'Diagnostic, prototype, or process. 30 min on Calendar or a short email.',
-          bodyPack:
-            'Calendar or email. If you added the pack field on the booking page, it arrives prefilled.',
+          bodyPack: 'Price on the call. One CTA above: Book 30 min.',
           packLabel: 'Format',
           ctaCalendar: 'Book 30 min',
           ctaMail: 'Write by email',
@@ -458,7 +457,7 @@ export default {
         description:
           'One tap: Diagnostic, Prototype, or Team process. One step: Book 30 min. No prices on the site.',
         freeNote:
-          'Same calendar if you only want a WCAG review of one flow.',
+          'Free · accessibility of one flow — same calendar as Diagnostic.',
         deliverablesLabel: 'Includes',
         cta: 'Start',
         ctaDemo: 'See demo · {min} min',
@@ -1110,7 +1109,7 @@ export default {
         badge: 'Viento Norte · SMBs',
         title: 'Write and we close scope',
         description:
-          'End of the funnel: diagnostic, prototype, process, or app. Reply within 24 business hours.',
+          'End of the funnel: diagnostic, prototype, or process. Reply within 24 business hours.',
         responseBadge: 'Reply <24 business hours',
         infoTitle: 'Consulting contact',
         infoDescription: 'UX consulting for SMBs · remote or hybrid',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -250,7 +250,7 @@ export default {
         title: 'Tecnología para empresas.',
         titleAccent: 'Elige tu alcance.',
         description:
-          'Diagnóstico, prototipo, proceso de equipo o app funcional.',
+          'Diagnóstico, prototipo o proceso de equipo. Kickoff 30 min. Precio en la llamada.',
         transparencyLine:
           'Entrada gratis a Diagnóstico: revisión WCAG 2.2 AA de un flujo crítico. Si aplica, conversemos el Diagnóstico completo (5–7 días).',
         ctaPrimary: 'Agendar en Google Calendar',
@@ -261,7 +261,7 @@ export default {
         ctaFreeLinkSchedule: 'Reservar 30 min gratis en Google Calendar',
         ctaFree: 'Pedir revisión gratis',
         trustLine: 'Respuesta en menos de 24 h',
-        trustChips: ['Respuesta <24 h', '5–7 días', 'Sin precios en la web'],
+        trustChips: ['Respuesta <24 h', 'Kickoff 30 min', 'Sin precios en la web'],
         segmentsLabel: '¿Qué necesitas?',
         segmentsHint: 'Un clic = servicio y lo que te llevas.',
         segments: {
@@ -273,12 +273,12 @@ export default {
           prototype: {
             title: 'Prototipo',
             hint: 'Pantallas listas para construir',
-            cta: 'Empezar Marco',
+            cta: 'Empezar Prototipo',
           },
           process: {
             title: 'Proceso de equipo',
             hint: 'Guía de cómo diseñan y entregan',
-            cta: 'Empezar Ops',
+            cta: 'Empezar Proceso',
           },
           app: {
             title: 'App de punta a punta',
@@ -454,9 +454,11 @@ export default {
       },
       packagesSection: {
         badge: 'Cómo se contrata',
-        title: 'Tres formatos + módulos que se instalan',
+        title: 'Elige tu alcance',
         description:
-          'Interfaces, Design Systems y research/AI data. Elige diagnóstico, prototipo o proceso. El cliente queda dueño del dato y del código.',
+          'Un tap: Diagnóstico, Prototipo o Proceso de equipo. Un solo paso: Agendar 30 min. Sin precios en la web.',
+        freeNote:
+          'Misma agenda si solo querés la revisión WCAG de un flujo.',
         deliverablesLabel: 'Incluye',
         cta: 'Empezar',
         ctaDemo: 'Ver demo · {min} min',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -248,7 +248,7 @@ export default {
         badge: 'Viento Norte · pymes',
         principleBadge: 'Consultoría UX',
         title: 'Tecnología para empresas.',
-        titleAccent: 'Elige tu alcance.',
+        titleAccent: '',
         description:
           'Diagnóstico, prototipo o proceso de equipo. Kickoff 30 min. Precio en la llamada.',
         transparencyLine:
@@ -328,11 +328,10 @@ export default {
         onboarding: {
           badge: 'Empezar',
           titleEmpty: 'Elige un alcance y agenda',
-          titlePack: 'Empezar {name}',
+          titlePack: 'Kickoff 30 min · {name}',
           bodyEmpty:
             'Diagnóstico, prototipo o proceso. 30 min en Calendar o un mail con el motivo.',
-          bodyPack:
-            'Calendar o mail. Si añadiste el campo pack en la agenda, llega prellenado.',
+          bodyPack: 'Precio en la llamada. Un solo CTA arriba: Agendar 30 min.',
           packLabel: 'Modalidad',
           ctaCalendar: 'Agendar 30 min',
           ctaMail: 'Escribir por mail',
@@ -458,7 +457,7 @@ export default {
         description:
           'Un tap: Diagnóstico, Prototipo o Proceso de equipo. Un solo paso: Agendar 30 min. Sin precios en la web.',
         freeNote:
-          'Misma agenda si solo querés la revisión WCAG de un flujo.',
+          'Gratis · accesibilidad de un flujo — misma agenda que Diagnóstico.',
         deliverablesLabel: 'Incluye',
         cta: 'Empezar',
         ctaDemo: 'Ver demo · {min} min',
@@ -1115,7 +1114,7 @@ export default {
         badge: 'Viento Norte · pymes',
         title: 'Escribe y cerramos alcance',
         description:
-          'Cierre del embudo: diagnóstico, prototipo, proceso o app. Respuesta en menos de 24 h hábiles.',
+          'Cierre del embudo: diagnóstico, prototipo o proceso. Respuesta en menos de 24 h hábiles.',
         responseBadge: 'Respuesta <24 h hábiles',
         infoTitle: 'Contacto consultoría',
         infoDescription: 'Consultoría UX para pymes · remoto o híbrido',
@@ -1224,7 +1223,7 @@ export default {
         sending: 'Enviando…',
         editMessage: 'Puedes editar el mensaje antes de enviar',
         privacyNote:
-          'Tus datos van a Google Forms (Viento Norte). Recibes copia por email; nos llega a contacto@vientonorte.cl — sin marketing.',
+          'Tus datos van al relay de Viento Norte. Recibes copia por email; nos llega a contacto@vientonorte.io — sin marketing.',
         success: '¡Listo! Te responderé en menos de 24 horas.',
       },
       social: {

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -502,8 +502,8 @@ export default {
         title: 'Empecemos',
         description: 'Cuatro pasos cortos. Eliges entregable y dejamos el mensaje listo.',
         points: [
-          'Diagnóstico · Prototipo · Proceso · App de punta a punta',
-          'App en uso: un solo interlocutor de idea a release',
+          'Diagnóstico · Prototipo · Proceso',
+          'Kickoff 30 min. Precio en la llamada',
           'Respuesta en menos de 24 h hábiles',
         ],
       },

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -50,6 +50,12 @@ export const ROUTES = {
     `/demo/${encodeURIComponent(pathId)}`,
 
   /**
+   * @deprecated Legacy POC prefix — HTTP `/poc` y hash `/#/poc/*`.
+   * `/poc#/auditoria` NO es freemium. Redirect a ROUTES.consulting.
+   */
+  pocRoot: "/poc",
+
+  /**
    * @deprecated Legacy POC path — redirect a ROUTES.consulting (SEM).
    */
   pocProductOnboarding: "/poc/product-onboarding",
@@ -64,6 +70,8 @@ export const ROUTES = {
 export const LEGACY_ROUTES = {
   cases: "/cases",
   casesProcess: (processId: string) => `/cases/process/${processId}`,
+  /** HTTP /poc y /poc#/auditoria → SEM (no mentoría) */
+  pocRoot: "/poc",
   /** POC tour → SEM oferta */
   pocProductOnboarding: "/poc/product-onboarding",
   /** Embudo viejo → home */
@@ -106,6 +114,12 @@ export function isConsultingPath(pathname: string): boolean {
   return (
     isConsultingFunnelPath(pathname) || isConsultingOfferPath(pathname)
   );
+}
+
+/** Prefijo POC deprecado (`/poc`, `/poc/product-onboarding`, `/poc#/auditoria`). */
+export function isDeprecatedPocPath(pathname: string): boolean {
+  const path = normalizePathname(pathname);
+  return path === "/poc" || path.startsWith("/poc/");
 }
 
 export function isAdminPath(pathname: string): boolean {

--- a/src/pages/AuditoriaPortfolio.tsx
+++ b/src/pages/AuditoriaPortfolio.tsx
@@ -166,6 +166,7 @@ export default function AuditoriaPortfolio() {
         keywords={t.seo.keywords}
         url={canonicalFromPath("/auditoria")}
         type="article"
+        noIndex
       />
 
       <header

--- a/src/pages/ConsultoriaVientoNorte.tsx
+++ b/src/pages/ConsultoriaVientoNorte.tsx
@@ -63,13 +63,6 @@ export default function ConsultoriaVientoNorte({
     });
   }, [location.pathname, location.state, navigate]);
 
-  const goOnboardWithPackage = (packageId?: ConsultingPackageId) => {
-    if (packageId) setSelectedPackage(packageId);
-    requestAnimationFrame(() =>
-      scrollToSection(CONSULTORIA_FUNNEL_KICKOFF_ID)
-    );
-  };
-
   const contactDraft = useMemo<ContactDraft>(
     () => ({
       message: selectedPackage
@@ -151,13 +144,20 @@ export default function ConsultoriaVientoNorte({
           Hero ofertas → detalle entregables → onboarding → método → prueba.
           Sin calculadora ni árbol (duplicaban la decisión del hero).
         */}
-        <ConsultoriaLandingHero
-          onExploreEvidence={() => scrollToSection("modalidades")}
-        />
+        <ConsultoriaLandingHero />
 
         <ConsultoriaPackages
-          onSelectPackage={(id) => goOnboardWithPackage(id)}
-          showAppStrip={!isSem}
+          selectedPackageId={selectedPackage}
+          onSelectPackage={(id) => {
+            setSelectedPackage(id);
+            const params = new URLSearchParams(location.search);
+            params.set("pack", id);
+            navigate(
+              { pathname: location.pathname, search: `?${params.toString()}` },
+              { replace: true, state: { recommendedPackage: id } }
+            );
+          }}
+          showAppStrip={false}
         />
 
         <ConsultoriaOnboarding packageId={selectedPackage} />

--- a/src/styles/offer-tour.css
+++ b/src/styles/offer-tour.css
@@ -196,6 +196,13 @@
     border-color var(--funnel-fast) var(--funnel-ease-soft);
 }
 
+[data-surface="consultoria-funnel"] .funnel-pack-card[data-selected="true"] {
+  border-color: var(--vn-color-brand, var(--primary));
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--vn-color-brand, var(--primary)) 38%, transparent),
+    0 12px 28px -14px color-mix(in srgb, var(--vn-color-brand-dark, #0d1b3d) 28%, transparent);
+}
+
 @media (hover: hover) and (pointer: fine) {
   [data-surface="consultoria-funnel"] .funnel-pack-card {
     will-change: transform;

--- a/worker/src/api/share.js
+++ b/worker/src/api/share.js
@@ -1,9 +1,4 @@
-const PATHS = [
-  "Diagnóstico",
-  "Prototipo",
-  "Proceso de equipo",
-  "App de punta a punta",
-];
+const PATHS = ["Diagnóstico", "Prototipo", "Proceso de equipo"];
 
 const PAGES = {
   "": {


### PR DESCRIPTION
## DS · Radio de tres nombres · Prototype + Test local

**Decider:** Rö `apply=true` · for ship.

### Storyboard
1. Landing `/#/consultoria` y `/s/consultoria` — alcance + kickoff 30 min.
2. Tres radios: **Diagnóstico / Prototipo / Proceso**. Sin Radar·Marco·Ops.
3. Tap → seleccionado. CTA único **Agendar 30 min** (`?pack=` interno).
4. Nota (no CTA hero): Gratis · accesibilidad → misma agenda Diagnóstico.
5. Precio en la llamada.

### Test local
- `tsc --noEmit` PASS
- vitest free-radar + featured-path 6/6
- `local-ads-scenarios.sh` **133/133 PASS** (base `http://127.0.0.1:5175`)
- Browser: tap alcance → `?pack=` + CTA Agendar habilitado + onboarding pinta el **nombre** (no SKU)

### No
- Ads / IG spend
- Merge a `main` hasta que Rö pulse merge (main protegido)
- nve-* / Elements en prod