### PR TITLE
feat(admin): roadmap 28 ago — Search ENABLED, TA PASS, PosicionApp

### DIFF
--- a/src/data/admin-roadmap.ts
+++ b/src/data/admin-roadmap.ts
@@ -10,38 +10,54 @@ export type RoadmapItem = {
   href?: string;
 };
 
-export const ADMIN_ROADMAP_UPDATED = "2026-08-28";
+export const ADMIN_ROADMAP_UPDATED = "2026-08-28 16:40";
 
 export const ADMIN_ROADMAP: RoadmapItem[] = [
   {
+    id: "hero-xcms",
+    title: "Hero v3 mockup X|CMS 16:10",
+    status: "done",
+    notes: "Merged #220 · 38478e3 · laptop 1440×900 contain. Live main.",
+    href: "https://vientonorte.io/#/consultoria",
+  },
+  {
     id: "sem-ta",
-    title: "SEM piloto Search 150k · Tag Assistant generate_lead",
-    status: "blocked",
+    title: "Tag Assistant generate_lead + book_call",
+    status: "done",
     notes:
-      "GTM v6 live. TA 12:53/14:00: Activadas = solo Google tag. ENABLED $0 hasta generate_lead + book_call en Activadas.",
+      "14:31 Chrome sin extensiones. Activadas: generate_lead 2× + book_call 2×. Conectado vientonorte.io. GTM v6.",
     href: "https://vientonorte.io/#/consultoria",
   },
   {
     id: "sem-ads-ui",
-    title: "Ads: import GA4 generate_lead/book_call + keywords phrase",
-    status: "next",
+    title: "Piloto Search 150k ENABLED",
+    status: "done",
     notes:
-      "Conversiones actuales: lead form Inactiva + Reservar cita. RSA en clipboard. Campañas detenidas.",
-    href: "https://ads.google.com/aw/conversions?ocid=8398019470",
+      "Leads-Search-1 · 24184249593 · CID 811-405-3092 · CLP 5.000/día · Chile · generate_lead principal + book_call secundario · AG-A phrase ×12. Smart detenido.",
+    href: "https://ads.google.com/aw/campaigns?ocid=8398019470",
+  },
+  {
+    id: "sem-ads-polish",
+    title: "Ads polish: rename + AG-D/B/C + negativos",
+    status: "now",
+    notes:
+      "UI aún Leads-Search-1. Falta sitelinks, quitar objetivo llamadas, IA Max si reaparece. No subir techo.",
+    href: "https://ads.google.com/aw/campaigns?ocid=8398019470",
+  },
+  {
+    id: "posicionapp",
+    title: "PosicionApp VN · 25 kws Chile",
+    status: "now",
+    notes:
+      "vientonorte.io Chile. Clusters a11y / design / privacy. Tracking 28 ago. Pos 21 = fuera top 20. Ley 21.719 vol. 1,6k.",
+    href: "https://panel.posicion.app/proyectos/q1NSHH1azZwuazuSwaZt",
   },
   {
     id: "poc-fintoc-bdp",
     title: "PoC Fintoc × X|CMS · /vn-bdp",
     status: "next",
     notes:
-      "DS-2026-08-28 A→C. v1 Payment Link post-kickoff (Worker /api/pay). v2 botón en flujo CMS del cliente. Hero no cobra. Keys Fintoc NO DATO.",
+      "DS-2026-08-28 A→C. v1 Worker /api/pay. Hero no cobra. Keys Fintoc NO DATO. Wait apply=true.",
     href: "https://vientonorte.io/#/demo/x-cms",
-  },
-  {
-    id: "hero-xcms",
-    title: "Hero v3 mockup X|CMS 16:10",
-    status: "now",
-    notes: "PR #220 · dashboard 1440×900 contain. Live main aún recorta hasta merge.",
-    href: "https://github.com/vientonorte/mi-portafolio/pull/220",
   },
 ];


### PR DESCRIPTION
## Por qué
`/#/admin/roadmap` seguía en blocked TA 12:53 y Ads detenidas. Eso ya no es live.

## Qué cambia
SSOT corto `src/data/admin-roadmap.ts` (panel Roadmap + overview):

- **done:** hero #220 merge, TA generate_lead+book_call 14:31, piloto Search 150k ENABLED (CID 811-405-3092 · 5.000/día · Chile)
- **now:** Ads polish (rename, AG-D/B/C, negativos) · PosicionApp VN 25 kws Chile
- **next:** Fintoc /api/pay — keys NO DATO

Sin CPC inventado. Smart sigue detenido.