### PR TITLE
fix(gtm): tag /s/ with GTM-PM5LBQRP (coverage Sin etiquetar)

### DIFF
--- a/public/s/index.html
+++ b/public/s/index.html
@@ -31,7 +31,7 @@
     <!--
       Index /s/ is a hop to home. GTM coverage crawler flags it untagged
       unless gtm.js is in this HTML. Same container as /s/consultoria.
-      No gtag.js paralelo.
+      No gtag paralelo (duplica page_view).
     -->
     <script>
       (function (w, d, s, l, i) {

--- a/public/s/index.html
+++ b/public/s/index.html
@@ -28,12 +28,56 @@
       name="twitter:image"
       content="https://vientonorte.io/images/branding/og-home-1200.png"
     />
+    <!--
+      Index /s/ is a hop to home. GTM coverage crawler flags it untagged
+      unless gtm.js is in this HTML. Same container as /s/consultoria.
+      No gtag.js paralelo.
+    -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-PM5LBQRP");
+    </script>
     <meta http-equiv="refresh" content="5;url=https://vientonorte.io/" />
     <script>
-      location.replace("https://vientonorte.io/");
+      (function () {
+        var q = window.location.search || "";
+        var ref = document.referrer || "";
+        var ua = navigator.userAgent || "";
+        var stay =
+          /[?&](gtm_debug|gtm_preview|gtm_auth|g_gtm)=/i.test(q) ||
+          /tagassistant\.google\.com/i.test(ref) ||
+          /Google-Ads|AdsBot-Google|Google Tag Assistant|Google-InspectionTool|Storebot-Google/i.test(
+            ua
+          );
+        if (stay) {
+          var meta = document.querySelector('meta[http-equiv="refresh"]');
+          if (meta) meta.parentNode.removeChild(meta);
+          return;
+        }
+        window.setTimeout(function () {
+          window.location.replace("https://vientonorte.io/" + q);
+        }, 1500);
+      })();
     </script>
   </head>
   <body>
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-PM5LBQRP"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+        title="Google Tag Manager"
+      ></iframe
+    ></noscript>
     <main>
       <h1>Tecnología para empresas</h1>
       <p>

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -56,7 +56,7 @@ describe("SEO P0 · crawler HTML /s/", () => {
     expect(shareHome).toContain('content="5;url=https://vientonorte.io/"');
     expect(shareHome).toContain("GTM-PM5LBQRP");
     expect(shareHome).toContain("googletagmanager.com/gtm.js?id=");
-    expect(shareHome).not.toContain("gtag.js");
+    expect(shareHome).not.toContain("gtag/js?id=");
     expect(shareHome).toContain("gtm_debug");
     expect(shareHome).toContain("tagassistant");
   });

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -54,6 +54,11 @@ describe("SEO P0 · crawler HTML /s/", () => {
     expect(shareHome).toMatch(/Tecnología para empresas:/);
     expect(shareHome).toContain('rel="canonical" href="https://vientonorte.io/"');
     expect(shareHome).toContain('content="5;url=https://vientonorte.io/"');
+    expect(shareHome).toContain("GTM-PM5LBQRP");
+    expect(shareHome).toContain("googletagmanager.com/gtm.js?id=");
+    expect(shareHome).not.toContain("gtag.js");
+    expect(shareHome).toContain("gtm_debug");
+    expect(shareHome).toContain("tagassistant");
   });
 
   it("share consultoria has H1, three paths, query, and no hash canonical", () => {


### PR DESCRIPTION
## Por qué
Tag Manager cobertura 27 ago: `vientonorte.io/s/` **Sin etiquetar**. `/s/consultoria/` y `/s/proceso/` ya Etiquetada. Final URL paid no cambia.

GET live: `/s/` 200, 0 `gtm.js`. `/s/consultoria/` `GTM-PM5LBQRP`, sin gtag paralelo.

## Qué
Snippet + noscript en `public/s/index.html`. Hop 1.5s a `/` salvo Preview/coverage UA.

## No
Ads ENABLED. gtag paralelo. Privacy Polijuego. Segundo admin GTM (humano).