### PR TITLE
fix(seo): sacar /s/ del sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-26] — Sitemap: no gastar crawl en `/s/`
+
+### Changed
+- `public/sitemap.xml`: se saca `https://vientonorte.io/s/` (canonical a home = duplicado). Quedan `/`, `/s/consultoria/`, `/s/proceso/` y privacy legal.
+
+---
+
 ## [2026-08-26] — Hero: storytelling de marca (flujo · CMS/CRM)
 
 ### Changed

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <!-- SEO orgánico · solo paths HTTP. Google ignora fragments (#/). -->
+  <!-- /s/ omitido: canonical a home; no gastar crawl budget en duplicado. -->
   <url>
     <loc>https://vientonorte.io/</loc>
-    <lastmod>2026-08-17</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://vientonorte.io/s/</loc>
-    <lastmod>2026-08-17</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://vientonorte.io/s/consultoria/</loc>
-    <lastmod>2026-08-17</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.96</priority>
   </url>


### PR DESCRIPTION
## Por qué
GSC 26 ago: 1 URL indexada (`/`) y 2 no indexadas (`/s/`, `/s/consultoria/`). `/s/` declara canonical a home — duplicado que gasta crawl budget.

## Qué
- Sitemap: `/`, `/s/consultoria/`, `/s/proceso/`, privacy.
- Sin `/s/`.
- `robots.txt` no se toca.

## Después del merge
Reenviar sitemap en GSC **mañana** (cuota de inspección diaria agotada hoy). Una solicitud de indexación a `/s/consultoria/`.