### PR TITLE
feat(polijuego): static privacy page for Play crawlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-24] — Privacidad estática Polijuego (`/s/polijuego-privacy/`)
+
+### Added
+- HTML crawlable para Play: no account; no network for game content; AES-256-GCM vault on device; Keychain/Keystore ThisDeviceOnly; export JSON only on user action; purge rotates key and deletes file; no ads/analytics.
+- Sin GTM, sin hop HashRouter, sin reusar FO privacy. `sitemap.xml` lista `https://vientonorte.io/s/polijuego-privacy/`.
+
 ## [2026-08-22] — Recarga /#/sobre-mi: LCP shell no tapa inner routes
 
 ### Fixed

--- a/public/s/polijuego-privacy/index.html
+++ b/public/s/polijuego-privacy/index.html
@@ -8,10 +8,7 @@
       name="description"
       content="RADAR El Polijuego: no account; no network for game content; AES-256-GCM vault on device; Keychain/Keystore ThisDeviceOnly; export JSON only on user action; purge rotates key and deletes file; no ads/analytics."
     />
-    <link
-      rel="canonical"
-      href="https://vientonorte.io/s/polijuego-privacy/"
-    />
+    <link rel="canonical" href="https://vientonorte.io/s/polijuego-privacy/" />
     <meta property="og:type" content="website" />
     <meta
       property="og:url"

--- a/public/s/polijuego-privacy/index.html
+++ b/public/s/polijuego-privacy/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacidad · RADAR El Polijuego · Viento Norte</title>
+    <meta
+      name="description"
+      content="RADAR El Polijuego: no account; no network for game content; AES-256-GCM vault on device; Keychain/Keystore ThisDeviceOnly; export JSON only on user action; purge rotates key and deletes file; no ads/analytics."
+    />
+    <link
+      rel="canonical"
+      href="https://vientonorte.io/s/polijuego-privacy/"
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://vientonorte.io/s/polijuego-privacy/"
+    />
+    <meta
+      property="og:title"
+      content="Privacidad · RADAR El Polijuego"
+    />
+    <meta
+      property="og:description"
+      content="Sin cuenta. Sin red para el contenido del juego. Vault AES-256-GCM en el dispositivo. Keychain/Keystore ThisDeviceOnly. Sin anuncios ni analítica."
+    />
+    <meta name="robots" content="index,follow" />
+    <style>
+      :root {
+        --vn-azul-noche: #0d1b3d;
+        --vn-marfil: #f7f2e7;
+        --vn-pizarra: #4a5568;
+        --vn-azul-evo: #1a8fdc;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: var(--vn-marfil);
+        color: var(--vn-azul-noche);
+        line-height: 1.55;
+      }
+      main {
+        max-width: 40rem;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 4rem;
+      }
+      h1 {
+        font-family: "DM Serif Display", Georgia, serif;
+        font-size: 2rem;
+        line-height: 1.2;
+        font-weight: 400;
+        margin: 0 0 0.5rem;
+      }
+      h2 {
+        font-size: 1.125rem;
+        margin: 1.75rem 0 0.5rem;
+      }
+      p,
+      li {
+        font-size: 1rem;
+      }
+      .lead {
+        color: var(--vn-pizarra);
+        margin-top: 0;
+      }
+      a {
+        color: var(--vn-azul-evo);
+      }
+      .meta {
+        font-size: 0.875rem;
+        color: var(--vn-pizarra);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="meta">
+        Viento Norte · bundle <code>io.vientonorte.polijuego</code>
+      </p>
+      <h1>Privacidad · R.A.D.A.R. El Polijuego</h1>
+      <p class="lead">
+        Política de privacidad de la app nativa RADAR El Polijuego (v1 Free).
+        Página HTML estática. No es la política de consultoría ni el formulario
+        de contacto del sitio.
+      </p>
+
+      <h2>Sin cuenta</h2>
+      <p>
+        No account. No hay cuenta, no hay registro y no hay servidor de
+        identidad. El juego no pide email ni perfil.
+      </p>
+
+      <h2>Cero red de contenido</h2>
+      <p>
+        No network for game content. v1 Free no envía cartas, notas, tableros ni
+        partidas a internet. El contenido del juego vive en este dispositivo.
+      </p>
+
+      <h2>Qué se guarda (vault)</h2>
+      <p>
+        AES-256-GCM vault on device. El tablero (sesiones, cartas, notas,
+        acuerdos) se cifra con AES-256-GCM y queda solo en este teléfono. La
+        clave está en Keychain/Keystore ThisDeviceOnly
+        (<code>WHEN_UNLOCKED_THIS_DEVICE_ONLY</code>).
+      </p>
+
+      <h2>Export JSON</h2>
+      <p>
+        Export JSON only on user action. «Exportar JSON» genera un archivo en
+        claro en el share sheet. Solo ocurre si lo pides; no hay backup en la
+        nube.
+      </p>
+
+      <h2>Purge</h2>
+      <p>
+        Purge rotates key and deletes file. «Borrar todos mis datos» rota la
+        clave, borra el archivo del vault y elimina sesiones y notas de este
+        teléfono. No se puede deshacer. No hay cuenta que borrar en un servidor.
+      </p>
+
+      <h2>Sin anuncios ni analítica</h2>
+      <p>
+        No ads/analytics. No hay SDK de anuncios ni de analytics. Las salas
+        remotas y las compras in-app no están en esta versión.
+      </p>
+
+      <h2>Quién publica</h2>
+      <p>
+        Viento Norte ·
+        <a href="mailto:contacto@vientonorte.io">contacto@vientonorte.io</a>
+      </p>
+      <p class="meta">Actualizado 24 ago 2026 · v1 Free</p>
+
+      <h2 lang="en">English (store crawlers)</h2>
+      <p lang="en">
+        RADAR El Polijuego: no account; no network for game content; AES-256-GCM
+        vault on device; Keychain/Keystore ThisDeviceOnly; export JSON only on
+        user action; purge rotates key and deletes file; no ads/analytics.
+      </p>
+    </main>
+  </body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -19,4 +19,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.96</priority>
   </url>
+  <url>
+    <loc>https://vientonorte.io/s/polijuego-privacy/</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
 </urlset>

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -11,6 +11,10 @@ const shareConsultoria = readFileSync(
   resolve(root, "public/s/consultoria/index.html"),
   "utf8"
 );
+const polijuegoPrivacy = readFileSync(
+  resolve(root, "public/s/polijuego-privacy/index.html"),
+  "utf8"
+);
 const sitemap = readFileSync(resolve(root, "public/sitemap.xml"), "utf8");
 
 const PATHS = ["Diagnóstico", "Prototipo", "Proceso de equipo"];
@@ -64,6 +68,28 @@ describe("SEO P0 · crawler HTML /s/", () => {
       'content="5;url=https://vientonorte.io/#/consultoria"'
     );
   });
+
+  it("polijuego privacy is static, crawlable, and not FO /#/privacy", () => {
+    expect(polijuegoPrivacy).toMatch(/<h1>\s*Privacidad · R\.A\.D\.A\.R\. El Polijuego\s*<\/h1>/);
+    expect(polijuegoPrivacy).toContain("no account");
+    expect(polijuegoPrivacy).toContain("no network for game content");
+    expect(polijuegoPrivacy).toContain("AES-256-GCM vault on device");
+    expect(polijuegoPrivacy).toContain("Keychain/Keystore ThisDeviceOnly");
+    expect(polijuegoPrivacy).toContain("export JSON only on user action");
+    expect(polijuegoPrivacy).toContain("purge rotates key and deletes file");
+    expect(polijuegoPrivacy).toContain("no ads/analytics");
+    expect(polijuegoPrivacy).toContain("Cero red de contenido");
+    expect(polijuegoPrivacy).toContain(
+      'rel="canonical" href="https://vientonorte.io/s/polijuego-privacy/"'
+    );
+    expect(polijuegoPrivacy).not.toContain("GTM-PM5LBQRP");
+    expect(polijuegoPrivacy).not.toContain("gtag.js");
+    expect(polijuegoPrivacy).not.toContain("/#/privacy");
+    expect(polijuegoPrivacy).not.toContain("http-equiv=\"refresh\"");
+    expect(polijuegoPrivacy).not.toMatch(/<form[\s>]/i);
+    expect(polijuegoPrivacy).not.toContain("noIndex");
+    expect(polijuegoPrivacy).not.toContain("Ley 21.719");
+  });
 });
 
 describe("SEO P0 · sitemap HTTP only", () => {
@@ -72,6 +98,9 @@ describe("SEO P0 · sitemap HTTP only", () => {
     expect(sitemap).toContain("<loc>https://vientonorte.io/s/</loc>");
     expect(sitemap).toContain(
       "<loc>https://vientonorte.io/s/consultoria/</loc>"
+    );
+    expect(sitemap).toContain(
+      "<loc>https://vientonorte.io/s/polijuego-privacy/</loc>"
     );
     expect(sitemap).not.toMatch(/<loc>https:\/\/vientonorte\.io\/#\//);
     expect(sitemap).not.toContain("/admin");


### PR DESCRIPTION
## DS
Beat **1** · [DS-2026-08-24 Polijuego Play internal](https://github.com/vientonorte/mi-portafolio/blob/feat/polijuego-privacy-static/CHANGELOG.md). Workflow `vn-polijuego-play` `apply=true`.

## Qué
HTML estático crawlable: `https://vientonorte.io/s/polijuego-privacy/`

- vault AES-256-GCM · cero red de contenido · export a pedido · purge
- **No** GTM, **no** hop SPA, **no** `/#/privacy` (FO Ley 21.719 noIndex)
- sitemap incluye la URL

## Test local
Vitest pool iCloud timeout (NO DATO CI). Python file asserts **PASS**.

## No
Apple · EAS · merge a stores · Ads · wrangler

Live curl 200 = Test del beat 1 **después** de merge Pages.