### PR TITLE
fix(csr): hide home LCP shell on inner HashRouter reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-22] — Recarga /#/sobre-mi: LCP shell no tapa inner routes
+
+### Fixed
+- El overlay LCP de home (#206) esperaba `#inicio`. En `/#/sobre-mi` nunca llega: recarga = pantalla “Tecnología para empresas” colgada.
+- Inner hash (`sobre-mi`, `contacto`, …) oculta el shell **antes del paint**. Home/SEM siguen con LCP.
+- Ya no se borra `rg-chunk-reload` al boot (loop 503 tras deploy). SW `controllerchange` una vez por sesión.
+
 ## [2026-08-22] — Sobre mí: chips VB 7+ / 3+ lead
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -215,6 +215,10 @@
       #lcp-shell[hidden] {
         display: none !important;
       }
+      /* Inner HashRouter routes: never paint the home LCP overlay on reload. */
+      html[data-vn-route="inner"] #lcp-shell {
+        display: none !important;
+      }
       #lcp-shell h1 {
         margin: 0;
         max-width: 40rem;
@@ -237,6 +241,16 @@
   </head>
 
   <body>
+    <script>
+      (function () {
+        var h = (location.hash || "#/").replace(/^#/, "").split("?")[0] || "/";
+        if (h.charAt(0) !== "/") h = "/" + h;
+        if (h.length > 1 && h.slice(-1) === "/") h = h.slice(0, -1);
+        if (h !== "/" && h !== "/consultoria") {
+          document.documentElement.setAttribute("data-vn-route", "inner");
+        }
+      })();
+    </script>
     <div id="lcp-shell" aria-hidden="true">
       <h1>Tecnología para empresas.</h1>
       <p class="section-header__description">

--- a/src/__tests__/lib/lcp-shell.test.ts
+++ b/src/__tests__/lib/lcp-shell.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { pathFromHash, shouldSkipLcpShell } from "../../lib/lcp-shell";
+
+describe("LCP shell vs HashRouter reload", () => {
+  it("keeps the shell on home and SEM consultoria", () => {
+    expect(shouldSkipLcpShell("")).toBe(false);
+    expect(shouldSkipLcpShell("#")).toBe(false);
+    expect(shouldSkipLcpShell("#/")).toBe(false);
+    expect(shouldSkipLcpShell("#/?utm=ads")).toBe(false);
+    expect(shouldSkipLcpShell("#/consultoria")).toBe(false);
+    expect(shouldSkipLcpShell("#/consultoria?pack=ops")).toBe(false);
+  });
+
+  it("skips the home overlay on inner routes like /#/sobre-mi", () => {
+    expect(pathFromHash("#/sobre-mi")).toBe("/sobre-mi");
+    expect(shouldSkipLcpShell("#/sobre-mi")).toBe(true);
+    expect(shouldSkipLcpShell("#/contacto")).toBe(true);
+    expect(shouldSkipLcpShell("#/proyectos")).toBe(true);
+    expect(shouldSkipLcpShell("#/admin")).toBe(true);
+  });
+});

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -28,6 +28,8 @@ describe("SEO P0 · title home vs query", () => {
     expect(indexHtml).toContain(
       "<title>Tecnología para empresas · Viento Norte</title>"
     );
+    expect(indexHtml).toContain('data-vn-route');
+    expect(indexHtml).toContain('html[data-vn-route="inner"] #lcp-shell');
   });
 });
 

--- a/src/lib/lcp-shell.ts
+++ b/src/lib/lcp-shell.ts
@@ -1,0 +1,59 @@
+/**
+ * Static LCP shell in index.html is for the home/consultoria first paint.
+ * Inner HashRouter routes (e.g. /#/sobre-mi) never mount #inicio — the shell
+ * must not wait for that node or a reload looks like a hung home overlay.
+ */
+
+export const LCP_HOME_PATHS = new Set(["/", "/consultoria"]);
+
+export function pathFromHash(hash: string): string {
+  const raw = (hash || "#/").replace(/^#/, "");
+  const path = (raw.split("?")[0] || "/").trim() || "/";
+  if (path.length > 1 && path.endsWith("/")) return path.slice(0, -1);
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function shouldSkipLcpShell(hash: string): boolean {
+  return !LCP_HOME_PATHS.has(pathFromHash(hash));
+}
+
+export function hideLcpShell(shell: Element | null): void {
+  if (!shell) return;
+  shell.setAttribute("hidden", "");
+  shell.setAttribute("aria-hidden", "true");
+}
+
+export function attachLcpShell(options: {
+  root: ParentNode | null;
+  shell: Element | null;
+  hash?: string;
+  timeoutMs?: number;
+}): () => void {
+  const { root, shell, hash = "", timeoutMs = 1600 } = options;
+  if (!shell) return () => undefined;
+
+  if (shouldSkipLcpShell(hash)) {
+    hideLcpShell(shell);
+    return () => undefined;
+  }
+
+  const ready = () => Boolean(root?.querySelector("#main"));
+  if (ready()) {
+    hideLcpShell(shell);
+    return () => undefined;
+  }
+
+  const hide = () => {
+    observer.disconnect();
+    window.clearTimeout(timer);
+    hideLcpShell(shell);
+  };
+
+  const observer = new MutationObserver(() => {
+    if (ready()) hide();
+  });
+  if (root) observer.observe(root, { childList: true, subtree: true });
+  const timer = window.setTimeout(hide, timeoutMs);
+
+  return hide;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import './styles/design-system.css';
 import './styles/offer-tour.css';
 import { ErrorBoundary } from './components/organisms/ErrorBoundary';
 import { normalizeDoubleHashUrl } from './lib/normalize-hash-url';
+import { attachLcpShell } from './lib/lcp-shell';
 
 function bootstrapTheme() {
   try {
@@ -26,18 +27,16 @@ function bootstrapTheme() {
 bootstrapTheme();
 normalizeDoubleHashUrl();
 
-try {
-  sessionStorage.removeItem('rg-chunk-reload');
-} catch {
-  /* ignore */
-}
-
 if (import.meta.env.PROD && 'serviceWorker' in navigator) {
   const base = import.meta.env.BASE_URL;
-  let reloadedForSw = false;
+  const SW_RELOAD_KEY = 'vn-sw-controller-reload';
   navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (reloadedForSw) return;
-    reloadedForSw = true;
+    try {
+      if (sessionStorage.getItem(SW_RELOAD_KEY)) return;
+      sessionStorage.setItem(SW_RELOAD_KEY, '1');
+    } catch {
+      return;
+    }
     window.location.reload();
   });
 
@@ -58,34 +57,16 @@ if (import.meta.env.PROD && 'serviceWorker' in navigator) {
     });
 }
 
-function dismissLcpShell() {
-  const shell = document.getElementById('lcp-shell');
-  const root = document.getElementById('root');
-  if (!shell || !root) return;
-  const hide = () => {
-    shell.setAttribute('hidden', '');
-    shell.setAttribute('aria-hidden', 'true');
-  };
-  const ready = () => Boolean(root.querySelector('#inicio, #consultoria-hero-heading'));
-  if (ready()) {
-    hide();
-    return;
-  }
-  const observer = new MutationObserver(() => {
-    if (ready()) {
-      observer.disconnect();
-      hide();
-    }
-  });
-  observer.observe(root, { childList: true, subtree: true });
-}
-
 const rootEl = document.getElementById('root');
 if (!rootEl) {
   throw new Error('No se encontró #root en index.html');
 }
 
-dismissLcpShell();
+attachLcpShell({
+  root: rootEl,
+  shell: document.getElementById('lcp-shell'),
+  hash: window.location.hash,
+});
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>


### PR DESCRIPTION
## Por qué
Recargar [/#/sobre-mi](https://vientonorte.io/#/sobre-mi) dejaba el overlay LCP de home (`Tecnología para empresas`) porque `dismissLcpShell` esperaba `#inicio`, que esa ruta no tiene.

## Qué
- Inner hash (`sobre-mi`, `contacto`, …): `data-vn-route=inner` **antes del paint**
- Home/SEM: shell se oculta al pintar `#main` (timeout 1.6s)
- No borrar `rg-chunk-reload` al boot (evita loop 503)
- SW `controllerchange` una vez por sesión

## Test
`npx vitest run src/__tests__/lib/lcp-shell.test.ts`