### PR TITLE
fix(ci): Tests Calendar delay + sitemap drop /s/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 
 ---
 
+## [2026-08-28] — CI Tests + sitemap `/s/`
+
+### Fixed
+- `openFreeRadarEntry` test: Calendar abre a los 300 ms (GTM CE `generate_lead` primero). El job Tests ya no bloquea Deploy Pages.
+
+### Changed
+- `public/sitemap.xml`: se saca `https://vientonorte.io/s/` (canonical a home = duplicado). Quedan `/`, `/s/consultoria/`, `/s/proceso/` y privacy legal.
+
+---
+
 ## [2026-08-28] — Hero v3: X|CMS producto estrella
 
 ### Changed

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <!-- SEO orgánico · solo paths HTTP. Google ignora fragments (#/). -->
+  <!-- /s/ omitido: canonical a home; no gastar crawl budget en duplicado. -->
   <url>
     <loc>https://vientonorte.io/</loc>
-    <lastmod>2026-08-17</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://vientonorte.io/s/</loc>
-    <lastmod>2026-08-17</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://vientonorte.io/s/consultoria/</loc>
-    <lastmod>2026-08-17</lastmod>
+    <lastmod>2026-08-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.96</priority>
   </url>

--- a/src/__tests__/lib/free-radar-entry.test.ts
+++ b/src/__tests__/lib/free-radar-entry.test.ts
@@ -44,10 +44,19 @@ describe("openFreeRadarEntry", () => {
     );
 
     expect(channel).toBe("google_calendar");
-    expect(openSpy).toHaveBeenCalledWith(
-      "https://calendar.app.google/vn-a11y-test",
-      "_blank",
-      "noopener,noreferrer"
+    expect(trackEventSpy).toHaveBeenCalledWith(
+      "generate_lead",
+      expect.objectContaining({ channel: "google_calendar" })
+    );
+    expect(openSpy).not.toHaveBeenCalled();
+    await vi.waitFor(
+      () =>
+        expect(openSpy).toHaveBeenCalledWith(
+          "https://calendar.app.google/vn-a11y-test",
+          "_blank",
+          "noopener,noreferrer"
+        ),
+      { timeout: 1000 }
     );
     expect(navigateSpy).not.toHaveBeenCalled();
   });

--- a/src/__tests__/lib/seo-p0-crawler.test.ts
+++ b/src/__tests__/lib/seo-p0-crawler.test.ts
@@ -135,9 +135,9 @@ describe("SEO P0 · crawler HTML /s/", () => {
 });
 
 describe("SEO P0 · sitemap HTTP only", () => {
-  it("lists / /s/ /s/consultoria/ and no hash locs", () => {
+  it("lists / /s/consultoria/ /s/proceso/ and no hash locs", () => {
     expect(sitemap).toContain("<loc>https://vientonorte.io/</loc>");
-    expect(sitemap).toContain("<loc>https://vientonorte.io/s/</loc>");
+    expect(sitemap).not.toContain("<loc>https://vientonorte.io/s/</loc>");
     expect(sitemap).toContain(
       "<loc>https://vientonorte.io/s/consultoria/</loc>"
     );


### PR DESCRIPTION
## Por qué
Deploy Pages solo corre si **CI completo** es success. Tests fallaba 1 caso: Calendar se abre a los 300 ms. #220 y #221 están en main pero **no live**.

## Qué
- Test `openFreeRadarEntry`: `generate_lead` inmediato; `window.open` tras 300 ms (`vi.waitFor`).
- Sitemap: se saca `/s/` (duplicado de home). Supercede #216.

## DoD
- Job Tests verde → Deploy Pages de #220+#221+#este.
- No commitea `* 2.*` ni `hero-reserva.jpg`.