### PR TITLE
feat(consultoria): hero v3 X|CMS product mockup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 ## [2026-08-28] — Hero v3: X|CMS producto estrella
 
 ### Changed
-- Hero SEM (`ConsultoriaLandingHero`): mockup laptop X|CMS (`data-hero-version="3"`) en vez de teselas de anuncio o foto lifestyle. Chip + CTA **Ver demo** → `/#/demo/x-cms` (`hero_x_cms_open` dataLayer). **Agendar** sigue `generate_lead` kickoff. **Gratis · accesibilidad** intacto.
+- Hero SEM (`ConsultoriaLandingHero`): mockup laptop X|CMS (`data-hero-version="3"`) en vez de teselas de anuncio o foto lifestyle. Chip + CTA **Ver demo** → `/#/demo/x-cms` (`hero_x_cms_open` dataLayer). **Agendar** sigue `generate_lead` kickoff. **Gratis · accesibilidad** intacto. Sin lockup **Viento Norte** (ya está en nav).
 - Pills del embudo (Modalidades / Empezar / Contacto) ocultas en mobile consultoría (`ProcessNavigation showMobile={false}`); el dock las cubría.
 - Admin: rol `hero_consultoria` → slot `branding.heroConsultoria`. Worker spec en `image-roles.js` (live = `wrangler deploy --keep-vars`, no este PR).
 - Code Connect parserless: `ConsultoriaLandingHero.figma.ts` + `DeviceMockup` en archivo Figma campaign assets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-28] — Hero v3: X|CMS producto estrella
+
+### Changed
+- Hero SEM (`ConsultoriaLandingHero`): mockup laptop X|CMS (`data-hero-version="3"`) en vez de teselas de anuncio o foto lifestyle. Chip + CTA **Ver demo** → `/#/demo/x-cms` (`hero_x_cms_open` dataLayer). **Agendar** sigue `generate_lead` kickoff. **Gratis · accesibilidad** intacto.
+- Pills del embudo (Modalidades / Empezar / Contacto) ocultas en mobile consultoría (`ProcessNavigation showMobile={false}`); el dock las cubría.
+- Admin: rol `hero_consultoria` → slot `branding.heroConsultoria`. Worker spec en `image-roles.js` (live = `wrangler deploy --keep-vars`, no este PR).
+- Code Connect parserless: `ConsultoriaLandingHero.figma.ts` + `DeviceMockup` en archivo Figma campaign assets.
+
+### Not
+- No merge a `main`. Live HTML `/s/consultoria` sigue last-mod 27 ago hasta deploy.
+- `hero_x_cms_open` / `demo_x_cms_*` = dataLayer; no hay CE GTM. Preview `generate_lead` = Chrome humano.
+- No se commitea `hero-reserva.jpg` ni duplicados iCloud `* 2.*`.
+
 ## [2026-08-27] — SEM: operaciones digitales en `/s/consultoria`
 
 ### Changed

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,10 +4,12 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
+/** ESLint 10: no mezclar `extends` + `plugins` en el mismo objeto (ConfigError Unexpected key "plugins"). */
 export default tseslint.config(
   { ignores: ['dist', 'coverage', 'V2'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/figma.config.json
+++ b/figma.config.json
@@ -1,0 +1,13 @@
+{
+  "codeConnect": {
+    "parser": "react",
+    "include": ["src/**/*.figma.ts"],
+    "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"],
+    "importPaths": {
+      "src/components/*": "@/*"
+    },
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/src/__tests__/components/ConsultoriaLandingHero.test.tsx
+++ b/src/__tests__/components/ConsultoriaLandingHero.test.tsx
@@ -60,5 +60,6 @@ describe("ConsultoriaLandingHero", () => {
     expect(img).toHaveAttribute("loading", "eager");
     expect(container.textContent).toMatch(/X\|CMS/);
     expect(container.textContent).not.toMatch(/Radar/i);
+    expect(container.textContent).not.toMatch(/Viento Norte/);
   });
 });

--- a/src/__tests__/components/ConsultoriaLandingHero.test.tsx
+++ b/src/__tests__/components/ConsultoriaLandingHero.test.tsx
@@ -7,6 +7,15 @@ import { ConsultoriaLandingHero } from "@/components/organisms/ConsultoriaLandin
 import { LanguageProvider } from "@/lib/LanguageContext";
 
 const openCalendarBooking = vi.fn(() => true);
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
 
 vi.mock("@/lib/site-contact", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/site-contact")>();
@@ -27,36 +36,29 @@ function renderHero() {
 }
 
 describe("ConsultoriaLandingHero", () => {
-  it("restores Agendar in the home hero", async () => {
+  it("opens X|CMS demo and still offers Agendar", async () => {
     const user = userEvent.setup();
     renderHero();
-    const agendar = screen.getByTestId("hero-agendar");
-    expect(agendar).toHaveTextContent(/Agendar/i);
+    expect(screen.getByTestId("hero-demo-xcms")).toHaveTextContent(/X\|CMS/i);
+    expect(screen.getByTestId("hero-agendar")).toHaveTextContent(/Agendar/i);
     expect(screen.getByTestId("hero-gratis-a11y")).toBeInTheDocument();
-    await user.click(agendar);
+    await user.click(screen.getByTestId("hero-demo-xcms"));
+    expect(navigate).toHaveBeenCalledWith("/demo/x-cms");
+    await user.click(screen.getByTestId("hero-agendar"));
     expect(openCalendarBooking).toHaveBeenCalledWith({ origin: "consultoria-hero" });
   });
 
-  it("tells brand story without Radar, auditoria, or personal name", () => {
+  it("shows X|CMS product mockup, not a lifestyle cafe photo", () => {
     const { container } = renderHero();
+    expect(container.querySelector("[data-hero-version='3']")).toBeTruthy();
+    expect(container.querySelector("[data-product='x-cms']")).toBeTruthy();
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       /Tecnología para empresas/i
     );
-    expect(screen.getByText(/Diseño que reduce el ruido/i)).toBeInTheDocument();
-    const tiles = screen.getByTestId("hero-story-tiles");
-    expect(tiles).toHaveTextContent(/Revisión de un flujo/i);
-    expect(tiles).toHaveTextContent(/En su CMS o CRM/i);
-    expect(tiles).toHaveTextContent(/Diagnóstico 5–7 días/i);
-    const imgs = screen.getAllByRole("img");
-    expect(imgs).toHaveLength(4);
-    expect(imgs.map((img) => img.getAttribute("src"))).toEqual([
-      "/images/ads/01-1200x627-revision-flujo.png",
-      "/images/ads/02-1200x627-tecnologia-empresas.png",
-      "/images/ads/03-1080x1080-cms-crm.png",
-      "/images/ads/04-1080x1080-diagnostico.png",
-    ]);
+    const img = screen.getByRole("img", { name: /CMS/i });
+    expect(img.getAttribute("src") ?? "").toMatch(/x-cms-dashboard/);
+    expect(img).toHaveAttribute("loading", "eager");
+    expect(container.textContent).toMatch(/X\|CMS/);
     expect(container.textContent).not.toMatch(/Radar/i);
-    expect(container.textContent).not.toMatch(/auditor[íi]a/i);
-    expect(container.textContent).not.toMatch(/Rodrigo/i);
   });
 });

--- a/src/components/atoms/HeroMedia.figma.ts
+++ b/src/components/atoms/HeroMedia.figma.ts
@@ -1,0 +1,19 @@
+// url=https://www.figma.com/design/C2ZgaajABQa3NiFJTnFF45/VN-%C2%B7-Campaign-assets-%C2%B7-piloto-a11y?node-id=44-32
+// source=src/components/molecules/DeviceMockup.tsx
+// component=DeviceMockup
+import figma from 'figma'
+void figma.selectedInstance
+
+export default {
+  example: figma.code`
+    <DeviceMockup
+      variant="browser"
+      src="/images/consultoria/x-cms-dashboard.png"
+      alt="Dashboard CMS — operaciones digitales en el stack del cliente"
+      caption="cms · operaciones"
+    />
+  `,
+  imports: ['import { DeviceMockup } from "@/components/molecules/DeviceMockup"'],
+  id: 'hero-ops-media',
+  metadata: { nestable: true },
+}

--- a/src/components/molecules/DeviceMockup.tsx
+++ b/src/components/molecules/DeviceMockup.tsx
@@ -15,6 +15,8 @@ type DeviceMockupProps = {
   className?: string;
   /** Soft ambient glow behind device */
   glow?: boolean;
+  addressBar?: string;
+  loading?: "eager" | "lazy";
 };
 
 export function DeviceMockup({
@@ -24,13 +26,15 @@ export function DeviceMockup({
   variant = "laptop",
   className,
   glow = true,
+  addressBar = "x-cms · local",
+  loading = "lazy",
 }: DeviceMockupProps) {
   if (variant === "phone") {
     return (
       <figure className={cn("relative mx-auto w-full max-w-[280px]", className)}>
         {glow ? (
           <div
-            className="pointer-events-none absolute -inset-10 rounded-full bg-white/[0.04] blur-3xl"
+            className="pointer-events-none absolute -inset-10 rounded-full bg-white/[0.04] blur-3xl motion-reduce:hidden"
             aria-hidden
           />
         ) : null}
@@ -45,7 +49,7 @@ export function DeviceMockup({
               src={src}
               alt={alt}
               className="aspect-[9/19.5] w-full object-cover object-top"
-              loading="lazy"
+              loading={loading}
               decoding="async"
             />
           </div>
@@ -78,7 +82,7 @@ export function DeviceMockup({
         </span>
         <div className="ml-2 flex min-w-0 flex-1 items-center justify-center">
           <div className="w-full max-w-[220px] truncate rounded-md bg-black/40 px-3 py-1 text-center text-[10px] text-white/35">
-            x-cms · local
+            {addressBar}
           </div>
         </div>
       </div>
@@ -86,7 +90,7 @@ export function DeviceMockup({
         src={src}
         alt={alt}
         className="aspect-[16/10] w-full object-cover object-top"
-        loading="lazy"
+        loading={loading}
         decoding="async"
       />
     </div>
@@ -97,7 +101,7 @@ export function DeviceMockup({
       <figure className={cn("relative w-full", className)}>
         {glow ? (
           <div
-            className="pointer-events-none absolute -inset-8 rounded-[2rem] bg-white/[0.035] blur-2xl"
+            className="pointer-events-none absolute -inset-8 rounded-[2rem] bg-white/[0.035] blur-2xl motion-reduce:hidden"
             aria-hidden
           />
         ) : null}
@@ -118,7 +122,7 @@ export function DeviceMockup({
     <figure className={cn("relative w-full", className)}>
       {glow ? (
         <div
-          className="pointer-events-none absolute -inset-10 rounded-[2.5rem] bg-white/[0.04] blur-3xl"
+          className="pointer-events-none absolute -inset-10 rounded-[2.5rem] bg-white/[0.04] blur-3xl motion-reduce:hidden"
           aria-hidden
         />
       ) : null}

--- a/src/components/molecules/ProcessNavigation.tsx
+++ b/src/components/molecules/ProcessNavigation.tsx
@@ -9,15 +9,21 @@ import {
 interface ProcessNavigationProps {
   sections: ProcessNavSection[];
   mobileAriaLabel?: string;
+  /** Home/SEM FO: dock cubre 01–03. Default true (detalle de caso). */
+  showMobile?: boolean;
 }
 
-export function ProcessNavigation({ sections, mobileAriaLabel }: ProcessNavigationProps) {
+export function ProcessNavigation({
+  sections,
+  mobileAriaLabel,
+  showMobile = true,
+}: ProcessNavigationProps) {
   const { activeSection, visitedSections, scrollToSection } = useProcessSectionSpy(sections);
   const prefersReducedMotion = useReducedMotion();
 
   return (
     <>
-      {/* Mobile: sticky horizontal section nav */}
+      {showMobile ? (
       <nav
         className="process-nav-mobile lg:hidden sticky z-[45] border-b border-border/60 bg-background shadow-[0_8px_16px_-12px_rgba(15,23,42,0.28)]"
         style={{ top: "var(--process-nav-mobile-top, 3.25rem)" }}
@@ -48,6 +54,7 @@ export function ProcessNavigation({ sections, mobileAriaLabel }: ProcessNavigati
           </ul>
         </div>
       </nav>
+      ) : null}
 
       {/* Desktop: lateral TOC */}
       <motion.div

--- a/src/components/organisms/ConsultoriaLandingHero.figma.ts
+++ b/src/components/organisms/ConsultoriaLandingHero.figma.ts
@@ -1,0 +1,25 @@
+// url=https://www.figma.com/design/C2ZgaajABQa3NiFJTnFF45/VN-%C2%B7-Campaign-assets-%C2%B7-piloto-a11y?node-id=44-32
+// source=src/components/organisms/ConsultoriaLandingHero.tsx
+// component=ConsultoriaLandingHero
+import figma from 'figma'
+const instance = figma.selectedInstance
+
+const title = instance.getString('Title')
+const description = instance.getString('Description')
+const ctaPrimary = instance.getString('CtaPrimary')
+const ctaFree = instance.getString('CtaFree')
+const showFree = instance.getBoolean('ShowFreeCta')
+void title
+void description
+void ctaPrimary
+void ctaFree
+void showFree
+
+export default {
+  example: figma.code`<ConsultoriaLandingHero />`,
+  imports: [
+    'import { ConsultoriaLandingHero } from "@/components/organisms/ConsultoriaLandingHero"',
+  ],
+  id: 'consultoria-landing-hero-v3',
+  metadata: { nestable: false },
+}

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -1,39 +1,43 @@
-import { Calendar } from "lucide-react";
+import { Calendar, Play } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
+import { DeviceMockup } from "../molecules/DeviceMockup";
+import { LogoMarkSvg } from "../atoms/Logo";
+import { SEO_SITE } from "../../lib/seo";
+import { ROUTES } from "../../lib/routes";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
-import { analytics } from "../../lib/analytics";
+import { analytics, trackEvent } from "../../lib/analytics";
 import { openFreeRadarEntry } from "../../lib/free-radar-entry";
 import { openCalendarBooking } from "../../lib/site-contact";
 import { scrollToSection } from "../../lib/scroll-to-section";
+import { getPortfolioImages, resolveImageUrl } from "../../lib/image-overrides";
+import { useImageManifestVersion } from "../../lib/image-manifest-context";
 
-/** Figma 07 · contexto valor (personas + stack). Archivo campañas C2ZgaajABQa3NiFJTnFF45. */
-const STORY_IMAGES: Record<string, string> = {
-  flujo: "/images/ads/01-1200x627-revision-flujo.png",
-  reserva: "/images/ads/02-1200x627-tecnologia-empresas.png",
-  stack: "/images/ads/03-1080x1080-cms-crm.png",
-  diagnostico: "/images/ads/04-1080x1080-diagnostico.png",
-};
+const HERO_SLOT = "branding.heroConsultoria";
 
 /**
- * Hero SEM/FO · Radio de tres nombres.
- * H1 = message-match Ads (“Tecnología para empresas.”).
- * Relato = universo marca Figma 07/08: un flujo · personas · CMS/CRM · diagnóstico.
- * CTA de agenda vive en el hero. Alcance sigue en #modalidades.
+ * Hero FO/SEM v3 — mockup X|CMS (producto estrella).
+ * Demo: /#/demo/x-cms · eventos dataLayer demo_x_cms_* (GTM CE: no).
  */
 export function ConsultoriaLandingHero() {
   const navigate = useNavigate();
   const { language } = useLanguage();
   const t = useTranslation(language).consultoria.landing;
-  const es = language === "es";
+  useImageManifestVersion();
+  const images = getPortfolioImages();
+  const mediaSrc = resolveImageUrl(HERO_SLOT, images.consultoria.heroOps);
+  const mediaAlt =
+    t.storyTiles.find((tile) => tile.id === "stack")?.alt ??
+    "X|CMS — dashboard de operaciones en el CMS del cliente";
+  const descId = "consultoria-hero-desc";
 
   const bookKickoff = () => {
     analytics.generateLead({
       lead_type: "kickoff",
       channel: "google_calendar",
       origin: "consultoria-hero",
+      package_id: "marco",
     });
     if (!openCalendarBooking({ origin: "consultoria-hero" })) {
       scrollToSection("contacto");
@@ -44,127 +48,121 @@ export function ConsultoriaLandingHero() {
     openFreeRadarEntry(navigate, language, "consultoria-hero");
   };
 
+  const openXcmsDemo = () => {
+    trackEvent("hero_x_cms_open", {
+      category: "engagement",
+      surface: "consultoria-hero",
+      product: "x-cms",
+      path_id: "prototype",
+    });
+    navigate(ROUTES.demoXcms);
+  };
+
   return (
     <section
       id="inicio"
-      className="funnel-section-enter section-pad-default section-atmosphere section-atmosphere-matte relative overflow-hidden border-b border-border/40 scroll-mt-[calc(var(--header-height)+0.75rem)]"
+      data-hero-version="3"
+      data-hero-ui="vn-design-ops"
+      data-product="x-cms"
+      className="funnel-section-enter relative overflow-hidden border-b border-border/40 scroll-mt-[calc(var(--header-height)+0.75rem)] bg-[#0A0A0A] text-[#E8E5DF]"
       aria-labelledby="consultoria-hero-heading"
     >
-      <div className="container relative mx-auto max-w-5xl">
-        <div className="mx-auto space-y-6 text-center">
-          <div className="mx-auto max-w-2xl space-y-6">
-            <Badge
-              variant="outline"
-              className="border-primary/25 font-normal text-foreground"
+      <div className="h-1.5 w-full bg-brand-gradient" aria-hidden />
+      <div className="container relative mx-auto max-w-6xl px-4 py-8 md:py-12">
+        <div className="flex flex-col gap-8 lg:grid lg:grid-cols-12 lg:items-center lg:gap-12">
+          <div className="order-1 lg:order-2 lg:col-span-7" data-testid="hero-ops-media">
+            <button
+              type="button"
+              onClick={openXcmsDemo}
+              className="hero-xcms-hit"
+              aria-label={t.ctaDemo}
             >
-              {t.badge}
-            </Badge>
+              <span className="hero-xcms-play" aria-hidden>
+                <Play className="h-3.5 w-3.5" />
+                {t.ctaDemo}
+              </span>
+              <DeviceMockup
+                variant="laptop"
+                src={mediaSrc}
+                alt={mediaAlt}
+                caption={t.xcmsCaption}
+                addressBar="x-cms · operaciones"
+                loading="eager"
+              />
+            </button>
+          </div>
 
-            <p
-              className="font-mono text-xs uppercase text-muted-foreground"
-              style={{ letterSpacing: "0.18em" }}
-            >
+          <div className="order-2 space-y-5 lg:order-1 lg:col-span-5">
+            <div className="flex items-center gap-3">
+              <LogoMarkSvg
+                size={36}
+                showPlate
+                plate="floating"
+                interactive
+                className="logo-mark--on-dark"
+              />
+              <p className="text-sm font-semibold tracking-tight text-[#E8E5DF]">
+                {SEO_SITE.brand}
+              </p>
+            </div>
+
+            <p className="inline-flex min-h-8 items-center rounded-full border border-[#FF931E]/40 bg-[#FF931E]/10 px-3 text-xs font-medium text-[#FF931E]">
+              {t.xcmsLabel}
+            </p>
+
+            <p className="font-mono text-xs uppercase tracking-[0.18em] text-white/45">
               {t.principleBadge}
             </p>
 
             <h1
               id="consultoria-hero-heading"
-              className="text-3xl font-bold tracking-tight sm:text-4xl md:text-[2.5rem] md:leading-[1.12]"
+              className="text-[1.75rem] font-bold leading-tight tracking-tight text-[#E8E5DF] sm:text-4xl"
             >
               {t.title}
-              {t.titleAccent ? (
-                <>
-                  {" "}
-                  <span className="text-brand-gradient">{t.titleAccent}</span>
-                </>
-              ) : null}
             </h1>
 
-            <p className="mx-auto max-w-xl text-base leading-relaxed text-muted-foreground md:text-lg">
+            <p
+              id={descId}
+              className="max-w-xl text-sm leading-relaxed text-white/60 md:text-base"
+            >
               {t.description}
             </p>
-          </div>
 
-          <ul
-            className="grid gap-3 text-left sm:grid-cols-2"
-            role="list"
-            aria-label={t.storyLabel}
-            data-testid="hero-story-tiles"
-          >
-            {t.storyTiles.map((tile) => (
-              <li
-                key={tile.id}
-                className="overflow-hidden rounded-2xl border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated/90"
+            <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+              <Button
+                type="button"
+                size="lg"
+                data-testid="hero-demo-xcms"
+                aria-describedby={descId}
+                className="funnel-cta-primary min-h-[48px] bg-brand-gradient px-8 font-semibold text-white hover:opacity-90"
+                onClick={openXcmsDemo}
               >
-                <img
-                  src={STORY_IMAGES[tile.id]}
-                  alt={tile.alt}
-                  width={1200}
-                  height={630}
-                  loading="lazy"
-                  decoding="async"
-                  className="aspect-[16/10] w-full object-cover object-center"
-                  data-testid={`hero-story-img-${tile.id}`}
-                />
-                <div className="p-4">
-                  <p
-                    className="font-mono text-[11px] uppercase text-muted-foreground"
-                    style={{ letterSpacing: "0.16em" }}
-                  >
-                    {tile.label}
-                  </p>
-                  <p className="mt-1 text-sm font-semibold tracking-tight text-foreground">
-                    {tile.title}
-                  </p>
-                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                    {tile.hint}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
-
-          <ul
-            className="flex flex-wrap items-center justify-center gap-2"
-            role="list"
-            aria-label={es ? "Compromisos" : "Commitments"}
-          >
-            {t.trustChips.map((chip) => (
-              <li key={chip}>
-                <span className="inline-flex min-h-[32px] items-center rounded-full border border-[color:var(--logo-surface-border)] bg-surface-matte-elevated/90 px-3 py-1 text-xs font-medium text-muted-foreground">
-                  {chip}
-                </span>
-              </li>
-            ))}
-          </ul>
-
-          <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
-            <Button
-              size="lg"
-              data-testid="hero-agendar"
-              className="min-h-[48px] bg-brand-gradient px-8 font-semibold hover:opacity-90"
-              onClick={bookKickoff}
-            >
-              <Calendar className="h-4 w-4" aria-hidden />
-              {t.ctaPrimary}
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              data-testid="hero-gratis-a11y"
-              className="min-h-[48px]"
-              onClick={bookFree}
-            >
-              {t.ctaFreeA11y}
-            </Button>
+                <Play className="h-4 w-4" aria-hidden />
+                {t.ctaDemo}
+              </Button>
+              <Button
+                type="button"
+                size="lg"
+                variant="outline"
+                data-testid="hero-agendar"
+                aria-describedby={descId}
+                className="funnel-cta-ghost min-h-[48px] border-white/20 bg-transparent text-[#E8E5DF] hover:bg-white/5"
+                onClick={bookKickoff}
+              >
+                <Calendar className="h-4 w-4" aria-hidden />
+                {t.ctaPrimary}
+              </Button>
+              <Button
+                type="button"
+                variant="link"
+                data-testid="hero-gratis-a11y"
+                className="funnel-link min-h-[44px] px-0 text-white/55 hover:text-[#E8E5DF]"
+                onClick={bookFree}
+              >
+                {t.ctaFreeA11y}
+              </Button>
+            </div>
           </div>
-          <Button
-            variant="link"
-            className="min-h-[44px] text-muted-foreground"
-            onClick={() => scrollToSection("modalidades")}
-          >
-            {t.ctaSecondary}
-          </Button>
         </div>
       </div>
     </section>

--- a/src/components/organisms/ConsultoriaLandingHero.tsx
+++ b/src/components/organisms/ConsultoriaLandingHero.tsx
@@ -2,8 +2,6 @@ import { Calendar, Play } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { DeviceMockup } from "../molecules/DeviceMockup";
-import { LogoMarkSvg } from "../atoms/Logo";
-import { SEO_SITE } from "../../lib/seo";
 import { ROUTES } from "../../lib/routes";
 import { useLanguage } from "../../lib/LanguageContext";
 import { useTranslation } from "../../lib/i18n";
@@ -93,19 +91,6 @@ export function ConsultoriaLandingHero() {
           </div>
 
           <div className="order-2 space-y-5 lg:order-1 lg:col-span-5">
-            <div className="flex items-center gap-3">
-              <LogoMarkSvg
-                size={36}
-                showPlate
-                plate="floating"
-                interactive
-                className="logo-mark--on-dark"
-              />
-              <p className="text-sm font-semibold tracking-tight text-[#E8E5DF]">
-                {SEO_SITE.brand}
-              </p>
-            </div>
-
             <p className="inline-flex min-h-8 items-center rounded-full border border-[#FF931E]/40 bg-[#FF931E]/10 px-3 text-xs font-medium text-[#FF931E]">
               {t.xcmsLabel}
             </p>

--- a/src/data/image-registry.ts
+++ b/src/data/image-registry.ts
@@ -32,6 +32,14 @@ export const IMAGE_REGISTRY: ImageRegistryEntry[] = [
   entry("branding.favicon", "Branding", "Favicon", "favicon.ico", portfolioImages.branding.favicon, "Favicon Viento Norte"),
   entry("branding.schemaLogo", "Branding", "Schema.org logo", "icon-512x512.png", portfolioImages.branding.schemaLogo, "Logo schema Viento Norte"),
   entry("branding.appleTouch", "Branding", "Apple / PWA", "icon-192x192.png", portfolioImages.branding.appleTouch, "Apple touch Viento Norte"),
+  entry(
+    "branding.heroConsultoria",
+    "Consultoría",
+    "Hero · operaciones CMS",
+    "consultoria/x-cms-dashboard.png",
+    portfolioImages.consultoria.xCmsDashboard,
+    "Dashboard CMS — operaciones digitales en el stack del cliente"
+  ),
   entry("sura.riaOnboarding", "SURA", "RIA onboarding", "sura/ria-onboarding.png", portfolioImages.sura.riaOnboarding, "Onboarding RIA SURA US"),
   entry("sura.webPrototype", "SURA", "Prototipo web RIA", "sura/web-prototype.png", portfolioImages.sura.webPrototype, "Prototipo web SURA — plataforma inversiones / RIA"),
   entry("sura.componentPipeline", "SURA", "Pipeline componentes", "sura/component-pipeline.png", portfolioImages.sura.componentPipeline, "Pipeline MVP — Explorar, Refinar, Documentar, Implementar"),

--- a/src/data/image-roles.ts
+++ b/src/data/image-roles.ts
@@ -8,6 +8,7 @@ export type ImageWebRole =
   | "favicon"
   | "logo"
   | "apple"
+  | "hero_consultoria"
   | "faq"
   | "gallery";
 
@@ -61,6 +62,12 @@ export const IMAGE_WEB_ROLES: ImageRoleDef[] = [
     label: "Apple / PWA",
     hint: "icon-192. Cuadrado.",
     slotId: "branding.appleTouch",
+  },
+  {
+    id: "hero_consultoria",
+    label: "Hero · operaciones CMS",
+    hint: "Pantalla de producto (CMS/CRM), no lifestyle. 16:10 o 1200×630. Alt obligatorio.",
+    slotId: "branding.heroConsultoria",
   },
   {
     id: "faq",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -247,6 +247,10 @@ export default {
       landing: {
         badge: 'Viento Norte · SMBs',
         principleBadge: 'Design that cuts the noise',
+        opsLabel: 'Digital operations',
+        xcmsLabel: 'X|CMS',
+        xcmsCaption: 'X|CMS · 5 min demo',
+        ctaDemo: 'View X|CMS demo',
         title: 'Technology for business.',
         titleAccent: '',
         description:

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -247,6 +247,10 @@ export default {
       landing: {
         badge: 'Viento Norte · pymes',
         principleBadge: 'Diseño que reduce el ruido',
+        opsLabel: 'Operaciones digitales',
+        xcmsLabel: 'X|CMS',
+        xcmsCaption: 'X|CMS · demo 5 min',
+        ctaDemo: 'Ver demo X|CMS',
         title: 'Tecnología para empresas.',
         titleAccent: '',
         description:

--- a/src/lib/portfolio-image-urls.ts
+++ b/src/lib/portfolio-image-urls.ts
@@ -46,6 +46,7 @@ export const portfolioImages = {
     uxValueChain: img("framework/ux-value-chain.png"),
   },
   consultoria: {
+    heroOps: img("consultoria/x-cms-dashboard.png"),
     xCmsDashboard: img("consultoria/x-cms-dashboard.png"),
     xCmsDashboardWebp: img("consultoria/x-cms-dashboard.webp"),
     geesDashboard: img("consultoria/gees-dashboard.png", true),

--- a/src/pages/ConsultoriaVientoNorte.tsx
+++ b/src/pages/ConsultoriaVientoNorte.tsx
@@ -137,6 +137,7 @@ export default function ConsultoriaVientoNorte({
         <ProcessNavigation
           sections={funnelSections}
           mobileAriaLabel={funnelNav.ariaLabel}
+          showMobile={false}
         />
 
         {/*

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -425,17 +425,17 @@ html[data-nav="site"] [data-surface="consultoria-funnel"] {
 }
 
 @media (max-width: 1023.98px) {
+  /* Funnel FO: sin pills 01–03 (dock cubre). Solo header. */
   html[data-nav="site"] [data-surface="consultoria-funnel"] {
-    padding-top: calc(var(--header-height) + 3.9rem);
+    padding-top: var(--header-height);
   }
 
   html[data-nav="subpage"] [data-surface="consultoria-funnel"] {
-    padding-top: 3.9rem;
+    padding-top: 0;
   }
 
-  html[data-nav="site"],
-  html[data-nav="subpage"] {
-    scroll-padding-top: calc(var(--header-height) + 3.9rem);
+  html[data-nav="site"] {
+    scroll-padding-top: calc(var(--header-height) + 0.5rem);
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -628,6 +628,11 @@
     stroke-opacity: var(--logo-track-opacity);
   }
 
+  .logo-mark--on-dark .logo-mark-track {
+    stroke: #e8e5df;
+    stroke-opacity: 0.4;
+  }
+
   .logo-mark-core-shine {
     opacity: var(--logo-shine-opacity);
   }

--- a/src/styles/offer-tour.css
+++ b/src/styles/offer-tour.css
@@ -233,6 +233,70 @@
   transition: box-shadow var(--funnel-base) var(--funnel-ease);
 }
 
+[data-surface="consultoria-funnel"] .hero-xcms-hit {
+  position: relative;
+  display: block;
+  width: 100%;
+  border-radius: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--funnel-base) var(--funnel-ease);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  [data-surface="consultoria-funnel"] .hero-xcms-hit:hover {
+    transform: translateY(-6px);
+  }
+}
+
+[data-surface="consultoria-funnel"] .hero-xcms-hit:active {
+  transform: translateY(-1px) scale(0.995);
+}
+
+[data-surface="consultoria-funnel"] .hero-xcms-hit:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+}
+
+[data-surface="consultoria-funnel"] .hero-xcms-play {
+  pointer-events: none;
+  position: absolute;
+  right: 1rem;
+  bottom: 2.75rem;
+  z-index: 2;
+  display: inline-flex;
+  min-height: 44px;
+  min-width: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary) 92%, #0a0a0a);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 10px 28px -10px color-mix(in srgb, var(--primary) 45%, transparent);
+  opacity: 0.92;
+  transform: translateY(4px);
+  transition:
+    opacity var(--funnel-fast) var(--funnel-ease-soft),
+    transform var(--funnel-base) var(--funnel-spring);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  [data-surface="consultoria-funnel"] .hero-xcms-play {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  [data-surface="consultoria-funnel"] .hero-xcms-hit:hover .hero-xcms-play,
+  [data-surface="consultoria-funnel"] .hero-xcms-hit:focus-visible .hero-xcms-play {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 [data-surface="consultoria-funnel"] .funnel-section-enter {
   animation: funnel-section-in var(--funnel-slow) var(--funnel-ease) both;
 }
@@ -268,7 +332,14 @@
   [data-surface="consultoria-funnel"] .funnel-pack-card:hover,
   [data-surface="consultoria-funnel"] .funnel-pack-card:active,
   [data-surface="consultoria-funnel"] .funnel-cta-primary:active,
-  [data-surface="consultoria-funnel"] .funnel-cta-ghost:active {
+  [data-surface="consultoria-funnel"] .funnel-cta-ghost:active,
+  [data-surface="consultoria-funnel"] .hero-xcms-hit:hover,
+  [data-surface="consultoria-funnel"] .hero-xcms-hit:active {
+    transform: none;
+  }
+
+  [data-surface="consultoria-funnel"] .hero-xcms-play {
+    opacity: 1;
     transform: none;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,7 @@
     "src/components/ui/drawer.tsx",
     "src/components/ui/resizable.tsx",
     "src/data/projects-data.ts",
-    "src/vite.config.ts"
+    "src/vite.config.ts",
+    "src/**/*.figma.ts"
   ]
 }

--- a/worker/src/data/image-roles.js
+++ b/worker/src/data/image-roles.js
@@ -68,6 +68,15 @@ export const IMAGE_WEB_ROLES = [
     alt: 'Apple touch Viento Norte',
   },
   {
+    id: 'hero_consultoria',
+    label: 'Hero · operaciones CMS',
+    hint: 'Pantalla de producto (CMS/CRM), no lifestyle. 16:10. Alt obligatorio.',
+    slotId: 'branding.heroConsultoria',
+    path: 'consultoria/x-cms-dashboard.png',
+    category: 'Consultoría',
+    alt: 'Dashboard CMS — operaciones digitales en el stack del cliente',
+  },
+  {
     id: 'faq',
     label: 'FAQ / ayuda',
     hint: 'Sin cable HTML automático.',


### PR DESCRIPTION
## Por qué
Hero SEM no entregaba marca ni producto: teselas de anuncio duplicaban H1/CTA; la foto lifestyle no era VN. v3 pone el producto estrella **X|CMS** (laptop DeviceMockup) y dos CTAs medibles.

## Qué cambia (FO)
- `ConsultoriaLandingHero` `data-hero-version="3"` `data-product="x-cms"` · CTA **Ver demo** → `/#/demo/x-cms` + `hero_x_cms_open` (dataLayer, **no** CE GTM).
- **Agendar** sigue `generate_lead` kickoff · **Gratis · accesibilidad** intacto.
- Pills del embudo ocultas en mobile consultoría (`ProcessNavigation showMobile={false}`).
- Admin rol `hero_consultoria` → `branding.heroConsultoria`. Worker spec en `image-roles.js` — live requiere `wrangler deploy --keep-vars` (Decider, no este PR).
- Code Connect parserless en Figma campaign assets (`C2ZgaajABQa3NiFJTnFF45`).
- ESLint 10: configs recommended en spread (no `extends`+`plugins` en el mismo objeto).

## No entra
- `hero-reserva.jpg` (café) ni duplicados iCloud `* 2.*`.
- Merge a `main`.
- Spend Ads.
- Pedido de indexación GSC (cuota 26 ago).

## QA hecho (no inventado)
| Superficie | Hecho |
|---|---|
| Local SEO smoke `http://localhost:3000` | **133/133 PASS** |
| Live `/s/consultoria/` | 200 · self-canonical · **GTM-PM5LBQRP ×3** · sin gtag.js paralelo (comentario) · refresh 5s → `/#/consultoria` · last-mod **27 ago** (hero v3 **no live** hasta merge+deploy) |
| Live `/s/` | 200 · GTM×2 · canonical **home** (no indexar como URL propia) |
| Live `/` | 200 · GTM=0 en HTML (SPA `initGTM`) |
| Sitemap | 5 locs · incluye `/s/` y `/s/consultoria/` · sin hash |
| robots.txt | `Allow: /` · Disallow admin/poc/auditoria/ops |
| GSC verify | `https://vientonorte.io/google5858e011b32ea566.html` **200** |
| Vitest hero | **NO DATO** — `ERR_WORKER_INVALID_EXEC_ARGV --max-old-space-size=4096` (preexistente) |
| preprod-gate `--quick` | **NO DATO** — `tsc` hung 0% CPU iCloud; matado |
| GTM Preview `generate_lead` | **pendiente humano Chrome** (no MCP, no Safari+AdGuard) |

## GO / NO-GO
- **Ship PR: GO** (hash `c41f7be`).
- **Merge `main`: NO-GO** hasta Decider.
- **GTM conversión: NO-GO spend** — Preview Gratis → `GA4 · generate_lead` en Etiquetas activadas sigue P0 humano.
- **Google Search: GO cobertura crawler** (`/s/consultoria/` indexable, GTM en HTML). **NO-GO “está indexado”** — validación 26 ago N/D; no pido indexación otra vez.

## Humano (lock 24 ago)
1. Chrome logueado → Tag Assistant Preview → `https://vientonorte.io/#/consultoria` → **Gratis · accesibilidad** → `GA4 · generate_lead` activado.
2. Si PASS: Decider *activar campañas* (un piloto, final URL `/s/consultoria`). `$0` hasta entonces.
3. GSC: 1 index request `/s/consultoria/` solo si Decider lo pide (cuota).
4. Worker: `wrangler deploy --keep-vars` para el rol `hero_consultoria` live.