### PR TITLE
fix(home): restore Agendar CTAs in the consultoria hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-22] — Hero home: Agendar de vuelta
+
+### Fixed
+- `ConsultoriaLandingHero` otra vez abre Google Calendar desde el primer fold (`Agendar` + `Gratis · accesibilidad`). El parking DS lo había dejado solo en `#modalidades`.
+
 ## [2026-08-22] — CWV: recortar render delay CSR
 
 ### Changed

--- a/src/__tests__/components/ConsultoriaLandingHero.test.tsx
+++ b/src/__tests__/components/ConsultoriaLandingHero.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ConsultoriaLandingHero } from "@/components/organisms/ConsultoriaLandingHero";
+import { LanguageProvider } from "@/lib/LanguageContext";
+
+const openCalendarBooking = vi.fn(() => true);
+
+vi.mock("@/lib/site-contact", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/site-contact")>();
+  return {
+    ...actual,
+    openCalendarBooking: (...args: unknown[]) => openCalendarBooking(...args),
+  };
+});
+
+function renderHero() {
+  return render(
+    <MemoryRouter>
+      <LanguageProvider>
+        <ConsultoriaLandingHero />
+      </LanguageProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("ConsultoriaLandingHero", () => {
+  it("restores Agendar in the home hero", async () => {
+    const user = userEvent.setup();
+    renderHero();
+    const agendar = screen.getByTestId("hero-agendar");
+    expect(agendar).toHaveTextContent(/Agendar/i);
+    expect(screen.getByTestId("hero-gratis-a11y")).toBeInTheDocument();
+    await user.click(agendar);
+    expect(openCalendarBooking).toHaveBeenCalledWith({ origin: "hero" });
+  });
+});

--- a/src/__tests__/components/ConsultoriaLandingHero.test.tsx
+++ b/src/__tests__/components/ConsultoriaLandingHero.test.tsx
@@ -34,6 +34,6 @@ describe("ConsultoriaLandingHero", () => {
     expect(agendar).toHaveTextContent(/Agendar/i);
     expect(screen.getByTestId("hero-gratis-a11y")).toBeInTheDocument();
     await user.click(agendar);
-    expect(openCalendarBooking).toHaveBeenCalledWith({ origin: "hero" });
+    expect(openCalendarBooking).toHaveBeenCalledWith({ origin: "consultoria-hero" });
   });
 });

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -1,15 +1,39 @@
+import { Calendar } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
+import { analytics } from "../../lib/analytics";
+import { openFreeRadarEntry } from "../../lib/free-radar-entry";
+import { openCalendarBooking } from "../../lib/site-contact";
+import { scrollToSection } from "../../lib/scroll-to-section";
 
 /**
  * Hero SEM/FO · Radio de tres nombres.
- * Alcance y CTA único viven en #modalidades. Calendar no va en el hero (parking DS).
+ * CTA de agenda vive otra vez en el hero (Decider: restaurar capacidad de agendar).
+ * Alcance sigue en #modalidades.
  */
 export function ConsultoriaLandingHero() {
+  const navigate = useNavigate();
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.landing;
   const es = language === "es";
+
+  const bookKickoff = () => {
+    analytics.generateLead({
+      lead_type: "kickoff",
+      channel: "google_calendar",
+      origin: "hero",
+    });
+    if (!openCalendarBooking({ origin: "hero" })) {
+      scrollToSection("contacto");
+    }
+  };
+
+  const bookFree = () => {
+    openFreeRadarEntry(navigate, language, "hero");
+  };
 
   return (
     <section
@@ -56,6 +80,34 @@ export function ConsultoriaLandingHero() {
               </li>
             ))}
           </ul>
+
+          <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
+            <Button
+              size="lg"
+              data-testid="hero-agendar"
+              className="min-h-[48px] bg-brand-gradient px-8 font-semibold hover:opacity-90"
+              onClick={bookKickoff}
+            >
+              <Calendar className="h-4 w-4" aria-hidden />
+              {t.ctaPrimary}
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              data-testid="hero-gratis-a11y"
+              className="min-h-[48px]"
+              onClick={bookFree}
+            >
+              {t.ctaFreeA11y}
+            </Button>
+          </div>
+          <Button
+            variant="link"
+            className="min-h-[44px] text-muted-foreground"
+            onClick={() => scrollToSection("modalidades")}
+          >
+            {t.ctaSecondary}
+          </Button>
         </div>
       </div>
     </section>

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -24,15 +24,15 @@ export function ConsultoriaLandingHero() {
     analytics.generateLead({
       lead_type: "kickoff",
       channel: "google_calendar",
-      origin: "hero",
+      origin: "consultoria-hero",
     });
-    if (!openCalendarBooking({ origin: "hero" })) {
+    if (!openCalendarBooking({ origin: "consultoria-hero" })) {
       scrollToSection("contacto");
     }
   };
 
   const bookFree = () => {
-    openFreeRadarEntry(navigate, language, "hero");
+    openFreeRadarEntry(navigate, language, "consultoria-hero");
   };
 
   return (


### PR DESCRIPTION
## Por qué
El hero de [vientonorte.io](https://vientonorte.io) (FO = funnel consultoría) dejó de agendar: el DS aparcó Calendar en `#modalidades` y el botón principal quedó *disabled* hasta elegir pack.

Decider: restaurar capacidad de agendar en el primer fold.

## Qué
- `ConsultoriaLandingHero`: **Agendar en Google Calendar** + **Gratis · accesibilidad** + link a alcance.
- Copy ya existía (`landing.ctaPrimary` / `ctaFreeA11y`). No se reescribe el Radio.
- `generate_lead` origin `hero`. Fallback a `#contacto` si no hay URL de agenda.

## Test
`npx vitest run src/__tests__/components/ConsultoriaLandingHero.test.tsx`

## No
- No toca `/s/consultoria`.
- No reabre el hero viejo de 3 path cards (“Diseño que reduce el ruido”).