### PR TITLE
fix(sobre-mi): restore VB chips 7+ craft and 3+ lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-22] — Sobre mí: chips VB 7+ / 3+ lead
+
+### Fixed
+- QA VB-SOBRE-MI en `/#/sobre-mi`: chips **7+ años** (craft) y **3+ lead** (mobility→wealth) otra vez visibles. Rail: SURA 23–26 · VN ahora. Copy i18n ya no pinta Lead UX como cargo actual.
+
 ## [2026-08-22] — Hero home: Agendar de vuelta
 
 ### Fixed

--- a/src/__tests__/components/About.vb.test.tsx
+++ b/src/__tests__/components/About.vb.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { About } from "@/components/organisms/About";
+import { TrajectoryRail } from "@/components/organisms/TrajectoryRail";
+import { LanguageProvider } from "@/lib/LanguageContext";
+
+function wrap(ui: React.ReactNode) {
+  return render(
+    <MemoryRouter>
+      <LanguageProvider>{ui}</LanguageProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("VB-SOBRE-MI hero", () => {
+  it("VB-1 title is UX Manager · Viento Norte, not current Lead UX SURA", () => {
+    wrap(<About />);
+    expect(screen.getAllByText("UX Manager · Viento Norte").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Lead UX · SURA")).not.toBeInTheDocument();
+  });
+
+  it("VB-2 SURA is past tense through Jun 2026", () => {
+    wrap(<About />);
+    expect(
+      screen.getByText(/Antes: UX Lead SURA \(regional, hasta jun\. 2026\)/)
+    ).toBeInTheDocument();
+  });
+
+  it("VB-3 and VB-4 expose 7+ years craft and 3+ lead chips", () => {
+    wrap(<About />);
+    expect(screen.getByText("7+ años")).toBeInTheDocument();
+    expect(screen.getByText("3+ lead")).toBeInTheDocument();
+  });
+
+  it("VB-5 rail ends at Viento Norte now and marks SURA 23–26", () => {
+    wrap(<TrajectoryRail />);
+    expect(screen.getByText("Viento Norte")).toBeInTheDocument();
+    expect(screen.getByText(/ahora · UX Manager n2n/)).toBeInTheDocument();
+    expect(screen.getByText(/SURA 23–26/)).toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/About.tsx
+++ b/src/components/organisms/About.tsx
@@ -15,6 +15,8 @@ import {
   Equal,
   ChevronDown,
   ChevronUp,
+  Timer,
+  Layers2,
 } from "lucide-react";
 import { ProfileAvatar } from "../atoms/ProfileAvatar";
 import { PageSection } from "../layout/PageSection";
@@ -58,6 +60,18 @@ const roles = {
 
 /** Chips visibles sin expandir (ruido bajo). */
 const ROLE_CHIPS_INITIAL = 4;
+
+/** VB-SOBRE-MI VB-3 / VB-4 — craft vs lead, visibles en el primer fold. */
+const STAT_CHIPS = {
+  es: [
+    { icon: Timer, label: "7+ años", detail: "Craft UX/UI · Viento Norte 2019–" },
+    { icon: Layers2, label: "3+ lead", detail: "Mobility → Wealth (Transvip · SURA)" },
+  ],
+  en: [
+    { icon: Timer, label: "7+ years", detail: "UX/UI craft · Viento Norte 2019–" },
+    { icon: Layers2, label: "3+ lead", detail: "Mobility → Wealth (Transvip · SURA)" },
+  ],
+} as const;
 
 const LINE = {
   es: "Interfaces de producto en empresas reales. Hoy: Viento Norte (n2n) y micro1 (AI data, EE.UU.). Antes: UX Lead SURA (regional, hasta jun. 2026).",
@@ -145,6 +159,27 @@ export function About() {
           <p className="mt-3 max-w-prose text-sm leading-relaxed text-muted-foreground">
             {LINE[language]}
           </p>
+
+          <ul
+            className="mt-3 flex flex-wrap justify-center gap-2 sm:justify-start"
+            aria-label={es ? "Años de oficio y liderazgo" : "Years of craft and lead"}
+          >
+            {STAT_CHIPS[language].map((chip) => {
+              const Icon = chip.icon;
+              return (
+                <li key={chip.label}>
+                  <span
+                    className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-primary/25 bg-primary/5 px-2.5 py-1 text-[11px] font-semibold text-primary"
+                    title={chip.detail}
+                  >
+                    <Icon className="h-3.5 w-3.5" aria-hidden />
+                    {chip.label}
+                    <span className="font-medium text-muted-foreground">· {chip.detail}</span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
 
           <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-start sm:gap-3">
             <Button
@@ -253,7 +288,7 @@ export function About() {
         {/* Dot rail — same pattern as timeline / Flujo Mejora Continua */}
         <div
           className="mt-5 flex flex-wrap items-center justify-center gap-1 sm:gap-2"
-          role="tablist"
+          role="group"
           aria-label={es ? "Pasos del ciclo" : "Cycle steps"}
         >
           {PERFIL_CYCLE.map((s, i) => {
@@ -263,8 +298,7 @@ export function About() {
               <button
                 key={s.n}
                 type="button"
-                role="tab"
-                aria-selected={selected}
+                aria-pressed={selected}
                 aria-controls="perfil-step-panel"
                 id={`perfil-step-tab-${s.n}`}
                 onClick={() => setActiveStep(i)}
@@ -298,7 +332,6 @@ export function About() {
         {/* Un solo panel de detalle */}
         <div
           id="perfil-step-panel"
-          role="tabpanel"
           aria-labelledby={`perfil-step-tab-${step.n}`}
           className="mt-4 rounded-xl border border-border/50 bg-card/80 px-4 py-4 text-center sm:px-6"
           aria-live="polite"

--- a/src/components/organisms/TrajectoryRail.tsx
+++ b/src/components/organisms/TrajectoryRail.tsx
@@ -15,7 +15,7 @@ const STAGES = {
     {
       id: "regional",
       label: "Regional",
-      sub: "SURA · 5+ países",
+      sub: "SURA 23–26 · 5+ países",
     },
     {
       id: "international",
@@ -25,7 +25,7 @@ const STAGES = {
     {
       id: "vn",
       label: "Viento Norte",
-      sub: "UX Manager · n2n",
+      sub: "ahora · UX Manager n2n",
     },
   ],
   en: [
@@ -37,7 +37,7 @@ const STAGES = {
     {
       id: "regional",
       label: "Regional",
-      sub: "SURA · 5+ countries",
+      sub: "SURA 23–26 · 5+ countries",
     },
     {
       id: "international",
@@ -47,7 +47,7 @@ const STAGES = {
     {
       id: "vn",
       label: "Viento Norte",
-      sub: "UX Manager · n2n",
+      sub: "now · UX Manager n2n",
     },
   ],
 } as const;

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -59,7 +59,7 @@ export default {
         about: {
           title: 'About',
           description:
-            'Rodrigo Gaete, UX Lead in fintech & mobility. Design Ops, research, design systems, and cases at SURA, Transvip, Karri.',
+            'Rodrigo Gaete, UX Manager at Viento Norte. Previously UX Lead at SURA Investments. Design Ops, research, design systems. SURA, Transvip, Karri.',
         },
         contact: {
           title: 'Contact',
@@ -993,10 +993,10 @@ export default {
     // About
     about: {
       badge: 'About',
-      title: 'Experience Designer',
-      subtitle: 'Idea + Body',
+      title: 'UX Manager · Viento Norte',
+      subtitle: '7+ years craft · 3+ lead mobility→wealth',
       description:
-        'From Senior Product Designer at Transvip/Karri to UX Lead at SURA Investments (Wealth, 5+ countries). Research, Design Sprints, design systems, and measurable results — including −40% onboarding.',
+        'Now UX Manager at Viento Norte (n2n) and AI Trainer at micro1. Previously UX Lead at SURA Investments (Wealth, 5+ countries, through Jun 2026). Research, Design Sprints, design systems, and −40% onboarding.',
       philosophy: {
         idea: {
           title: 'Idea',

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -59,7 +59,7 @@ export default {
         about: {
           title: 'Sobre mí',
           description:
-            'Rodrigo Gaete, UX Lead en fintech y mobility. Design Ops, research, design systems y casos en SURA, Transvip y Karri.',
+            'Rodrigo Gaete, UX Manager en Viento Norte. Antes UX Lead en SURA Investments. Design Ops, research, design systems. SURA, Transvip y Karri.',
         },
         contact: {
           title: 'Contacto',
@@ -998,10 +998,10 @@ export default {
     // About
     about: {
       badge: 'Sobre mí',
-      title: '3+ años. 2 verticales. Impacto regional.',
-      subtitle: 'Lead UX · Fintech & Mobility',
+      title: 'UX Manager · Viento Norte',
+      subtitle: '7+ años craft · 3+ lead mobility→wealth',
       description:
-        'De Senior Product Designer en Transvip/Karri a UX Lead en SURA Investments (Wealth, 5+ países). Research, Design Sprints, design system y resultados medibles — incluido −40% onboarding.',
+        'Hoy UX Manager en Viento Norte (n2n) y AI Trainer en micro1. Antes UX Lead en SURA Investments (Wealth, 5+ países, hasta jun. 2026). Research, Design Sprints, design system y −40% onboarding.',
       philosophy: {
         idea: {
           title: 'Idea',


### PR DESCRIPTION
## Por qué
QA VB en [/#/sobre-mi](https://vientonorte.io/#/sobre-mi) no pasaba: #166 sacó los chips de oficio/lead. `docs/VB-SOBRE-MI.md` sigue pidiendo VB-3 (7+ años) y VB-4 (3+ lead).

Live cargaba, pero el perfil se leía como ficha sin años.

## Qué
- Chips **7+ años** / **3+ lead** otra vez en el fold de About
- Rail: `SURA 23–26` · `Viento Norte · ahora`
- i18n about: cargo actual = UX Manager VN, SURA en pasado
- Tabs del ciclo → `aria-pressed` (sin tablist incompleto)

## Test
`npx vitest run src/__tests__/components/About.vb.test.tsx`